### PR TITLE
feat(progress): flex-width progress bar

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -618,7 +618,7 @@ impl Hook {
             return None;
         }
         let mut hk_progress = ProgressJobBuilder::new()
-            .body("{{hk}}{{hook}}{{message}}  {{progress_bar(width=40)}} {{cur}}/{{total}}")
+            .body("{{hk}}{{hook}}{{message}}  {{progress_bar(flex=true)}} {{cur}}/{{total}}")
             .body_text(Some("{{hk}}{{hook}}{{message}}"))
             .prop(
                 "hk",


### PR DESCRIPTION
- Add progress_bar(flex=true) which auto-sizes to available width and wraps itself in flex tags\n- Update header template to use it; no need for `| flex` pipe\n- Add unit tests and ensure no overflow\n