### PR TITLE
feat(step): per-step output summaries (stderr|stdout|combined|hide)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ hooks {
         report = #"node scripts/upload-timings.js <<<"$HK_REPORT_JSON""#
     }
 }
-```text
+```
 
 The first line (`amends`) is critical because that imports the base configuration pkl for extending.
 
@@ -64,7 +64,7 @@ env {
     ["HK_FAIL_FAST"] = "0"
     ["NODE_ENV"] = "production"
 }
-```text
+```
 
 ## `hooks.<HOOK>`
 
@@ -105,7 +105,7 @@ hooks {
         }
     }
 }
-```text
+```pkl
 
 If you want to use a different check command for different operating systems, you can define a Script instead of a String:
 
@@ -143,7 +143,7 @@ hooks {
         }
     }
 }
-```plain
+```pkl
 
 ### `<STEP>.check_diff: (String | Script)`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,7 +105,7 @@ hooks {
         }
     }
 }
-```pkl
+```
 
 If you want to use a different check command for different operating systems, you can define a Script instead of a String:
 
@@ -143,7 +143,7 @@ hooks {
         }
     }
 }
-```pkl
+```
 
 ### `<STEP>.check_diff: (String | Script)`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ hooks {
         report = #"node scripts/upload-timings.js <<<"$HK_REPORT_JSON""#
     }
 }
-```
+```text
 
 The first line (`amends`) is critical because that imports the base configuration pkl for extending.
 
@@ -64,7 +64,7 @@ env {
     ["HK_FAIL_FAST"] = "0"
     ["NODE_ENV"] = "production"
 }
-```
+```text
 
 ## `hooks.<HOOK>`
 
@@ -105,7 +105,7 @@ hooks {
         }
     }
 }
-```
+```text
 
 If you want to use a different check command for different operating systems, you can define a Script instead of a String:
 
@@ -126,10 +126,10 @@ hooks {
 
 Template variables:
 
-- <code v-pre>{{files}}</code>: A list of files to run the linter on.
-- <code v-pre>{{workspace}}</code>: When `workspace_indicator` is set and matched, this is the workspace directory path (e.g., `.` for the repo root or `packages/app`).
-- <code v-pre>{{workspace_indicator}}</code>: Full path to the matched workspace indicator file (e.g., `packages/app/package.json`).
-- <code v-pre>{{workspace_files}}</code>: A list of files relative to <code v-pre>{{workspace}}</code>.
+- `{{files}}`: A list of files to run the linter on.
+- `{{workspace}}`: When `workspace_indicator` is set and matched, this is the workspace directory path (e.g., `.` for the repo root or `packages/app`).
+- `{{workspace_indicator}}`: Full path to the matched workspace indicator file (e.g., `packages/app/package.json`).
+- `{{workspace_files}}`: A list of files relative to `{{workspace}}`.
 
 ### `<STEP>.check_list_files: (String | Script)`
 
@@ -143,7 +143,7 @@ hooks {
         }
     }
 }
-```
+```plain
 
 ### `<STEP>.check_diff: (String | Script)`
 
@@ -206,7 +206,7 @@ local linters = new Mapping<String, Step> {
 
 In this example, given a file list like the following:
 
-```
+```text
 └── workspaces/
     ├── proj1/
     │   ├── Cargo.toml
@@ -227,9 +227,9 @@ hk will run 1 step for each workspace even though multiple rs files are in each 
 
 When `workspace_indicator` is used, the following template variables become available in commands and env:
 
-- <code v-pre>{{workspace}}</code>: the workspace directory path
-- <code v-pre>{{workspace_indicator}}</code>: the matched indicator file path
-- <code v-pre>{{workspace_files}}</code>: files relative to <code v-pre>{{workspace}}</code>
+- `{{workspace}}`: the workspace directory path
+- `{{workspace_indicator}}`: the matched indicator file path
+- `{{workspace_files}}`: files relative to `{{workspace}}`
 
 For example, in a monorepo with Node packages:
 
@@ -415,6 +415,40 @@ local linters = new Mapping<String, Step> {
 }
 ```
 
+### `<STEP>.output_summary: "stdout" | "stderr" | "combined" | "hide"`
+
+Default: `"stderr"`
+
+Controls which stream(s) from the step’s command are captured and printed at the end of the hook run. This prints a single consolidated block per step that produced any output, with a header like `STEP_NAME stderr:`.
+
+- `"stderr"` (default): capture only standard error
+- `"stdout"`: capture only standard output
+- `"combined"`: capture both stdout and stderr interleaved (line-by-line as produced)
+- `"hide"`: capture nothing and print nothing for this step
+
+Examples:
+
+```pkl
+hooks {
+  ["check"] {
+    steps {
+      ["lint"] {
+        check = "eslint {{files}}"
+        output_summary = "combined"
+      }
+      ["format"] {
+        check = "prettier --check {{files}}"
+        output_summary = "stdout"
+      }
+      ["quiet-step"] {
+        check = "echo noisy && echo warn 1>&2"
+        output_summary = "hide"
+      }
+    }
+  }
+}
+```
+
 ### `<STEP>.env: Mapping<String, String>`
 
 Environment variables specific to this step. These are merged with the global environment variables.
@@ -554,5 +588,6 @@ hooks {
 ```
 
 The hkrc configuration is applied after loading the project configuration (`hk.pkl`), which means:
+
 - User configuration takes precedence over project configuration
 - Project-specific settings in `hk.pkl` can override or extend the global configuration

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -139,9 +139,11 @@ Default: `(empty)`
 A comma-separated list of warning tags to suppress. This allows you to hide specific warning messages that you don't want to see.
 
 Available warning tags:
+
 - `missing-profiles`: Suppresses warnings about steps being skipped due to missing profiles
 
 Example usage:
+
 ```bash
 HK_HIDE_WARNINGS=missing-profiles hk check
 ```
@@ -178,6 +180,7 @@ Type: `path`
 If set to a file path, hk will write a JSON timing report at the end of a run. The report includes total wall time and per-step wall time, with overlapping intervals merged so time isn’t double-counted across parallel step parts.
 
 The `steps` field is an object mapping step names to an object with:
+
 - `wall_time_ms`: merged wall time in milliseconds
 - `profiles` (optional): the list of profiles required for that step. If there are no profiles, this field is omitted.
 
@@ -199,4 +202,17 @@ Example output shape:
     "fmt": { "wall_time_ms": 2100 }
   }
 }
