### PR TITLE
chore: release v1.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.13.3](https://github.com/jdx/hk/compare/v1.13.2..v1.13.3) - 2025-09-17
+
+### 🔍 Other Changes
+
+- diagnose pkl package failure in release workflow by [@jdx](https://github.com/jdx) in [#274](https://github.com/jdx/hk/pull/274)
+
 ## [1.13.2](https://github.com/jdx/hk/compare/v1.13.1..v1.13.2) - 2025-09-17
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.13.2"
+version = "1.13.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.13.2"
+version = "1.13.3"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2167,7 +2167,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.13.2",
+  "version": "1.13.3",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.13.2
+**Version**: 1.13.3
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.13.2"
+version "1.13.3"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.13.3](https://github.com/jdx/hk/compare/v1.13.2..v1.13.3) - 2025-09-17

### 🔍 Other Changes

- diagnose pkl package failure in release workflow by [@jdx](https://github.com/jdx) in [#274](https://github.com/jdx/hk/pull/274)