### PR TITLE
feat(templates): add {{workspace_files}}

### DIFF
--- a/src/step_job.rs
+++ b/src/step_job.rs
@@ -78,6 +78,10 @@ impl StepJob {
         tctx.with_files(self.step.shell_type(), &command_files);
         if let Some(workspace_indicator) = &self.workspace_indicator {
             tctx.with_workspace_indicator(workspace_indicator);
+            let workspace_dir = workspace_indicator
+                .parent()
+                .unwrap_or(std::path::Path::new("."));
+            tctx.with_workspace_files(self.step.shell_type(), workspace_dir, &self.files);
         }
         tctx
     }

--- a/test/workspace_indicator.bats
+++ b/test/workspace_indicator.bats
@@ -25,7 +25,7 @@ local linters = new Mapping<String, Step> {
   ["golangci-lint"] {
     glob = "*.go"
     workspace_indicator = "go.mod"
-    check = "echo {{ files }}"
+    check = "echo \"ws={{workspace}}; files={{files}}; wfiles={{workspace_files}}\""
   }
 }
 
@@ -45,15 +45,15 @@ EOF
 
   # Should see three jobs, one for each workspace, each with only its own file
   # Root workspace
-  assert_output --partial "echo main.go"
+  assert_output --partial "echo \"ws=.; files=main.go; wfiles=main.go\""
   # Workspace a
-  assert_output --partial "echo a/main.go"
+  assert_output --partial "echo \"ws=a; files=a/main.go; wfiles=main.go\""
   # Workspace b
-  assert_output --partial "echo b/main.go"
+  assert_output --partial "echo \"ws=b; files=b/main.go; wfiles=main.go\""
 
   # Should NOT see a/main.go or b/main.go in the root workspace's echo
   # (i.e., no echo with multiple files)
-  refute_output --partial "echo a/main.go b/main.go main.go"
-  refute_output --partial "echo a/main.go main.go"
-  refute_output --partial "echo b/main.go main.go"
+  refute_output --partial "files=a/main.go b/main.go main.go"
+  refute_output --partial "files=a/main.go main.go"
+  refute_output --partial "files=b/main.go main.go"
 } 


### PR DESCRIPTION
This adds a new Tera variable: \`{{workspace_files}}\` to list files relative to the current workspace when \`workspace_indicator\` is detected.\n\n- Implemented in \`src/tera.rs\` and wired via \`StepJob::tctx\`\n- Ensures root workspace renders as \`.\` for consistency\n- Includes a Bats test updating \`test/workspace_indicator.bats\`\n\nContext: [Discussion #164](https://github.com/jdx/hk/discussions/164).