### PR TITLE
chore: release v1.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.10.7](https://github.com/jdx/hk/compare/v1.10.6..v1.10.7) - 2025-08-27
+
+### 🐛 Bug Fixes
+
+- show `--from-ref` instructions for missing profile warning by [@jdx](https://github.com/jdx) in [#204](https://github.com/jdx/hk/pull/204)
+
+### 📚 Documentation
+
+- document default_branch by [@jdx](https://github.com/jdx) in [#206](https://github.com/jdx/hk/pull/206)
+
 ## [1.10.6](https://github.com/jdx/hk/compare/v1.10.5..v1.10.6) - 2025-08-26
 
 ### 🔍 Other Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,7 +1081,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.10.6"
+version = "1.10.7"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1774,7 +1774,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.10.6",
+  "version": "1.10.7",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.10.6
+**Version**: 1.10.7
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.10.6"
+version "1.10.7"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.10.7](https://github.com/jdx/hk/compare/v1.10.6..v1.10.7) - 2025-08-27

### 🐛 Bug Fixes

- show `--from-ref` instructions for missing profile warning by [@jdx](https://github.com/jdx) in [#204](https://github.com/jdx/hk/pull/204)

### 📚 Documentation

- document default_branch by [@jdx](https://github.com/jdx) in [#206](https://github.com/jdx/hk/pull/206)