### PR TITLE
fix: elixir steps named properly

### DIFF
--- a/pkl/builtins/mix_compile.pkl
+++ b/pkl/builtins/mix_compile.pkl
@@ -1,6 +1,6 @@
 import "../Config.pkl"
 
-mix_fmt = new Config.Step {
+mix_compile = new Config.Step {
     glob = "*.ex"
     stage = glob
     exclude = List("deps/**/*")

--- a/pkl/builtins/mix_test.pkl
+++ b/pkl/builtins/mix_test.pkl
@@ -1,6 +1,6 @@
 import "../Config.pkl"
 
-mix_fmt = new Config.Step {
+mix_test = new Config.Step {
     glob = List("*.ex", "*.exs")
     stage = glob
     exclude = List("deps/**/*")


### PR DESCRIPTION
Fix the elixir builtin names to not conflict.

The pkl builtin needs to be updated as well, via https://github.com/jdx/hk/pull/138
