### PR TITLE
feat: centralized skip configuration for steps and hooks

### DIFF
--- a/pkl/UserConfig.pkl
+++ b/pkl/UserConfig.pkl
@@ -11,6 +11,8 @@ class Defaults {
     fix: Boolean?
     check: Boolean?
     exclude: (String | List<String>)?
+    skip_steps: (String | List<String>)?
+    skip_hooks: (String | List<String>)?
 }
 
 class HookConfig {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -93,6 +93,8 @@ impl ConfigGet {
             "display_skip_reasons" => json!(settings.display_skip_reasons),
             "warnings" => json!(settings.warnings),
             "exclude" => json!(settings.exclude),
+            "skip_steps" => json!(settings.skip_steps),
+            "skip_hooks" => json!(settings.skip_hooks),
             _ => return Err(eyre::eyre!("Unknown configuration key: {}", self.key)),
         };
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -65,6 +65,8 @@ impl ConfigDump {
             "display_skip_reasons": settings.display_skip_reasons,
             "warnings": settings.warnings,
             "exclude": settings.exclude,
+            "skip_steps": settings.skip_steps,
+            "skip_hooks": settings.skip_hooks,
         });
 
         match self.format.as_str() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,6 +183,22 @@ impl Config {
                 crate::settings::Settings::add_exclude(patterns);
             }
 
