### PR TITLE
fix: Mismatched stylelint pkl export #121

### DIFF
--- a/pkl/builtins/stylelint.pkl
+++ b/pkl/builtins/stylelint.pkl
@@ -1,6 +1,6 @@
 import "../Config.pkl"
 
-style_lint = new Config.Step {
+stylelint = new Config.Step {
     glob = "*.{css,scss,sass,less}"
     stage = "*.{css,scss,sass,less}"
     check = "stylelint {{ files }}"


### PR DESCRIPTION
closes #121

Fixes mismatched internal stylelint `builtins/stylelint.pkl` export that doesn't match `Builtins.pkl` export name.