### PR TITLE
chore: release v1.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+## [1.13.6](https://github.com/jdx/hk/compare/v1.13.5..v1.13.6) - 2025-09-17
+
+### 🔍 Other Changes
+
+- fix build-pkl upload path to use mise dist (docs/public/pkl) by [@jdx](https://github.com/jdx) in [6745830](https://github.com/jdx/hk/commit/6745830a9f5f4bb949216b682ba501119aa4262f)
+
 ## [1.13.5](https://github.com/jdx/hk/compare/v1.13.4..v1.13.5) - 2025-09-17
 
 ### 🔍 Other Changes
 
 - fix pkl release building by [@jdx](https://github.com/jdx) in [#278](https://github.com/jdx/hk/pull/278)
+- enable cache for release-plz by [@jdx](https://github.com/jdx) in [85195fa](https://github.com/jdx/hk/commit/85195fadfcaa50137d3807b165d924bcabbc6d0a)
 
 ## [1.13.4](https://github.com/jdx/hk/compare/v1.13.3..v1.13.4) - 2025-09-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.13.5"
+version = "1.13.6"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.13.5"
+version = "1.13.6"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2167,7 +2167,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.13.5",
+  "version": "1.13.6",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.13.5
+**Version**: 1.13.6
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.13.5"
+version "1.13.6"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.13.6](https://github.com/jdx/hk/compare/v1.13.5..v1.13.6) - 2025-09-17

### 🔍 Other Changes

- fix build-pkl upload path to use mise dist (docs/public/pkl) by [@jdx](https://github.com/jdx) in [6745830](https://github.com/jdx/hk/commit/6745830a9f5f4bb949216b682ba501119aa4262f)