### PR TITLE
fix: issue with files being staged that were fixer did not modify

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -189,8 +189,9 @@ impl HookContext {
         self.file_locks.files()
     }
 
-    pub fn add_files(&self, files: &[PathBuf]) {
-        self.file_locks.add_files(files);
+    pub fn add_files(&self, added_paths: &[PathBuf], created_paths: &[PathBuf]) {
+        self.file_locks.add_files(added_paths);
+        self.file_locks.add_files(created_paths);
         // self.expr_ctx
         //     .lock()
         //     .unwrap()

--- a/src/step.rs
+++ b/src/step.rs
@@ -12,7 +12,12 @@ use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, OneOrMany, PickFirst, serde_as};
 use shell_quote::QuoteInto;
 use shell_quote::QuoteRefExt;
-use std::{collections::HashSet, fmt::Display, path::PathBuf, str::FromStr};
+use std::{
+    collections::{BTreeSet, HashSet},
+    fmt::Display,
+    path::PathBuf,
+    str::FromStr,
+};
 use std::{
     ffi::OsString,
     sync::{Arc, LazyLock},
@@ -520,15 +525,13 @@ impl Step {
                     }
                 }
 
-                // Intersect candidates with currently-unstaged files for this pathspec set
-                let unstaged_vec = status.unstaged_files.into_iter().collect_vec();
-                for path in &unstaged_vec {
-                    candidates.insert(path.clone());
-                }
+                // Build candidate list strictly from job files plus explicit non-glob stage paths.
+                // Do NOT add arbitrary unstaged files from git status (prevents over-staging).
                 let candidate_vec = candidates.into_iter().collect_vec();
                 let matched_candidates = glob::get_matches(&stage_globs, &candidate_vec)?;
                 // Now keep only those that are actually unstaged
-                let unstaged_set: indexmap::IndexSet<PathBuf> = unstaged_vec.into_iter().collect();
+                let unstaged_set: indexmap::IndexSet<PathBuf> =
+                    status.unstaged_files.iter().cloned().collect();
                 let filtered = matched_candidates
                     .into_iter()
                     .filter(|p| unstaged_set.contains(p))
@@ -539,10 +542,20 @@ impl Step {
                     self, &filtered
                 );
                 if !filtered.is_empty() {
+                    // Snapshot pre-staging untracked set for classification
+                    let pre_untracked: BTreeSet<PathBuf> = status.untracked_files.clone();
                     // Only stage matched files; do NOT unstage other previously-staged files.
                     // Unintended staging caused by stash/apply is handled separately in git.pop_stash().
                     ctx.hook_ctx.git.lock().await.add(&filtered)?;
-                    ctx.add_files(&filtered);
+                    // Classify staged files using pre-staging untracked snapshot
+                    let filtered_set: BTreeSet<PathBuf> = filtered.iter().cloned().collect();
+                    let created_paths: BTreeSet<PathBuf> =
+                        filtered_set.intersection(&pre_untracked).cloned().collect();
+                    let added_paths: BTreeSet<PathBuf> =
+                        filtered_set.difference(&created_paths).cloned().collect();
+                    let added_paths: Vec<PathBuf> = added_paths.iter().cloned().collect();
+                    let created_paths: Vec<PathBuf> = created_paths.iter().cloned().collect();
+                    ctx.add_files(&added_paths, &created_paths);
                 }
             }
         }

--- a/src/step_context.rs
+++ b/src/step_context.rs
@@ -44,10 +44,11 @@ impl StepContext {
         }
     }
 
-    pub fn add_files(&self, files: &[PathBuf]) {
+    pub fn add_files(&self, added_paths: &[PathBuf], created_paths: &[PathBuf]) {
         let mut files_added = self.files_added.lock().unwrap();
-        files_added.extend(files.iter().cloned());
-        self.hook_ctx.add_files(files);
+        files_added.extend(added_paths.iter().cloned());
+        files_added.extend(created_paths.iter().cloned());
+        self.hook_ctx.add_files(added_paths, created_paths);
     }
 
     pub fn decrement_job_count(&self) {

--- a/test/overstaging_prettier.bats
+++ b/test/overstaging_prettier.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper/common_setup'
+  _common_setup
+}
+
+teardown() {
+  _common_teardown
+}
+
+@test "prettier stage globs do not over-stage unrelated files" {
+  cat <<'PKL' > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    fix = true
+    steps = new Mapping<String, Step> {
+      ["prettier"] {
+        glob = "src/changed.ts"
+        stage = List("**/*.ts", "src/explicit.ts")
+        fix = "printf 'fixed\n' >> src/changed.ts"
+      }
+    }
+  }
+}
+PKL
+  git add hk.pkl
+  git -c commit.gpgsign=false commit -m "init hk"
+
+  mkdir -p src
+  printf 'one\n' > src/changed.ts
+  printf 'two\n' > src/unrelated.ts
+  git add src/changed.ts
+  git -c commit.gpgsign=false commit -m "add changed"
+
+  printf 'one\nmore\n' > src/changed.ts
+  printf 'two\nmore\n' > src/unrelated.ts
+
+  run hk fix -v
+  assert_success
+
+  # Only the job file should be staged; unrelated.ts remains unstaged
+  run git status --porcelain -- src/changed.ts src/unrelated.ts
+  assert_success
+  # changed.ts should be staged (M or A); unrelated.ts unstaged (worktree change only)
+  assert_line --regexp '^[MA]  src/changed\.ts$'
+  refute_line --regexp '^[MA]  src/unrelated\.ts$'
+}

--- a/test/overstaging_prettier.bats
+++ b/test/overstaging_prettier.bats
@@ -10,7 +10,7 @@ teardown() {
 }
 
 @test "prettier stage globs do not over-stage unrelated files" {
-  cat <<'PKL' > hk.pkl
+  cat <<PKL > hk.pkl
 amends "$PKL_PATH/Config.pkl"
 hooks {
   ["fix"] {
@@ -27,6 +27,7 @@ hooks {
 PKL
   git add hk.pkl
   git -c commit.gpgsign=false commit -m "init hk"
+  hk install
 
   mkdir -p src
   printf 'one\n' > src/changed.ts


### PR DESCRIPTION
- **test: add overstaging reproduction for prettier stage globs**
- **fix: issue with files being staged that were fixer did not modify**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents over-staging by scoping stage globs to relevant files, classifying staged files as added vs created, updating add_files APIs, and adding a regression test.
> 
> - **Staging logic (fix)**:
>   - Scope stage candidates to job files plus explicit non-glob paths; for anchored globs, also consider unstaged files; filter strictly to unstaged matches.
>   - Snapshot untracked set pre-stage to classify staged files as `created` vs `added`, and pass both to context.
> - **API**:
>   - Change `HookContext::add_files` and `StepContext::add_files` to `add_files(added_paths, created_paths)`; propagate to `FileRwLocks`.
> - **Tests**:
>   - Add `test/overstaging_prettier.bats` to ensure prettier stage globs do not over-stage unrelated files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8889dfa57e00bf9c8aaf11e8269c1444bf19f034. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->