### PR TITLE
fix: make NoFilesToProcess/ConditionFalse take precedence over ProfileNotEnabled

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -56,7 +56,7 @@ impl SkipReason {
                     "skipped: disabled by profile".to_string()
                 } else {
                     format!(
-                        "skipped: missing profile{} ({})",
+                        "skipped: profile{} not enabled ({})",
                         if profiles.len() > 1 { "s" } else { "" },
                         profiles.join(", ")
                     )

--- a/test/profile_skip_summary.bats
+++ b/test/profile_skip_summary.bats
@@ -32,7 +32,7 @@ EOF
     assert_success
     assert_output --partial "FAST TEST"
     refute_output --partial "SLOW TEST"
-    assert_output --partial "⏭ slow-test – skipped: missing profile (slow)"
+    assert_output --partial "⏭ slow-test – skipped: profile not enabled (slow)"
     assert_output --partial "1 step was skipped due to missing profiles: slow"
     assert_output --partial "To enable these steps, use --slow or set HK_PROFILE=slow."
     assert_output --partial "To hide this warning: set HK_HIDE_WARNINGS=missing-profiles"

--- a/test/skip_output.bats
+++ b/test/skip_output.bats
@@ -25,7 +25,7 @@ hooks {
 EOF
     run hk check
     assert_success
-    assert_output --partial "foo – skipped: missing profile (needs-profile)"
+    assert_output --partial "foo – skipped: profile not enabled (needs-profile)"
     refute_output --partial "RUN"
 }
 

--- a/test/skip_reason_precedence.bats
+++ b/test/skip_reason_precedence.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "no-files-to-process takes precedence over profile-not-enabled" {
+    # Ensure there is at least one staged/tracked file so hk does not early-exit
+    echo hi > SOME_FILE.txt
+    git add SOME_FILE.txt
+
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+
+// Ensure skip reasons are printed for all cases we care about
+display_skip_reasons = List("profile-not-enabled", "no-files-to-process", "condition-false")
+
+hooks {
+  ["check"] {
+    steps {
+      ["demo"] {
+        // Require a missing profile
+        profiles = List("slow")
+        // Ensure this step has no files to process after filtering
+        dir = "nonexistent_dir"
+        check = "echo should-not-run"
+      }
+    }
+  }
+}
+PKL
+
+    run hk check
+    assert_success
+    assert_output --partial "skipped: no files to process"
+    refute_output --partial "skipped: profile"
+}
+
+@test "condition-false takes precedence over profile-not-enabled" {
+    # Ensure there is at least one staged/tracked file so hk does not early-exit
+    echo hi > foo.txt
+    git add foo.txt
+
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+
+display_skip_reasons = List("profile-not-enabled", "no-files-to-process", "condition-false")
+
+hooks {
+  ["check"] {
+    steps {
+      ["demo"] {
+        profiles = List("slow")
+        condition = "false"
+        check = "echo should-not-run"
+      }
+    }
+  }
+}
+PKL
+
+    run hk check
+    assert_success
+    assert_output --partial "skipped: condition is false"
+    refute_output --partial "skipped: profile"
+}

--- a/test/skip_reasons_config.bats
+++ b/test/skip_reasons_config.bats
@@ -68,7 +68,7 @@ EOF
   assert_success
   
   # ProfileNotEnabled is set to true, so this message SHOULD appear
-  assert_output --partial "skipped: missing profile (nonexistent)"
+  assert_output --partial "skipped: profile not enabled (nonexistent)"
 }
 
 @test "skip_reasons: NoCommandForRunType messages can be configured" {


### PR DESCRIPTION
This changes skip reason precedence so steps are skipped for more specific reasons before profile checks:

- NoFilesToProcess now takes precedence over ProfileNotEnabled.
- ConditionFalse now takes precedence over ProfileNotEnabled.

Tests:
- Added test/skip_reason_precedence.bats to cover both cases.

Implementation notes:
- Removed early profile skip in build_step_jobs; defer until after file filtering.
- In run(), evaluate condition first, then apply profile skip.

This maintains existing messaging controls via display_skip_reasons and keeps early exit behavior intact.