+            if let Some(skip_steps) = &user_config.defaults.skip_steps {
+                let steps: Vec<String> = match skip_steps {
+                    StringOrList::String(s) => vec![s.clone()],
+                    StringOrList::List(list) => list.clone(),
+                };
+                crate::settings::Settings::add_skip_steps(steps);
+            }
+
+            if let Some(skip_hooks) = &user_config.defaults.skip_hooks {
+                let hooks: Vec<String> = match skip_hooks {
+                    StringOrList::String(s) => vec![s.clone()],
+                    StringOrList::List(list) => list.clone(),
+                };
+                crate::settings::Settings::add_skip_hooks(hooks);
+            }
+
             for (hook_name, user_hook_config) in &user_config.hooks {
                 if let Some(hook) = self.hooks.get_mut(hook_name) {
                     for (step_or_group_name, step_or_group) in hook.steps.iter_mut() {
@@ -333,6 +349,8 @@ pub struct UserDefaults {
     pub fix: Option<bool>,
     pub check: Option<bool>,
     pub exclude: Option<StringOrList>,
+    pub skip_steps: Option<StringOrList>,
+    pub skip_hooks: Option<StringOrList>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/src/git_cfg.rs
+++ b/src/git_cfg.rs
@@ -90,6 +90,25 @@ pub fn read_git_config() -> Result<(), git2::Error> {
         Settings::add_exclude(exclude_globs.into_iter().collect::<Vec<_>>());
     }
 
+    // Read skip configuration
+    if let Ok(skip_steps) = read_string_list(&config, "hk.skipSteps") {
+        Settings::add_skip_steps(skip_steps.into_iter().collect::<Vec<_>>());
+    }
+
+    // Also check singular form for backward compatibility
+    if let Ok(skip_step) = read_string_list(&config, "hk.skipStep") {
+        Settings::add_skip_steps(skip_step.into_iter().collect::<Vec<_>>());
+    }
+
+    if let Ok(skip_hooks) = read_string_list(&config, "hk.skipHooks") {
+        Settings::add_skip_hooks(skip_hooks.into_iter().collect::<Vec<_>>());
+    }
+
+    // Also check singular form for backward compatibility
+    if let Ok(skip_hook) = read_string_list(&config, "hk.skipHook") {
+        Settings::add_skip_hooks(skip_hook.into_iter().collect::<Vec<_>>());
+    }
+
     Ok(())
 }
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -342,8 +342,8 @@ impl Hook {
         }
 
         let settings = Settings::get();
-        if env::HK_SKIP_HOOK.contains(&self.name) {
-            warn!("{}: skipping hook due to HK_SKIP_HOOK", &self.name);
+        if settings.skip_hooks.contains(&self.name) {
+            warn!("{}: skipping hook due to skip configuration", &self.name);
             return Ok(());
         }
         let run_type = self.run_type(&opts);
@@ -378,10 +378,11 @@ impl Hook {
 
         let skip_steps = {
             let mut m: IndexMap<String, SkipReason> = IndexMap::new();
-            for s in env::HK_SKIP_STEPS.iter() {
+            // Use settings for skip_steps which includes env vars, git config, etc.
+            for s in settings.skip_steps.iter() {
                 m.insert(
                     s.clone(),
-                    SkipReason::DisabledByEnv("HK_SKIP_STEPS".to_string()),
+                    SkipReason::DisabledByEnv("skip configuration".to_string()),
                 );
             }
             for s in opts.skip_step.iter() {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -343,7 +343,7 @@ impl Hook {
 
         let settings = Settings::get();
         if settings.skip_hooks.contains(&self.name) {
-            warn!("{}: skipping hook due to skip configuration", &self.name);
+            warn!("{}: skipping hook due to HK_SKIP_HOOK", &self.name);
             return Ok(());
         }
         let run_type = self.run_type(&opts);
@@ -382,7 +382,7 @@ impl Hook {
             for s in settings.skip_steps.iter() {
                 m.insert(
                     s.clone(),
-                    SkipReason::DisabledByEnv("skip configuration".to_string()),
+                    SkipReason::DisabledByEnv("HK_SKIP_STEPS".to_string()),
                 );
             }
             for s in opts.skip_step.iter() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -18,6 +18,8 @@ pub struct Settings {
     pub display_skip_reasons: HashSet<String>,
     pub warnings: IndexSet<String>,
     pub exclude: IndexSet<String>,
+    pub skip_steps: IndexSet<String>,
+    pub skip_hooks: IndexSet<String>,
 }
 
 static JOBS: LazyLock<Mutex<Option<NonZero<usize>>>> = LazyLock::new(Default::default);
@@ -35,6 +37,8 @@ static DISPLAY_SKIP_REASONS: LazyLock<Mutex<Option<HashSet<String>>>> =
 static WARNINGS: LazyLock<Mutex<Option<IndexSet<String>>>> = LazyLock::new(Default::default);
 static HIDE_WARNINGS: LazyLock<Mutex<Option<IndexSet<String>>>> = LazyLock::new(Default::default);
 static EXCLUDE: LazyLock<Mutex<Option<IndexSet<String>>>> = LazyLock::new(Default::default);
+static SKIP_STEPS: LazyLock<Mutex<Option<IndexSet<String>>>> = LazyLock::new(Default::default);
+static SKIP_HOOKS: LazyLock<Mutex<Option<IndexSet<String>>>> = LazyLock::new(Default::default);
 
 impl Settings {
     pub fn get() -> Settings {
@@ -113,6 +117,30 @@ impl Settings {
             set.insert(pattern.as_ref().to_string());
         }
     }
+
+    pub fn add_skip_steps<I, S>(steps: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut skip_steps = SKIP_STEPS.lock().unwrap();
+        let set = skip_steps.get_or_insert_with(IndexSet::new);
+        for step in steps {
+            set.insert(step.as_ref().to_string());
+        }
+    }
+
+    pub fn add_skip_hooks<I, S>(hooks: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut skip_hooks = SKIP_HOOKS.lock().unwrap();
+        let set = skip_hooks.get_or_insert_with(IndexSet::new);
+        for hook in hooks {
+            set.insert(hook.as_ref().to_string());
+        }
+    }
 }
 
 impl Default for Settings {
@@ -164,6 +192,17 @@ impl Default for Settings {
         let mut exclude = EXCLUDE.lock().unwrap().clone().unwrap_or_default();
         // Always add environment excludes (union semantics)
         exclude.extend(env::HK_EXCLUDE.iter().cloned());
+
+        // Always union skip_steps from all sources
+        let mut skip_steps = SKIP_STEPS.lock().unwrap().clone().unwrap_or_default();
+        // Always add environment skip_steps (union semantics)
+        skip_steps.extend(env::HK_SKIP_STEPS.iter().cloned());
+
+        // Always union skip_hooks from all sources
+        let mut skip_hooks = SKIP_HOOKS.lock().unwrap().clone().unwrap_or_default();
+        // Always add environment skip_hooks (union semantics)
+        skip_hooks.extend(env::HK_SKIP_HOOK.iter().cloned());
+
         Self {
             jobs: JOBS.lock().unwrap().unwrap_or(*env::HK_JOBS),
             enabled_profiles,
@@ -173,6 +212,8 @@ impl Default for Settings {
             display_skip_reasons,
             warnings,
             exclude,
+            skip_steps,
+            skip_hooks,
         }
     }
 }

--- a/test/skip_configuration.bats
+++ b/test/skip_configuration.bats
@@ -1,0 +1,286 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "git config: hk.skipSteps configuration" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["step1"] {
+                check = "echo 'STEP1 RAN'"
+            }
+            ["step2"] {
+                check = "echo 'STEP2 RAN'"
+            }
+            ["step3"] {
+                check = "echo 'STEP3 RAN'"
+            }
+        }
+    }
+}
+EOF
+
+    # Configure git to skip step2
+    git config --local hk.skipSteps "step2"
+
+    run hk check --all
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "STEP1 RAN"
+    ! echo "$output" | grep -q "STEP2 RAN"
+    echo "$output" | grep -q "STEP3 RAN"
+}
+
+@test "git config: multiple hk.skipSteps entries" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["step1"] {
+                check = "echo 'STEP1 RAN'"
+            }
+            ["step2"] {
+                check = "echo 'STEP2 RAN'"
+            }
+            ["step3"] {
+                check = "echo 'STEP3 RAN'"
+            }
+        }
+    }
+}
+EOF
+
+    # Skip multiple steps
+    git config --local hk.skipSteps "step1"
+    git config --local --add hk.skipSteps "step3"
+
+    run hk check --all
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -q "STEP1 RAN"
+    echo "$output" | grep -q "STEP2 RAN"
+    ! echo "$output" | grep -q "STEP3 RAN"
+}
+
+@test "git config: hk.skipHook configuration" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["test"] {
+                check = "echo 'CHECK HOOK RAN'"
+            }
+        }
+    }
+    ["pre-commit"] {
+        steps {
+            ["test"] {
+                check = "echo 'PRE-COMMIT HOOK RAN'"
+            }
+        }
+    }
+}
+EOF
+
+    # Skip the check hook
+    git config --local hk.skipHook "check"
+
+    run hk check --all
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -q "CHECK HOOK RAN"
+}
+
+@test "environment variable HK_SKIP_STEPS still works" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["step1"] {
+                check = "echo 'STEP1 RAN'"
+            }
+            ["step2"] {
+                check = "echo 'STEP2 RAN'"
+            }
+        }
+    }
+}
+EOF
+
+    export HK_SKIP_STEPS="step1"
+
+    run hk check --all
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -q "STEP1 RAN"
+    echo "$output" | grep -q "STEP2 RAN"
+}
+
+@test "union semantics: git config and env vars combine" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["step1"] {
+                check = "echo 'STEP1 RAN'"
+            }
+            ["step2"] {
+                check = "echo 'STEP2 RAN'"
+            }
+            ["step3"] {
+                check = "echo 'STEP3 RAN'"
+            }
+        }
+    }
+}
+EOF
+
+    # Skip step1 via git config
+    git config --local hk.skipSteps "step1"
+
+    # Skip step2 via environment variable
+    export HK_SKIP_STEPS="step2"
+
+    run hk check --all
+    [ "$status" -eq 0 ]
+    # Both step1 and step2 should be skipped (union semantics)
+    ! echo "$output" | grep -q "STEP1 RAN"
+    ! echo "$output" | grep -q "STEP2 RAN"
+    echo "$output" | grep -q "STEP3 RAN"
+}
+
+@test "CLI flag --skip-step overrides configuration" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["step1"] {
+                check = "echo 'STEP1 RAN'"
+            }
+            ["step2"] {
+                check = "echo 'STEP2 RAN'"
+            }
+            ["step3"] {
+                check = "echo 'STEP3 RAN'"
+            }
+        }
+    }
+}
+EOF
+
+    # Skip step1 via git config
+    git config --local hk.skipSteps "step1"
+
+    # Additionally skip step3 via CLI
+    run hk check --all --skip-step step3
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -q "STEP1 RAN"
+    echo "$output" | grep -q "STEP2 RAN"
+    ! echo "$output" | grep -q "STEP3 RAN"
+}
+
+@test "user config (.hkrc.pkl) skip configuration" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["step1"] {
+                check = "echo 'STEP1 RAN'"
+            }
+            ["step2"] {
+                check = "echo 'STEP2 RAN'"
+            }
+        }
+    }
+}
+EOF
+
+    cat > ~/.hkrc.pkl << EOF
+amends "$PKL_PATH/UserConfig.pkl"
+defaults {
+    skip_steps = List("step1")
+}
+EOF
+
+    run hk check --all
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -q "STEP1 RAN"
+    echo "$output" | grep -q "STEP2 RAN"
+}
+
+@test "config dump includes skip configuration" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+EOF
+
+    git config --local hk.skipSteps "test-step"
+    git config --local hk.skipHook "test-hook"
+
+    run hk config dump
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -r '.skip_steps[]' | grep -q "test-step"
+    echo "$output" | jq -r '.skip_hooks[]' | grep -q "test-hook"
+}
+
+@test "backward compatibility: hk.skipStep singular form" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["test"] {
+                check = "echo 'TEST RAN'"
+            }
+        }
+    }
+}
+EOF
+
+    # Use singular form
+    git config --local hk.skipStep "test"
+
+    run hk check --all
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -q "TEST RAN"
+}
+
+@test "comma-separated skip values in git config" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["step1"] {
+                check = "echo 'STEP1 RAN'"
+            }
+            ["step2"] {
+                check = "echo 'STEP2 RAN'"
+            }
+            ["step3"] {
+                check = "echo 'STEP3 RAN'"
+            }
+        }
+    }
+}
+EOF
+
+    # Use comma-separated values
+    git config --local hk.skipSteps "step1,step3"
+
+    run hk check --all
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -q "STEP1 RAN"
+    echo "$output" | grep -q "STEP2 RAN"
+    ! echo "$output" | grep -q "STEP3 RAN"
+}

