### PR TITLE
fix(cache): prevent duplicate _type in JSON cache serialization

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -112,6 +112,13 @@ where
                     Ok(val) => return Ok::<_, eyre::Report>(val),
                     Err(err) => {
                         warn!("failed to parse cache file: {} {:#}", path.display(), err);
+                        if let Err(e) = std::fs::remove_file(path) {
+                            warn!(
+                                "failed to delete invalid cache file: {} {:#}",
+                                path.display(),
+                                e
+                            );
+                        }
                     }
                 }
             }

--- a/src/step.rs
+++ b/src/step.rs
@@ -23,7 +23,7 @@ use xx::file::display_path;
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(debug_assertions, serde(deny_unknown_fields))]
 pub struct Step {
-    #[serde(default = "default_step_type")]
+    #[serde(default = "default_step_type", skip_serializing)]
     pub _type: String,
     #[serde(default)]
     pub name: String,

--- a/src/step_group.rs
+++ b/src/step_group.rs
@@ -17,7 +17,7 @@ use std::{
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, Eq, PartialEq)]
 pub struct StepGroup {
-    #[serde(default = "default_step_group_type")]
+    #[serde(default = "default_step_group_type", skip_serializing)]
     pub _type: String,
     pub name: Option<String>,
     pub steps: IndexMap<String, Step>,


### PR DESCRIPTION
`_type` was coming from either of `Step` or `StepGroup` but _also_ from the `StepOrGroup` enum. Serde was happily adding both, leading to JSON parse warnings.

I changed `Step` and `StepGroup` to skip serializing their `_type` and let it just come from the enum's serialization.

I also made it delete invalid cache files when encountered, so this bug should self-heal.

fixes #92