### PR TITLE
fix: add pre-commit task to mise.toml generation

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -77,6 +77,9 @@ hooks {
             let mise_content = r#"[tools]
 hk = "latest"
 pkl = "latest"
+
+[tasks.pre-commit]
+run = "hk run pre-commit"
 "#;
             if mise_toml.exists() {
                 warn!("mise.toml already exists, run with --force to overwrite");


### PR DESCRIPTION
## Summary
- Fixes #211 by adding the missing pre-commit task to mise.toml generation
- When running `hk init --mise`, the generated mise.toml now properly includes a pre-commit task

## Test plan
- [x] Tested locally with `hk init --mise` 
- [x] Verified mise.toml includes the pre-commit task
- [x] All CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)