### PR TITLE
chore: only build and deploy docs on the main jdx/hk repo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,7 @@ concurrency:
 jobs:
   # Build job
   build:
+    if: github.repository == 'jdx/hk'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,6 +54,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.repository == 'jdx/hk'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This Docs workflow only makes sense on the source repo, and fails on forks. Adding these conditionals is [the GitHub-recommended way](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/using-conditions-to-control-job-execution) to skip a job on a fork.