### PR TITLE
fix: use simple directory path for pkl artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: pkl-packages
-          path: .out/**/*
+          path: .out/
           retention-days: 1
 
   create-release:


### PR DESCRIPTION
## Summary
Fixes the persistent pkl artifact upload issue in the release workflow.

## Problem
Even after PR #271, the release workflow still shows:
```
No files were found with the provided path: .out/**/*. No artifacts will be uploaded.
```

The pkl package command successfully creates files in `.out/hk@<version>/` (we can see them in the logs), but the glob pattern `.out/**/*` doesn't properly match them in GitHub Actions upload-artifact.

## Solution
Changed from `.out/**/*` to `.out/` which simply uploads the entire directory and its contents. This is the most reliable way to capture all files regardless of nesting depth.

## Evidence
From the v1.13.0 release logs, we can see pkl creates the files:
```
.out/hk@1.13.0/hk@1.13.0.zip
.out/hk@1.13.0/hk@1.13.0.zip.sha256
.out/hk@1.13.0/hk@1.13.0
.out/hk@1.13.0/hk@1.13.0.sha256
```

But the upload-artifact action with `.out/**` or `.out/**/*` fails to find them.

🤖 Generated with [Claude Code](https://claude.ai/code)