### PR TITLE
feat: add *_on_fail output_summary options

### DIFF
--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -71,8 +71,9 @@ class Step {
     hide = false
     
     /// Controls which stream(s) to include in the end-of-run summary for this step
-    /// One of: "stdout", "stderr", "combined", "hide"
-    output_summary: "stdout" | "stderr" | "combined" | "hide" = "stderr"
+    /// One of: "stdout", "stderr", "combined", "combined_on_fail", "stderr_on_fail", "stdout_on_fail", "hide"
+    /// *_on_fail options only show output when the command fails (default: combined_on_fail)
+    output_summary: "stdout" | "stderr" | "combined" | "combined_on_fail" | "stderr_on_fail" | "stdout_on_fail" | "hide" = "combined_on_fail"
     
     /// run the linter scripts with these environment variables
     env = new Mapping<String, String>{}

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -537,9 +537,9 @@ impl Hook {
                     continue;
                 }
                 let label = match mode {
-                    OutputSummary::Stdout => "stdout",
-                    OutputSummary::Stderr => "stderr",
-                    OutputSummary::Combined => "output",
+                    OutputSummary::Stdout | OutputSummary::StdoutOnFail => "stdout",
+                    OutputSummary::Stderr | OutputSummary::StderrOnFail => "stderr",
+                    OutputSummary::Combined | OutputSummary::CombinedOnFail => "output",
                     OutputSummary::Hide => continue,
                 };
                 eprintln!("\n{}", style::ebold(format!("{} {}:", step_name, label)));

--- a/test/output_on_fail.bats
+++ b/test/output_on_fail.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "combined_on_fail hides output for successful commands" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["test-success"] {
+        check = "echo 'This should not appear' >&2 && echo 'Neither should this' && exit 0"
+        output_summary = "combined_on_fail"
+      }
+    }
+  }
+}
+EOF
+    run hk check
+    assert_success
+    # Output should not appear during execution or in summary
+    refute_output --partial "This should not appear"
+    refute_output --partial "Neither should this"
+}
+
+@test "combined_on_fail shows output for failed commands" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["test-fail"] {
+        check = "echo 'Error output' >&2 && echo 'Standard output' && exit 1"
+        output_summary = "combined_on_fail"
+      }
+    }
+  }
+}
+EOF
+    run hk check
+    assert_failure
+    # Both stdout and stderr should appear on failure
+    assert_output --partial "Error output"
+    assert_output --partial "Standard output"
+}
+
+@test "stderr_on_fail only shows stderr on failure" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["test-fail"] {
+        check = "echo 'Error output' >&2 && echo 'Standard output' && exit 1"
+        output_summary = "stderr_on_fail"
+      }
+    }
+  }
+}
+EOF
+    run hk check
+    assert_failure
+    # Only stderr should appear on failure
+    assert_output --partial "Error output"
+    # We should still see stdout in the summary, but test that stderr is shown
+}
+
+@test "stdout_on_fail only shows stdout on failure" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["test-fail"] {
+        check = "echo 'Error output' >&2 && echo 'Standard output' && exit 1"
+        output_summary = "stdout_on_fail"
+      }
+    }
+  }
+}
+EOF
+    run hk check
+    assert_failure
+    # Should see standard output in summary on failure
+    HK_SUMMARY_TEXT=1 run hk check
+    assert_failure
+    assert_output --partial "test-fail stdout:"
+    assert_output --partial "Standard output"
+}
+
+@test "combined_on_fail is the default" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["test-default"] {
+        check = "echo 'Info message' >&2 && exit 0"
+      }
+    }
+  }
+}
+EOF
+    run hk check
+    assert_success
+    # Default should be combined_on_fail, so output should be hidden on success
+    refute_output --partial "Info message"
+}
+
+@test "multiple steps with mixed output_summary settings" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["always-show"] {
+        check = "echo 'Always visible' >&2"
+        output_summary = "stderr"
+      }
+      ["only-on-fail"] {
+        check = "echo 'Should be hidden' >&2"
+        output_summary = "stderr_on_fail"
+      }
+      ["will-fail"] {
+        check = "echo 'Failure message' >&2 && exit 1"
+        output_summary = "stderr_on_fail"
+      }
+    }
+  }
+}
+EOF
+    HK_SUMMARY_TEXT=1 run hk check
+    assert_failure
+    # always-show should appear in summary
+    assert_output --partial "always-show stderr:"
+    assert_output --partial "Always visible"
+    # only-on-fail should not appear (it succeeded)
+    refute_output --partial "only-on-fail"
+    refute_output --partial "Should be hidden"
+    # will-fail should appear both real-time and in summary
+    assert_output --partial "Failure message"
+    assert_output --partial "will-fail stderr:"
+}

--- a/test/stderr_realtime.bats
+++ b/test/stderr_realtime.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "stderr is shown in real-time even for successful commands" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["show-info"] {
+        check = "echo 'INFO: This is an info message' >&2 && echo 'Normal output' && exit 0"
+        output_summary = "hide"
+      }
+    }
+  }
+}
+EOF
+    run hk check
+    assert_success
+    # The INFO message should appear in real-time output
+    assert_output --partial "INFO: This is an info message"
+}
+
+@test "stderr is shown in real-time for failed commands too" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["show-error"] {
+        check = "echo 'ERROR: Something went wrong' >&2 && exit 1"
+        output_summary = "hide"
+      }
+    }
+  }
+}
+EOF
+    run hk check
+    assert_failure
+    # The ERROR message should appear in real-time output
+    assert_output --partial "ERROR: Something went wrong"
+}


### PR DESCRIPTION
## Summary

- Adds new `output_summary` options that only show output when commands fail
- Sets `combined_on_fail` as the new default to reduce noise during successful runs  
- Preserves diagnostic information for failures while hiding unnecessary output during success

## Motivation

Currently, hk displays stderr output in real-time even for successful commands, which creates noise in the output (e.g., info messages from tools like `taplo`). This PR adds `*_on_fail` variants that buffer output and only display it when commands fail.

Fixes #308

## Changes

- **New OutputSummary variants**: `CombinedOnFail`, `StderrOnFail`, `StdoutOnFail`
- **Default changed**: From `stderr` to `combined_on_fail` for quieter successful runs
- **Buffering logic**: Added `silent_until_error` flag to ensembler to conditionally buffer output
- **Text mode handling**: Properly handles text mode (CI environments) to avoid progress bar issues

## Test plan

- [x] Added comprehensive tests in `test/output_on_fail.bats`
- [x] Verified no duplicate output in any mode
- [x] Tested both success and failure scenarios
- [x] Tested mixed configurations with different output_summary settings

🤖 Generated with [Claude Code](https://claude.ai/code)