### PR TITLE
chore: release v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 # Changelog
 
+## [1.15.1](https://github.com/jdx/hk/compare/v1.15.0..v1.15.1) - 2025-09-19
+
+### 🐛 Bug Fixes
+
+- Skip any hunks that begin before the current position to avoid partial re-application by [@jdx](https://github.com/jdx) in [8325a66](https://github.com/jdx/hk/commit/8325a66d7b6b85b672c8780b6f5a0e10af5dc0ce)
+
 ## [1.15.0](https://github.com/jdx/hk/compare/v1.14.0..v1.15.0) - 2025-09-19
 
 ### 🚀 Features
 
 - **(docs)** add custom VitePress theme with unique branding by [@jdx](https://github.com/jdx) in [#287](https://github.com/jdx/hk/pull/287)
+
+### 🐛 Bug Fixes
+
+- handle fixes and unstaged hunks in the same file by [@jdx](https://github.com/jdx) in [#283](https://github.com/jdx/hk/pull/283)
 
 ### 📦️ Dependency Updates
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -2547,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "once_cell",
  "ring",
@@ -3173,11 +3173,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.15.0"
+version = "1.15.1"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2178,7 +2178,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.15.0",
+  "version": "1.15.1",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.15.0
+**Version**: 1.15.1
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.15.0"
+version "1.15.1"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.15.1](https://github.com/jdx/hk/compare/v1.15.0..v1.15.1) - 2025-09-19

### 🐛 Bug Fixes

- Skip any hunks that begin before the current position to avoid partial re-application by [@jdx](https://github.com/jdx) in [8325a66](https://github.com/jdx/hk/commit/8325a66d7b6b85b672c8780b6f5a0e10af5dc0ce)