### PR TITLE
fix: include pkl packages in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           find artifacts/binary-* -type f \( -name "*.tar.gz" -o -name "*.tar.xz" -o -name "*.zip" \) -exec mv {} release-assets/ \;
           # Move pkl packages to release-assets
           if [ -d "artifacts/pkl-packages" ]; then
-            find artifacts/pkl-packages -type f -exec mv {} release-assets/ \;
+            find artifacts/pkl-packages -type f \( -name "*.zip" -o -name "*.sha256" \) -exec mv {} release-assets/ \;
           fi
           ls -la release-assets/
       - name: Create release with all assets


### PR DESCRIPTION
## Summary
- Fix missing pkl packages in release artifacts
- The release workflow was building pkl packages but not including them in final release assets
- Added file type filtering to properly move pkl package files (.zip and .sha256) to release assets

## Test plan
- [ ] Verify the workflow change is syntactically correct
- [ ] Test with next release to ensure pkl packages are included
- [ ] Check that both .zip and .sha256 files are properly included in release assets

🤖 Generated with [Claude Code](https://claude.ai/code)