### PR TITLE
feat: make stderr display in progress bars configurable

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -558,7 +558,8 @@ impl Step {
             .arg(&run)
             .with_pr(job.progress.as_ref().unwrap().clone())
             .with_cancel_token(ctx.hook_ctx.failed.clone())
-            .show_stderr_on_error(false);
+            .show_stderr_on_error(false)
+            .stderr_to_progress(true);
         if self.interactive {
             clx::progress::pause();
             cmd = cmd


### PR DESCRIPTION
## Summary
- Added `stderr_to_progress` configuration option to ensembler to control how stderr is displayed
- Default behavior in ensembler remains unchanged (stderr prints above progress bars)
- Updated hk to use `stderr_to_progress(true)` for consistent output handling

## Details
Previously, stderr output was always printed above the progress bars while stdout updated the progress property. This change allows stderr to be displayed inline with the progress bars, providing a cleaner output experience.

The implementation:
- Adds a new `stderr_to_progress` field to `CmdLineRunner` in ensembler (defaults to `false`)
- When enabled, stderr updates the same `ensembler_stdout` property that stdout uses
- When disabled, stderr continues to use `pr.println()` to print above progress bars
- hk now sets `stderr_to_progress(true)` for all step commands

## Test plan
- [x] Tested with steps that produce stderr output
- [x] Verified that stderr appears in the progress bars alongside stdout
- [x] Confirmed that ensembler's default behavior remains unchanged
- [x] Ensured no regression in error handling or output formatting

🤖 Generated with [Claude Code](https://claude.ai/code)