+```
+
+## `HK_SUMMARY_TEXT`
+
+Type: `bool`
+Default: `false`
+
+Controls whether per-step output summaries are printed in plain text mode. By default, summaries are only shown when hk is rendering progress bars (non-text mode). Set this to `true` to force summaries to appear in text mode.
+
+Example:
+
+```bash
+HK_SUMMARY_TEXT=1 hk check
 ```

--- a/hk.pkl
+++ b/hk.pkl
@@ -35,6 +35,7 @@ local linters = new Mapping<String, Step | Group> {
     ["docs"] = new Step {
         glob = "docs/**"
         check = "mise run docs:build"
+        output_summary = "hide"
     }
 }
 

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -70,6 +70,10 @@ class Step {
 
     hide = false
     
+    /// Controls which stream(s) to include in the end-of-run summary for this step
+    /// One of: "stdout", "stderr", "combined", "hide"
+    output_summary: "stdout" | "stderr" | "combined" | "hide" = "stderr"
+    
     /// run the linter scripts with these environment variables
     env = new Mapping<String, String>{}
 

--- a/pkl/builtins/cargo_check.pkl
+++ b/pkl/builtins/cargo_check.pkl
@@ -2,7 +2,7 @@ import "../Config.pkl"
 
 cargo_check = new Config.Step {
     glob = "*.rs"
-    check = "cargo check"
+    check = "cargo check -q"
     env {
         ["CARGO_TERM_COLOR"] = "{% if color %}always{% else %}never{% endif %}"
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -80,6 +80,9 @@ pub static HK_FAIL_FAST: LazyLock<bool> = LazyLock::new(|| !var_false("HK_FAIL_F
 pub static HK_HIDE_WARNINGS: LazyLock<IndexSet<String>> =
     LazyLock::new(|| var_csv("HK_HIDE_WARNINGS").unwrap_or_default());
 
+// When true, allow output summaries to be printed in text mode
+pub static HK_SUMMARY_TEXT: LazyLock<bool> = LazyLock::new(|| var_true("HK_SUMMARY_TEXT"));
+
 pub static GIT_INDEX_FILE: LazyLock<Option<PathBuf>> = LazyLock::new(|| var_path("GIT_INDEX_FILE"));
 
 fn var_path(name: &str) -> Option<PathBuf> {

--- a/test/output_summary.bats
+++ b/test/output_summary.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "output_summary default (stderr) prints only stderr" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["s"] {
+        // default output_summary
+        check = "echo OUT && echo ERR 1>&2"
+      }
+    }
+  }
+}
+EOF
+    HK_SUMMARY_TEXT=1 run hk check
+    assert_success
+    # Summary should include stderr header and content
+    assert_output --partial "s stderr:"
+    refute_output --partial "s stdout:"
+    assert_output --partial "ERR"
+}
+
+@test "output_summary stdout prints only stdout" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["s"] {
+        output_summary = "stdout"
+        check = "echo OUT && echo ERR 1>&2"
+      }
+    }
+  }
+}
+EOF
+    HK_SUMMARY_TEXT=1 run hk check
+    assert_success
+    assert_output --partial "s stdout:"
+    refute_output --partial "s stderr:"
+    assert_output --partial "OUT"
+}
+
+@test "output_summary combined prints interleaved output" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["s"] {
+        output_summary = "combined"
+        check = "echo O1; echo E1 1>&2; echo O2; echo E2 1>&2"
+      }
+    }
+  }
+}
+EOF
+    HK_SUMMARY_TEXT=1 run hk check
+    assert_success
+    assert_output --partial "s output:"
+    # We can't perfectly assert interleaving with lines, but ensure both appear
+    assert_output --partial "O1"
+    assert_output --partial "E1"
+    assert_output --partial "O2"
+    assert_output --partial "E2"
+}
+
+@test "output_summary hide prints nothing" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["s"] {
+        output_summary = "hide"
+        check = "echo OUT && echo ERR 1>&2"
+      }
+    }
+  }
+}
+EOF
+    HK_SUMMARY_TEXT=1 run hk check
+    assert_success
+    refute_output --partial "s stdout:"
+    refute_output --partial "s stderr:"
+    refute_output --partial "s output:"
+}


### PR DESCRIPTION
Adds per-step output summaries with modes: stderr (default), stdout, combined (interleaved), and hide. Aggregates and prints once per step with headers. In text mode, summaries are disabled by default unless HK_SUMMARY_TEXT=1. Includes Pkl schema, docs, and Bats tests.