### PR TITLE
docs: add glossary and update sidebar navigation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -40,16 +40,18 @@ export default defineConfig({
       { text: 'About', link: '/about' },
       { text: 'Getting Started', link: '/getting_started' },
       { text: 'Configuration', link: '/configuration' },
-      { 
-        text: 'Reference', 
+      {
+        text: 'Reference',
         items: [
           { text: 'Schema Reference', link: '/reference/schema' },
           { text: 'Built-in Linters', link: '/builtins' },
           { text: 'Configuration Examples', link: '/reference/examples/' },
+          { text: 'Glossary', link: '/glossary' },
         ]
       },
       { text: 'Environment Variables', link: '/environment_variables' },
       { text: 'Hooks', link: '/hooks' },
+      { text: 'Logging and Debugging', link: '/logging' },
       { text: 'Introduction to pkl', link: '/pkl_introduction' },
       { text: 'mise-en-place Integration', link: '/mise_integration' },
       { text: 'CLI Reference', link: '/cli', items: commands.map(cmd => ({ text: cmd.join(' '), link: `/cli/${cmd.join('/')}` })) },

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,128 @@
+---
+outline: "deep"
+---
+
+# Glossary
+
+This glossary defines key terms used throughout hk documentation and configuration.
+
+## Depends
+
+A step configuration property that specifies other steps that must complete successfully before this step can run. Dependencies control execution order and ensure prerequisites are met.
+
+Example:
+```pkl
+steps {
+  ["typecheck"] {
+    depends = List("lint", "format")  // Wait for lint and format to complete
+    check = "tsc --noEmit"
+  }
+}
+```
+
+See: [Step Dependencies](/reference/schema.md#depends)
+
+## Group
+
+A organizational unit that contains multiple steps, allowing you to structure your configuration hierarchically. Groups help organize related steps together and can be used to create logical divisions like "frontend" and "backend" tasks.
+
+Example:
+```pkl
+steps {
+  ["frontend"] = new Group {
+    steps {
+      ["prettier"] = Builtins.prettier
+      ["eslint"] = Builtins.eslint
+    }
+  }
+}
+```
+
+See: [Group Configuration](/reference/schema.md#group-configuration)
+
+## Hook
+
+A git hook or custom command that runs a collection of steps. hk supports standard git hooks like `pre-commit`, `pre-push`, `commit-msg`, and `prepare-commit-msg`, as well as custom hooks like `check` and `fix` for manual execution.
+
+Example:
+```pkl
+hooks {
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+    steps = linters
+  }
+}
+```
+
+See: [Hooks](/hooks.md)
+
+## Job
+
+The number of parallel processes that hk will use to execute steps concurrently. This affects performance by controlling how many linting/formatting tasks can run simultaneously. Can be configured via the `-j/--jobs` CLI flag or `HK_JOBS` environment variable.
+
+Example:
+```bash
+# Run with 4 parallel jobs
+hk check --jobs 4
+
+# Or via environment variable
+HK_JOBS=8 hk fix
+```
+
+See: [HK_JOBS](/environment_variables.md#hk_jobs)
+
+## Skip
+
+A mechanism to bypass execution of specific steps or entire hooks. Steps can be skipped using the `HK_SKIP_STEPS` environment variable, while entire hooks can be skipped with `HK_SKIP_HOOK`.
+
+Examples:
+```bash
+# Skip specific steps
+HK_SKIP_STEPS=lint,test hk run pre-commit
+
+# Skip entire hooks
+HK_SKIP_HOOK=pre-commit,pre-push git commit
+```
+
+See: [HK_SKIP_STEPS](/environment_variables.md#hk_skip_steps), [HK_SKIP_HOOK](/environment_variables.md#hk_skip_hook)
+
+## Stash
+
+A strategy for temporarily saving uncommitted changes before running hooks that might modify files. This prevents conflicts between your working directory changes and the automated fixes applied by linting tools.
+
+Stash strategies:
+- `git`: Uses `git stash` (default)
+- `patch-file`: Uses hk-generated patch files (faster, avoids lock conflicts)
+- `none`: No stashing (fastest, but may cause staging conflicts)
+
+Example:
+```pkl
+hooks {
+  ["pre-commit"] {
+    stash = "patch-file"  // Use patch-based stashing
+    steps = linters
+  }
+}
+```
+
+See: [HK_STASH](/environment_variables.md#hk_stash)
+
+## Step
+
+An individual linting, formatting, or validation task that processes files. Steps are the fundamental units of work in hk, each defining commands to check and/or fix code. Steps can specify which files they operate on using glob patterns, and can have dependencies on other steps.
+
+Example:
+```pkl
+steps {
+  ["eslint"] {
+    glob = List("*.js", "*.ts")
+    stage = List("*.js", "*.ts")
+    check = "eslint {{files}}"
+    fix = "eslint --fix {{files}}"
+    depends = List("prettier")  // Run after prettier
+  }
+}
+```
+
+See: [Step Configuration](/reference/schema.md#step-configuration)


### PR DESCRIPTION
## Summary

- Add comprehensive glossary defining key hk terminology: hook, step, job, group, depends, skip, stash
- Update sidebar navigation to include both glossary and logging documentation
- Improve documentation discoverability by organizing reference materials under Reference section

## Test plan

- [x] Documentation builds successfully (verified by docs pre-commit hook)
- [x] All glossary terms have accurate definitions based on current implementation
- [x] Sidebar navigation properly displays new documentation sections
- [x] Cross-references to existing documentation are valid

🤖 Generated with [Claude Code](https://claude.ai/code)