### PR TITLE
chore: release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.9.1](https://github.com/jdx/hk/compare/v1.9.0..v1.9.1) - 2025-08-19
+
+### 🐛 Bug Fixes
+
+- **(test)** make sandbox opt-in via {{tmp}}; clean fixtures on success; fix builtins to use {{tmp}}; docs: update examples by [@jdx](https://github.com/jdx) in [#182](https://github.com/jdx/hk/pull/182)
+
+### 🔍 Other Changes
+
+- subtree-sync by [@jdx](https://github.com/jdx) in [#184](https://github.com/jdx/hk/pull/184)
+
 ## [1.9.0](https://github.com/jdx/hk/compare/v1.8.0..v1.9.0) - 2025-08-19
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1093,7 +1093,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "chrono",
  "clap",
@@ -1282,7 +1282,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2311,7 +2311,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2553,7 +2553,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3075,7 +3075,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3833,7 +3833,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1774,7 +1774,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.9.0",
+  "version": "1.9.1",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.9.0
+**Version**: 1.9.1
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.9.0"
+version "1.9.1"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.9.1](https://github.com/jdx/hk/compare/v1.9.0..v1.9.1) - 2025-08-19

### 🐛 Bug Fixes

- **(test)** make sandbox opt-in via {{tmp}}; clean fixtures on success; fix builtins to use {{tmp}}; docs: update examples by [@jdx](https://github.com/jdx) in [#182](https://github.com/jdx/hk/pull/182)

### 🔍 Other Changes

- subtree-sync by [@jdx](https://github.com/jdx) in [#184](https://github.com/jdx/hk/pull/184)