### PR TITLE
fix: explicitly install pkl and run package command directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,54 +78,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jdx/mise-action@v2
+      - name: Install Pkl
+        run: |
+          # Install pkl CLI
+          curl -L -o /tmp/pkl https://github.com/apple/pkl/releases/download/0.29.0/pkl-linux-amd64
+          chmod +x /tmp/pkl
+          sudo mv /tmp/pkl /usr/local/bin/pkl
+          pkl --version
       - name: Package Pkl
         run: |
-          set -x  # Enable command tracing
           TAG_NAME="${{ github.ref_name }}"
           if [ -z "$TAG_NAME" ]; then
             TAG_NAME="v${{ inputs.version }}"
           fi
-          echo "::notice::Tag name is: $TAG_NAME"
           VERSION="${TAG_NAME#v}"
-          echo "::notice::Version is: $VERSION"
+          echo "Building pkl package for version: $VERSION"
 
-          # Check environment
-          echo "::group::Environment check"
-          echo "Current directory: $(pwd)"
-          echo "Directory listing:"
-          ls -la
-          echo "Pkl directory:"
-          ls -la pkl/ || echo "ERROR: No pkl directory found!"
-          echo "Mise tasks directory:"
-          ls -la mise-tasks/ || echo "ERROR: No mise-tasks directory!"
-          echo "Package pkl script:"
-          cat mise-tasks/package-pkl.sh || echo "ERROR: No package-pkl.sh script!"
-          echo "::endgroup::"
+          # Run pkl package directly
+          cd pkl && VERSION="${VERSION}" pkl project package
+          cd ..
 
-          # Run the package command with explicit error handling
-          echo "::group::Running pkl package"
-          if VERSION="${VERSION}" mise run package-pkl; then
-            echo "::notice::Package command succeeded"
-          else
-            EXIT_CODE=$?
-            echo "::error::Package command failed with exit code $EXIT_CODE"
-            # Try running the command directly to see more output
-            echo "Trying direct command: pkl project package pkl"
-            VERSION="${VERSION}" pkl project package pkl || true
+          # Check if files were created
+          if [ -d "pkl/.out" ]; then
+            echo "Found pkl/.out directory, moving to root"
+            mv pkl/.out .
           fi
-          echo "::endgroup::"
 
-          # Check results
-          echo "::group::Checking output"
-          if [ -d ".out" ]; then
-            echo "Found .out directory:"
-            ls -laR .out/
-          else
-            echo "::warning::No .out directory created"
-          fi
-          echo "Looking for any zip or sha256 files:"
-          find . -type f \( -name "*.zip" -o -name "*.sha256" \) 2>/dev/null | head -20 || echo "No files found"
-          echo "::endgroup::"
+          # List the output
+          echo "Contents of .out:"
+          ls -laR .out/ || echo "No .out directory found"
       - uses: actions/upload-artifact@v4
         with:
           name: pkl-packages


### PR DESCRIPTION
## Summary
Fixes the pkl package artifact upload failure in the release workflow.

## Root Cause
The pkl package command was silently failing because:
1. The `pkl` CLI tool wasn't installed in the GitHub Actions environment
2. The `mise run package-pkl` command was completing successfully but not actually running pkl
3. No error was reported, making it difficult to diagnose

## Solution
This PR:
1. **Explicitly installs pkl CLI** from GitHub releases before running the package command
2. **Runs the package command directly** in the pkl directory instead of through mise
3. **Handles the output directory properly** - pkl creates `.out` in its own directory, so we move it to the root
4. **Provides clear feedback** about what's happening at each step

## Testing
- The pkl installation uses the official release binary from apple/pkl
- The command now runs with proper directory context
- Output is properly moved to where the artifact upload expects it

This should resolve the persistent "No files were found" errors in releases.

Related issues:
- v1.13.3: https://github.com/jdx/hk/actions/runs/17786387224
- v1.13.2: https://github.com/jdx/hk/actions/runs/17786234063
- v1.13.1: https://github.com/jdx/hk/actions/runs/17786128005

🤖 Generated with [Claude Code](https://claude.ai/code)