### PR TITLE
chore: release v1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.10.2](https://github.com/jdx/hk/compare/v1.10.1..v1.10.2) - 2025-08-22
+
+### 🐛 Bug Fixes
+
+- use correct expr environment with builtins by [@jdx](https://github.com/jdx) in [2284b33](https://github.com/jdx/hk/commit/2284b334200b5cb17dd06536b84755bf85778021)
+
+### 📚 Documentation
+
+- correct expr examples for git staged file syntax by [@jdx](https://github.com/jdx) in [f1fa1cf](https://github.com/jdx/hk/commit/f1fa1cfebec13cd03b1fb867777af477d433a3fe)
+
 ## [1.10.1](https://github.com/jdx/hk/compare/v1.10.0..v1.10.1) - 2025-08-22
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ version = "0.2.11"
 dependencies = [
  "clx",
  "console 0.15.11",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "indicatif 0.17.11",
  "itertools",
  "log",
@@ -781,7 +781,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9ce3d235522134512e01e281dbf60f3a9a6ba6ffcddc4b6dbb10c9a62d66cb"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "log",
  "once_cell",
  "pest",
@@ -1054,7 +1054,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1093,7 +1093,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "chrono",
  "clap",
@@ -1108,7 +1108,7 @@ dependencies = [
  "getrandom 0.3.3",
  "git2",
  "globset",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools",
  "log",
  "once_cell",
@@ -1462,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -2731,7 +2731,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2769,7 +2769,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -2797,7 +2797,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itoa",
  "ryu",
  "serde",
@@ -3307,7 +3307,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3604,7 +3604,7 @@ checksum = "a10ea46630ad25b371a9f1c849e4a07217385cf2d908b1bebe324689d33c68b2"
 dependencies = [
  "clap",
  "heck",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "itertools",
  "kdl",
  "log",
@@ -4383,7 +4383,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.3",
  "hmac",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.10.1"
+version = "1.10.2"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1774,7 +1774,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.10.1",
+  "version": "1.10.2",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.10.1
+**Version**: 1.10.2
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.10.1"
+version "1.10.2"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.10.2](https://github.com/jdx/hk/compare/v1.10.1..v1.10.2) - 2025-08-22

### 🐛 Bug Fixes

- use correct expr environment with builtins by [@jdx](https://github.com/jdx) in [2284b33](https://github.com/jdx/hk/commit/2284b334200b5cb17dd06536b84755bf85778021)

### 📚 Documentation

- correct expr examples for git staged file syntax by [@jdx](https://github.com/jdx) in [f1fa1cf](https://github.com/jdx/hk/commit/f1fa1cfebec13cd03b1fb867777af477d433a3fe)