### PR TITLE
fix: prevent duplicate _type fields in JSON cache for groups (#296)

### DIFF
--- a/src/step.rs
+++ b/src/step.rs
@@ -28,6 +28,8 @@ use crate::step_test::StepTest;
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(debug_assertions, serde(deny_unknown_fields))]
 pub struct Step {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub _type: Option<String>,
     #[serde(default)]
     pub name: String,
     pub profiles: Option<Vec<String>>,

--- a/src/step_group.rs
+++ b/src/step_group.rs
@@ -17,8 +17,8 @@ use std::{
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, Eq, PartialEq)]
 pub struct StepGroup {
-    #[serde(default = "default_step_group_type")]
-    pub _type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub _type: Option<String>,
     pub name: Option<String>,
     pub steps: IndexMap<String, Step>,
 }
@@ -57,7 +57,7 @@ impl StepGroup {
             .fold(vec![], |mut groups, step| {
                 match step {
                     StepOrGroup::Group(group) => {
-                        groups.push(group.steps);
+                        groups.push((*group).steps);
                     }
                     StepOrGroup::Step(step) => {
                         if step.exclusive || groups.is_empty() {
@@ -75,7 +75,7 @@ impl StepGroup {
             .into_iter()
             .filter(|steps| !steps.is_empty())
             .map(|steps| Self {
-                _type: "group".to_string(),
+                _type: None,
                 name: None,
                 steps,
             })
@@ -226,8 +226,4 @@ impl StepGroup {
 
         Ok(files_in_contention)
     }
-}
-
-fn default_step_group_type() -> String {
-    "group".to_string()
 }

--- a/test/fix_duplicate_type_field.bats
+++ b/test/fix_duplicate_type_field.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+
+# Test for https://github.com/jdx/hk/discussions/296
+# Verifies that duplicate _type fields are not generated in JSON when using groups
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "basic group configuration works" {
+    # First, test that a basic config without groups works
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["step1"] {
+        shell = "echo step1"
+      }
+    }
+  }
+}
+EOF
+
+    run hk validate
+    assert_success
+}
+
+@test "group configuration validates without duplicate _type error" {
+    # Create a config file with groups like in the discussion
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    steps {
+      ["frontend"] = new Group {
+        steps {
+          ["prettier"] {
+            shell = "prettier --check"
+            glob = List("*.js", "*.jsx", "*.ts", "*.tsx")
+          }
+          ["eslint"] {
+            shell = "eslint"
+            glob = List("*.js", "*.jsx", "*.ts", "*.tsx")
+          }
+        }
+      }
+      ["backend"] = new Group {
+        steps {
+          ["black"] {
+            shell = "black --check"
+            glob = List("*.py")
+          }
+        }
+      }
+    }
+  }
+}
+EOF
+
+    # Validate should succeed without duplicate _type field errors
+    run hk validate
+    assert_success
+
+    # Check the output doesn't contain the duplicate field error
+    refute_output --partial "duplicate field \`_type\`"
+    refute_output --partial "failed to parse cache file"
+}
+
+@test "loading cached config with groups doesn't cause duplicate _type" {
+    # Create the same config
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["my_group"] = new Group {
+        steps {
+          ["step1"] {
+            shell = "echo hello"
+          }
+        }
+      }
+    }
+  }
+}
+EOF
+
+    # Run validate first time to generate cache
+    run hk validate
+    assert_success
+    refute_output --partial "duplicate field \`_type\`"
+
+    # Run validate second time to load from cache
+    run hk validate
+    assert_success
+    refute_output --partial "duplicate field \`_type\`"
+    refute_output --partial "failed to parse cache file"
+
+    # Run check to trigger loading and using the config
+    echo "test" > test.txt
+    run hk check --all
+    refute_output --partial "duplicate field \`_type\`"
+    refute_output --partial "failed to parse cache file"
+}


### PR DESCRIPTION
## Summary
- Fixes the duplicate `_type` field issue reported in https://github.com/jdx/hk/discussions/296
- Prevents JSON cache parsing errors when using groups in pkl configuration
- Adds comprehensive test coverage for group configurations

## Problem
When using groups in pkl configuration files, the JSON cache was generating duplicate `_type` fields. This happened because:
1. PKL generates `_type` fields for both groups and steps for type discrimination
2. The serde enum tag attribute (`#[serde(tag = "_type")]`) expects this field for discrimination
3. But the StepGroup struct also had its own `_type` field, causing duplication when serializing

## Solution
- Made the `_type` field optional (`Option<String>`) in both Step and StepGroup structs
- Added `#[serde(skip_serializing_if = "Option::is_none")]` to prevent writing the field when serializing
- This allows proper deserialization of pkl-generated JSON while avoiding duplication in serialized output

## Test plan
- [x] Added comprehensive bats test `test/fix_duplicate_type_field.bats` that verifies:
  - Basic group configurations work
  - No duplicate `_type` field errors occur
  - Cached configs with groups load correctly
- [x] All existing tests pass
- [x] `hk check --all` runs successfully on the hk codebase itself

🤖 Generated with [Claude Code](https://claude.ai/code)