--- a/test/skip_configuration.bats
+++ b/test/skip_configuration.bats
@@ -233,6 +233,34 @@ EOF
     echo "$output" | jq -r '.skip_hooks[]' | grep -q "test-hook"
 }
 
+@test "config get skip_steps works" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+EOF
+
+    git config --local hk.skipSteps "step1"
+    git config --local --add hk.skipSteps "step2"
+
+    run hk config get skip_steps
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -r '.[]' | grep -q "step1"
+    echo "$output" | jq -r '.[]' | grep -q "step2"
+}
+
+@test "config get skip_hooks works" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+EOF
+
+    git config --local hk.skipHook "pre-commit"
+    git config --local --add hk.skipHook "pre-push"
+
+    run hk config get skip_hooks
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -r '.[]' | grep -q "pre-commit"
+    echo "$output" | jq -r '.[]' | grep -q "pre-push"
+}
+
 @test "backward compatibility: hk.skipStep singular form" {
     cat > hk.pkl << EOF
 amends "$PKL_PATH/Config.pkl"


### PR DESCRIPTION
## Summary
Adds the ability to configure skip_steps and skip_hooks through the centralized configuration system, extending the configuration unification to include skip settings.

## Changes

### Skip Configuration Support
- **Settings Integration**: Added `skip_steps` and `skip_hooks` fields to the Settings struct
- **Union Semantics**: All skip configurations from different sources are merged rather than overridden
- **Multiple Sources**: Skip configuration can come from:
  - Environment variables (`HK_SKIP_STEPS`, `HK_SKIP_HOOK`)
  - Git config (`hk.skipSteps`, `hk.skipHooks`)
  - User config (`.hkrc.pkl`)
  - CLI flags (`--skip-step`)

### Git Config Support
- `hk.skipSteps` / `hk.skipStep` - Skip specific steps
- `hk.skipHooks` / `hk.skipHook` - Skip entire hooks
- Supports both singular and plural forms for backward compatibility
- Supports comma-separated values and multivar entries

### User Config Support
- Added `skip_steps` and `skip_hooks` to UserConfig defaults
- Can be configured in `.hkrc.pkl`:
  ```pkl
  defaults {
      skip_steps = List("step1", "step2")
      skip_hooks = List("pre-push")
  }
  ```

### Backward Compatibility
- Environment variables `HK_SKIP_STEPS` and `HK_SKIP_HOOK` continue to work
- CLI flags `--skip-step` continue to work
- All sources union together - nothing is overridden

## Testing
- Added comprehensive test suite (`test/skip_configuration.bats`)
- Tests cover all configuration sources and union semantics
- Tests verify backward compatibility
- All existing tests continue to pass

## Example Usage

```bash
# Skip steps via git config
git config --local hk.skipSteps "slow-test,flaky-test"

# Skip hooks via git config  
git config --local hk.skipHook "pre-push"

# Environment variables still work and combine
export HK_SKIP_STEPS="another-step"

# CLI flags add to the union
hk check --skip-step yet-another-step

# View effective configuration
hk config dump
```

🤖 Generated with [Claude Code](https://claude.ai/code)