### PR TITLE
chore: release v1.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.15.4](https://github.com/jdx/hk/compare/v1.15.3..v1.15.4) - 2025-09-22
+
+### 🐛 Bug Fixes
+
+- scope staging to step job files to avoid unrelated file commits; add lockfile regression test by [@jdx](https://github.com/jdx) in [#300](https://github.com/jdx/hk/pull/300)
+
 ## [1.15.3](https://github.com/jdx/hk/compare/v1.15.2..v1.15.3) - 2025-09-21
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -2568,7 +2568,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.4.0",
+ "security-framework 3.5.0",
 ]
 
 [[package]]
@@ -2667,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
+checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.15.3"
+version = "1.15.4"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2052,7 +2052,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.15.3",
+  "version": "1.15.4",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.15.3
+**Version**: 1.15.4
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.15.3"
+version "1.15.4"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.15.4](https://github.com/jdx/hk/compare/v1.15.3..v1.15.4) - 2025-09-22

### 🐛 Bug Fixes

- scope staging to step job files to avoid unrelated file commits; add lockfile regression test by [@jdx](https://github.com/jdx) in [#300](https://github.com/jdx/hk/pull/300)