### PR TITLE
chore: release v1.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.15.5](https://github.com/jdx/hk/compare/v1.15.4..v1.15.5) - 2025-09-22
+
+### 🐛 Bug Fixes
+
+- ensure stash cleanup by [@jdx](https://github.com/jdx) in [#302](https://github.com/jdx/hk/pull/302)
+
 ## [1.15.4](https://github.com/jdx/hk/compare/v1.15.3..v1.15.4) - 2025-09-22
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,7 +1097,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.15.4"
+version = "1.15.5"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.15.4"
+version = "1.15.5"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2052,7 +2052,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.15.4",
+  "version": "1.15.5",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.15.4
+**Version**: 1.15.5
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.15.4"
+version "1.15.5"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.15.5](https://github.com/jdx/hk/compare/v1.15.4..v1.15.5) - 2025-09-22

### 🐛 Bug Fixes

- ensure stash cleanup by [@jdx](https://github.com/jdx) in [#302](https://github.com/jdx/hk/pull/302)