### PR TITLE
Make `hk run` show `run` help instead of crashing

### DIFF
--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -8,7 +8,11 @@ mod prepare_commit_msg;
 
 /// Run a hook
 #[derive(clap::Args)]
-#[clap(visible_alias = "r", verbatim_doc_comment)]
+#[clap(
+    arg_required_else_help = true,
+    visible_alias = "r",
+    verbatim_doc_comment
+)]
 pub struct Run {
     #[clap(subcommand)]
     command: Option<Commands>,
@@ -31,11 +35,14 @@ impl Run {
         if let Some(hook) = &self.other {
             return self.hook.run(hook).await;
         }
-        match self.command.unwrap() {
-            Commands::CommitMsg(cmd) => cmd.run().await,
-            Commands::PreCommit(cmd) => cmd.run().await,
-            Commands::PrePush(cmd) => cmd.run().await,
-            Commands::PrepareCommitMsg(cmd) => cmd.run().await,
+        if let Some(cmd) = self.command {
+            return match cmd {
+                Commands::CommitMsg(cmd) => cmd.run().await,
+                Commands::PreCommit(cmd) => cmd.run().await,
+                Commands::PrePush(cmd) => cmd.run().await,
+                Commands::PrepareCommitMsg(cmd) => cmd.run().await,
+            };
         }
+        Ok(())
     }
 }


### PR DESCRIPTION
`hk run` crashes. Probably is better to have it show the `hk run` help, kinda like bare `hk` does.

Before:

```sh
 ❯ hk run

thread 'main' panicked at src/cli/run/mod.rs:34:28:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:

```sh
 ❯ hk run
Run a hook

Usage: run [OPTIONS] [FILES]... [COMMAND]

Commands:
  commit-msg          [aliases: cm]
  pre-commit          Sets up git hooks to run hk [aliases: pc]
  pre-push            [aliases: pp]
  prepare-commit-msg  [aliases: pcm]
  help                Print this message or the help of the given subcommand(s)

(etc)
```

Decided against adding a unit test because I didn't have a good feel for the patterns you want to use there.