### PR TITLE
chore: release v1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.10.3](https://github.com/jdx/hk/compare/v1.10.2..v1.10.3) - 2025-08-22
+
+### 🐛 Bug Fixes
+
+- **(step)** include root variant for '**/' stage globs (stage maintainers.yml at repo root) by [@jdx](https://github.com/jdx) in [#198](https://github.com/jdx/hk/pull/198)
+
+### 🔍 Other Changes
+
+- fix msrv job by [@jdx](https://github.com/jdx) in [5590e22](https://github.com/jdx/hk/commit/5590e2293f84907a142bd34334dbd0164bb050b6)
+
 ## [1.10.2](https://github.com/jdx/hk/compare/v1.10.1..v1.10.2) - 2025-08-22
 
 ### 🐛 Bug Fixes
@@ -9,6 +19,12 @@
 ### 📚 Documentation
 
 - correct expr examples for git staged file syntax by [@jdx](https://github.com/jdx) in [f1fa1cf](https://github.com/jdx/hk/commit/f1fa1cfebec13cd03b1fb867777af477d433a3fe)
+
+### 🔍 Other Changes
+
+- remove embedded subtrees in favor of submodules by [@jdx](https://github.com/jdx) in [186480d](https://github.com/jdx/hk/commit/186480d317441cce2294a9960932939112dc11d6)
+- fetch submodules by [@jdx](https://github.com/jdx) in [397e0d3](https://github.com/jdx/hk/commit/397e0d3ae78375be506963e6fe60900af4c23374)
+- fixing release-plz by [@jdx](https://github.com/jdx) in [86a2d79](https://github.com/jdx/hk/commit/86a2d7942f6fa19222e2f6b8311adb8cfab74f20)
 
 ## [1.10.1](https://github.com/jdx/hk/compare/v1.10.0..v1.10.1) - 2025-08-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1093,7 +1093,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "chrono",
  "clap",
@@ -1282,7 +1282,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2311,7 +2311,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2553,7 +2553,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3075,7 +3075,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3833,7 +3833,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.10.2"
+version = "1.10.3"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1774,7 +1774,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.10.2",
+  "version": "1.10.3",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.10.2
+**Version**: 1.10.3
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.10.2"
+version "1.10.3"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.10.3](https://github.com/jdx/hk/compare/v1.10.2..v1.10.3) - 2025-08-22

### 🐛 Bug Fixes

- **(step)** include root variant for '**/' stage globs (stage maintainers.yml at repo root) by [@jdx](https://github.com/jdx) in [#198](https://github.com/jdx/hk/pull/198)

### 🔍 Other Changes

- fix msrv job by [@jdx](https://github.com/jdx) in [5590e22](https://github.com/jdx/hk/commit/5590e2293f84907a142bd34334dbd0164bb050b6)