### PR TITLE
fix(step): include root variant for '**/' stage globs (stage maintainers.yml at repo root)

### DIFF
--- a/test/stage_root_glob.bats
+++ b/test/stage_root_glob.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "stage '**/maintainers.yml' matches root-level file" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    fix = true
+    steps {
+      ["stage-maintainers"] {
+        fix = "echo done"
+        glob = "maintainers.yml"
+        stage = "**/maintainers.yml"
+      }
+    }
+  }
+}
+EOF
+    git add hk.pkl
+    git commit -m "init"
+
+    # create root-level file that should match the stage glob
+    echo name: a > maintainers.yml
+
+    # ensure it's untracked before running
+    run git status --porcelain -- maintainers.yml
+    assert_success
+    [[ "$output" == '?? maintainers.yml' ]]
+
+    # run fix using hk in PATH (added by test helper)
+    hk fix -v
+
+    # file should be staged after hk fix
+    run git status --porcelain -- maintainers.yml
+    assert_success
+    [[ "$output" =~ ^A\  ]]
+}


### PR DESCRIPTION
- Add bats test to repro and verify
- Expand '**/file' stage patterns to also match 'file' at repo root

Fixes: staging miss for root-level files when using recursive glob
