### PR TITLE
chore: release v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+## [1.10.1](https://github.com/jdx/hk/compare/v1.10.0..v1.10.1) - 2025-08-22
+
+### 🐛 Bug Fixes
+
+- **(clx)** avoid Unicode slicing panic in truncate_text and previews by using char-safe prefix by [@jdx](https://github.com/jdx) in [3369b59](https://github.com/jdx/hk/commit/3369b591910d2bbdc36f8055021f469c307563ca)
+
 ## [1.10.0](https://github.com/jdx/hk/compare/v1.9.2..v1.10.0) - 2025-08-22
 
 ### 🚀 Features
 
 - **(progress)** flex-width progress bar by [@jdx](https://github.com/jdx) in [#187](https://github.com/jdx/hk/pull/187)
+- expose git status to expr conditions and Tera templates by [@jdx](https://github.com/jdx) in [#191](https://github.com/jdx/hk/pull/191)
 
 ### 🐛 Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,7 +1093,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.10.0"
+version = "1.10.1"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1774,7 +1774,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.10.0",
+  "version": "1.10.1",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.10.0
+**Version**: 1.10.1
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.10.0"
+version "1.10.1"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.10.1](https://github.com/jdx/hk/compare/v1.10.0..v1.10.1) - 2025-08-22

### 🐛 Bug Fixes

- **(clx)** avoid Unicode slicing panic in truncate_text and previews by using char-safe prefix by [@jdx](https://github.com/jdx) in [3369b59](https://github.com/jdx/hk/commit/3369b591910d2bbdc36f8055021f469c307563ca)