### PR TITLE
chore: release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [1.5.0](https://github.com/jdx/hk/compare/v1.4.0..v1.5.0) - 2025-08-14
+
+### 🚀 Features
+
+- json5 support for prettier builtin by [@tpansino](https://github.com/tpansino) in [#136](https://github.com/jdx/hk/pull/136)
+
+### 🐛 Bug Fixes
+
+- elixir steps named properly by [@paradox460](https://github.com/paradox460) in [#140](https://github.com/jdx/hk/pull/140)
+- pkl builtin by [@tpansino](https://github.com/tpansino) in [#138](https://github.com/jdx/hk/pull/138)
+- make glob, exclude, and stage relative to dir by [@jdx](https://github.com/jdx) in [#142](https://github.com/jdx/hk/pull/142)
+
+### 🔍 Other Changes
+
+- Prettier *.yml and *.md files by [@tpansino](https://github.com/tpansino) in [#141](https://github.com/jdx/hk/pull/141)
+
+### New Contributors
+
+- @tpansino made their first contribution in [#141](https://github.com/jdx/hk/pull/141)
+
 ## [1.4.0](https://github.com/jdx/hk/compare/v1.3.0..v1.4.0) - 2025-08-12
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.44"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1f056bae57e3e54c3375c41ff79619ddd13460a17d7438712bd0d83fda4ff8"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -812,7 +812,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2487,9 +2487,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hk"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1587,7 +1587,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.4.0",
+  "version": "1.5.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.4.0
+**Version**: 1.5.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.4.0"
+version "1.5.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.5.0](https://github.com/jdx/hk/compare/v1.4.0..v1.5.0) - 2025-08-14

### 🚀 Features

- json5 support for prettier builtin by [@tpansino](https://github.com/tpansino) in [#136](https://github.com/jdx/hk/pull/136)

### 🐛 Bug Fixes

- elixir steps named properly by [@paradox460](https://github.com/paradox460) in [#140](https://github.com/jdx/hk/pull/140)
- pkl builtin by [@tpansino](https://github.com/tpansino) in [#138](https://github.com/jdx/hk/pull/138)
- make glob, exclude, and stage relative to dir by [@jdx](https://github.com/jdx) in [#142](https://github.com/jdx/hk/pull/142)

### 🔍 Other Changes

- Prettier *.yml and *.md files by [@tpansino](https://github.com/tpansino) in [#141](https://github.com/jdx/hk/pull/141)

### New Contributors

- @tpansino made their first contribution in [#141](https://github.com/jdx/hk/pull/141)