### PR TITLE
fix: correct pkl package artifact path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: pkl-packages
-          path: .out/**
+          path: .out/**/*
           retention-days: 1
 
   create-release:


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions release workflow error: "No files were found with the provided path: .out/**"

## Problem
The pkl project package command outputs files to a versioned subdirectory `.out/hk@<version>/`, not directly in `.out/`. The artifact upload action was looking for `.out/**` which didn't match the nested files.

## Solution
Updated the artifact upload path from `.out/**` to `.out/**/*` to properly capture files in the nested directory structure.

## Testing
Verified locally that:
1. `pkl project package pkl` outputs to `.out/hk@<version>/`
2. The glob pattern `.out/**/*` correctly matches all generated files

This should resolve the artifact upload failures in the release workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)