### PR TITLE
fix: properly display aborted steps when fail-fast triggers

### DIFF
--- a/src/step_group.rs
+++ b/src/step_group.rs
@@ -164,6 +164,10 @@ impl StepGroup {
                 Ok(Err(err)) => {
                     if settings.fail_fast {
                         ctx.hook_ctx.failed.cancel();
+                        // Mark remaining steps as aborted
+                        for step_ctx in ctx.hook_ctx.step_contexts.lock().unwrap().values() {
+                            step_ctx.status_aborted();
+                        }
                         return Err(err);
                     } else if result.is_ok() {
                         result = Err(err);


### PR DESCRIPTION
## Summary
- Fixed progress indicators that were left spinning when fail-fast triggers
- Steps now properly show a yellow warning symbol (⚠) with "aborted" message
- Child job progress indicators are hidden when parent step is aborted

## Problem
When `fail-fast` is enabled and a step fails, other running steps would leave their progress spinners in a running state instead of showing they were aborted.

## Solution
1. When fail-fast triggers, mark all remaining steps as aborted
2. When a step is marked as aborted, hide all its child job progress indicators
3. Display a clear yellow warning symbol (⚠) with "aborted" message for aborted steps

## Test plan
- [x] Create a test config with multiple slow-running steps and one that fails immediately
- [x] Run with fail-fast enabled (default)
- [x] Verify that aborted steps show yellow warning symbols instead of spinners
- [x] Verify that job-level progress indicators are hidden

🤖 Generated with [Claude Code](https://claude.ai/code)