### PR TITLE
Include `.tfvars` files in Terraform builtin

### DIFF
--- a/pkl/builtins/terraform.pkl
+++ b/pkl/builtins/terraform.pkl
@@ -1,7 +1,7 @@
 import "../Config.pkl"
 
 terraform = new Config.Step {
-    glob = List("**/*.tf")
+    glob = List("**/*.{tf,tfvars}")
     check_list_files = "terraform fmt -check {{ files }}"
     fix = "terraform fmt {{ files }}"
 } 


### PR DESCRIPTION
The `terraform fmt` command can also check and fix `.tfvars` files which are used to provide values for any variables defined in a Terraform project.