### PR TITLE
chore: release v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,37 @@
 # Changelog
 
+## [1.13.0](https://github.com/jdx/hk/compare/v1.12.1..v1.13.0) - 2025-09-17
+
+### 🚀 Features
+
+- add tracing and performance diagnostics support by [@jdx](https://github.com/jdx) in [3045a38](https://github.com/jdx/hk/commit/3045a3826e4b1c4213dbccadb7dc1ce442a814fa)
+- add tracing and performance diagnostics support by [@jdx](https://github.com/jdx) in [#259](https://github.com/jdx/hk/pull/259)
+- comprehensive configuration unification with proper precedence and union semantics by [@jdx](https://github.com/jdx) in [#266](https://github.com/jdx/hk/pull/266)
+- centralized skip configuration for steps and hooks by [@jdx](https://github.com/jdx) in [#268](https://github.com/jdx/hk/pull/268)
+
+### 📚 Documentation
+
+- add comprehensive schema reference and built-in linters documentation by [@jdx](https://github.com/jdx) in [#261](https://github.com/jdx/hk/pull/261)
+- add comprehensive logging and debugging guide by [@jdx](https://github.com/jdx) in [#263](https://github.com/jdx/hk/pull/263)
+- add glossary and update sidebar navigation by [@jdx](https://github.com/jdx) in [#264](https://github.com/jdx/hk/pull/264)
+- document configuration unification and skip configuration features by [@jdx](https://github.com/jdx) in [#269](https://github.com/jdx/hk/pull/269)
+
+### 🔍 Other Changes
+
+- **(ci)** include Pkl artifacts in releases; support manual version input by [@jdx](https://github.com/jdx) in [#265](https://github.com/jdx/hk/pull/265)
+- mise.lock by [@bhanuprasad14](https://github.com/bhanuprasad14) in [5a5a5d0](https://github.com/jdx/hk/commit/5a5a5d03727a72a260383f67eb7696857894d664)
+
+### New Contributors
+
+- @bhanuprasad14 made their first contribution
+
 ## [1.12.1](https://github.com/jdx/hk/compare/v1.12.0..v1.12.1) - 2025-09-13
 
 ### 🐛 Bug Fixes
 
 - include pkl packages in releases by [@jdx](https://github.com/jdx) in [#227](https://github.com/jdx/hk/pull/227)
 - improve stashing error handling and robustness by [@jdx](https://github.com/jdx) in [#229](https://github.com/jdx/hk/pull/229)
+- only show fix help message when running in check mode by [@jdx](https://github.com/jdx) in [#230](https://github.com/jdx/hk/pull/230)
 
 ## [1.12.0](https://github.com/jdx/hk/compare/v1.11.2..v1.12.0) - 2025-09-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ version = "0.2.11"
 dependencies = [
  "clx",
  "console 0.15.11",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "indicatif 0.17.11",
  "itertools",
  "log",
@@ -764,7 +764,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9ce3d235522134512e01e281dbf60f3a9a6ba6ffcddc4b6dbb10c9a62d66cb"
 dependencies = [
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "log",
  "once_cell",
  "pest",
@@ -982,7 +982,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.5+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1043,7 +1043,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1082,7 +1082,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.12.1"
+version = "1.13.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1097,7 +1097,7 @@ dependencies = [
  "getrandom 0.3.3",
  "git2",
  "globset",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "itertools",
  "log",
  "once_cell",
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64",
  "bytes",
@@ -1456,13 +1456,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1595,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "6247da8b8658ad4e73a186e747fcc5fc2a29f979d6fe6269127fdb5fd08298d0"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1648,9 +1649,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags",
  "libc",
@@ -2565,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.5"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a37813727b78798e53c2bec3f5e8fe12a6d6f8389bf9ca7802add4c9905ad8"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2672,24 +2673,34 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2698,24 +2709,25 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2740,7 +2752,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -2768,7 +2780,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "itoa",
  "ryu",
  "serde",
@@ -3263,12 +3275,12 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
 dependencies = [
- "indexmap 2.11.1",
- "serde",
+ "indexmap 2.11.3",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
@@ -3278,11 +3290,11 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "a197c0ec7d131bfc6f7e82c8442ba1595aeab35da7adbf05b6b73cd06a16b6be"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3565,7 +3577,7 @@ checksum = "a10ea46630ad25b371a9f1c849e4a07217385cf2d908b1bebe324689d33c68b2"
 dependencies = [
  "clap",
  "heck",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "itertools",
  "kdl",
  "log",
@@ -3648,27 +3660,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.5+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
  "wasip2",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "4ad224d2776649cfb4f4471124f8176e54c1cca67a88108e30a0cd98b90e7ad3"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3679,9 +3691,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+checksum = "3a1364104bdcd3c03f22b16a3b1c9620891469f5e9f09bc38b2db121e593e732"
 dependencies = [
  "bumpalo",
  "log",
@@ -3693,9 +3705,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.51"
+version = "0.4.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
+checksum = "9c0a08ecf5d99d5604a6666a70b3cde6ab7cc6142f5e641a8ef48fc744ce8854"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3706,9 +3718,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "0d7ab4ca3e367bb1ed84ddbd83cc6e41e115f8337ed047239578210214e36c76"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3716,9 +3728,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "4a518014843a19e2dbbd0ed5dfb6b99b23fb886b14e6192a00803a3e14c552b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3729,18 +3741,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "255eb0aa4cc2eea3662a00c2bbd66e93911b7361d5e0fcd62385acfd7e15dcee"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.78"
+version = "0.3.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "50462a022f46851b81d5441d1a6f5bac0b21a1d72d64bd4906fbdd4bf7230ec7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4183,9 +4195,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
@@ -4396,7 +4408,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.3",
  "hmac",
- "indexmap 2.11.1",
+ "indexmap 2.11.3",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.12.1"
+version = "1.13.0"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2167,7 +2167,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.12.1",
+  "version": "1.13.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.12.1
+**Version**: 1.13.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.12.1"
+version "1.13.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.13.0](https://github.com/jdx/hk/compare/v1.12.1..v1.13.0) - 2025-09-17

### 🚀 Features

- add tracing and performance diagnostics support by [@jdx](https://github.com/jdx) in [3045a38](https://github.com/jdx/hk/commit/3045a3826e4b1c4213dbccadb7dc1ce442a814fa)
- add tracing and performance diagnostics support by [@jdx](https://github.com/jdx) in [#259](https://github.com/jdx/hk/pull/259)
- comprehensive configuration unification with proper precedence and union semantics by [@jdx](https://github.com/jdx) in [#266](https://github.com/jdx/hk/pull/266)
- centralized skip configuration for steps and hooks by [@jdx](https://github.com/jdx) in [#268](https://github.com/jdx/hk/pull/268)

### 📚 Documentation

- add comprehensive schema reference and built-in linters documentation by [@jdx](https://github.com/jdx) in [#261](https://github.com/jdx/hk/pull/261)
- add comprehensive logging and debugging guide by [@jdx](https://github.com/jdx) in [#263](https://github.com/jdx/hk/pull/263)
- add glossary and update sidebar navigation by [@jdx](https://github.com/jdx) in [#264](https://github.com/jdx/hk/pull/264)
- document configuration unification and skip configuration features by [@jdx](https://github.com/jdx) in [#269](https://github.com/jdx/hk/pull/269)

### 🔍 Other Changes

- **(ci)** include Pkl artifacts in releases; support manual version input by [@jdx](https://github.com/jdx) in [#265](https://github.com/jdx/hk/pull/265)
- mise.lock by [@bhanuprasad14](https://github.com/bhanuprasad14) in [5a5a5d0](https://github.com/jdx/hk/commit/5a5a5d03727a72a260383f67eb7696857894d664)

### New Contributors

- @bhanuprasad14 made their first contribution