### PR TITLE
fix(docs): add v-pre directive to inline code for proper rendering

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -63,6 +63,14 @@ export default defineConfig({
     },
   },
   markdown: {
+    // https://github.com/vuejs/vitepress/discussions/3724
+    config(md) {
+      const defaultCodeInline = md.renderer.rules.code_inline!
+      md.renderer.rules.code_inline = (tokens, idx, options, env, self) => {
+        tokens[idx].attrSet('v-pre', '')
+        return defaultCodeInline(tokens, idx, options, env, self)
+      }
+    },
     languages: [{
       name: 'pkl',
       displayName: 'pkl',


### PR DESCRIPTION
Fixes VitePress rendering issue where inline code containing double curly braces was being interpreted as Vue template syntax instead of literal text.

Strings containing `{{}}` were not displayed correctly in https://hk.jdx.dev/configuration.html.
<img width="1416" height="354" alt="CleanShot 2025-08-23 at 22 26 57@2x" src="https://github.com/user-attachments/assets/60bbdf7f-41d6-4954-82b7-ff9c269570fc" />

I solved it using the method introduced in https://github.com/vuejs/vitepress/discussions/3724.