### PR TITLE
feat: improve Pkl config error messages

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -285,7 +285,57 @@ impl UserConfig {
 }
 
 fn parse_pkl<T: DeserializeOwned>(bin: &str, path: &Path) -> Result<T> {
-    let json = xx::process::sh(&format!("{bin} eval -f json {}", path.display()))?;
+    use std::process::{Command, Stdio};
+
+    // Run pkl with captured stderr to check for specific error patterns
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(&format!("{bin} eval -f json {}", path.display()))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .wrap_err("failed to execute pkl command")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // Check for common Pkl errors and provide helpful messages
+        if stderr.contains("Cannot find type `Hook`") || stderr.contains("Cannot find type `Step`")
+        {
+            bail!(
+                "Missing 'amends' declaration in {}. \n\n\
+                Your hk.pkl file should start with one of:\n\
+                • amends \"pkl/Config.pkl\" (for local development)\n\
+                • amends \"package://github.com/jdx/hk/releases/download/vX.Y.Z/hk@X.Y.Z#/Config.pkl\" (for released versions)\n\n\
+                See https://github.com/jdx/hk for more information.",
+                path.display()
+            );
+        } else if stderr.contains("Module URI") && stderr.contains("has invalid syntax") {
+            bail!(
+                "Invalid module URI in {}. \n\n\
+                Make sure your 'amends' declaration uses a valid path or package URL.\n\
+                Examples:\n\
+                • amends \"pkl/Config.pkl\" (for local development)\n\
+                • amends \"package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl\"",
+                path.display()
+            );
+        }
+
+        // Return the full error if it's not a known pattern
+        let code = output
+            .status
+            .code()
+            .map_or("unknown".to_string(), |c| c.to_string());
+        bail!(
+            "Failed to evaluate Pkl config at {}\n\nExit code: {}\n\nError output:\n{}",
+            path.display(),
+            code,
+            stderr
+        );
+    }
+
+    let json = String::from_utf8_lossy(&output.stdout);
     serde_json::from_str(&json).wrap_err("failed to parse pkl config file")
 }
 

--- a/test/pkl_config_errors.bats
+++ b/test/pkl_config_errors.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+# Test Pkl configuration error messages
+
+setup() {
+    export HK="${HK:-$BATS_TEST_DIRNAME/../target/debug/hk}"
+    export TEST_DIR="$(mktemp -d)"
+    cd "$TEST_DIR"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "missing amends declaration shows helpful error" {
+    # Create a Pkl config without amends declaration
+    cat > hk.pkl << 'EOF'
+hooks {
+  ["check"] = new Hook {
+    steps {
+      ["test"] = new Step {
+        run = "echo test"
+      }
+    }
+  }
+}
+EOF
+
+    # Run hk and expect it to fail with helpful error message
+    run $HK check
+    [ "$status" -ne 0 ]
+
+    # Check that the error message contains helpful information
+    [[ "$output" =~ "Missing 'amends' declaration" ]] || fail "Should mention missing amends"
+    [[ "$output" =~ "Your hk.pkl file should start with one of:" ]] || fail "Should provide examples"
+    [[ "$output" =~ "amends \"pkl/Config.pkl\"" ]] || fail "Should show local development example"
+    [[ "$output" =~ "amends \"package://github.com/jdx/hk" ]] || fail "Should show package URL example"
+}
+
+@test "invalid module URI shows helpful error" {
+    # Create a Pkl config with invalid module URI
+    cat > hk.pkl << 'EOF'
+amends "package://hk.sh/Config.pkl"
+
+hooks {
+  ["check"] = new Hook {
+    steps {
+      ["test"] = new Step {
+        run = "echo test"
+      }
+    }
+  }
+}
+EOF
+
+    # Run hk and expect it to fail with helpful error message
+    run $HK check
+    [ "$status" -ne 0 ]
+
+    # Check that the error message contains helpful information
+    [[ "$output" =~ "Invalid module URI" ]] || fail "Should mention invalid module URI"
+    [[ "$output" =~ "Make sure your 'amends' declaration uses a valid path or package URL" ]] || fail "Should provide guidance"
+}
+
+@test "pkl file with syntax errors shows original error" {
+    # Create a Pkl config with syntax errors
+    cat > hk.pkl << 'EOF'
+amends "../pkl/Config.pkl"
+
+hooks = { this is invalid syntax
+EOF
+
+    # Run hk and expect it to fail
+    run $HK check
+    [ "$status" -ne 0 ]
+
+    # Should show the Pkl error (not our custom messages)
+    [[ "$output" =~ "Failed to evaluate Pkl config" ]] || [[ "$output" =~ "Unexpected token" ]] || fail "Should show Pkl evaluation error"
+}


### PR DESCRIPTION
## Summary
- Adds helpful error messages when hk.pkl is missing the 'amends' declaration
- Provides clear examples of correct syntax for amending Config.pkl  
- Detects invalid module URIs and provides guidance

## Details
When users forget to add the 'amends' declaration to their hk.pkl file, they previously got a cryptic "Cannot find type `Hook`" error. This PR improves the error handling to detect this common mistake and provide helpful guidance.

The improved error message now shows:
- Clear indication that the 'amends' declaration is missing
- Examples of correct syntax for both local development and package URLs
- Link to documentation for more information

## Test plan
- Added comprehensive bats tests in `test/pkl_config_errors.bats`
- Tests cover missing amends declaration, invalid module URIs, and regular syntax errors
- All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)