### PR TITLE
feat: add HK_STAGE setting to control automatic staging of fixed files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1169,6 +1169,23 @@ This is a convenience flag equivalent to `--profile=slow`.
 
 Useful for thorough checking in CI or before major releases.
 
+### `stage`
+
+- Type: `bool`
+- Default: `true`
+- Sources:
+  - ENV: `HK_STAGE`
+  - Git: `hk.stage`
+
+Controls whether hk automatically stages files that were fixed by pre-commit hooks.
+
+When enabled (default), files modified by fix commands will be automatically staged.
+When disabled (`HK_STAGE=0`), fixed files will remain as unstaged changes, allowing you to review them before committing.
+
+This is useful when you want to manually review changes made by auto-fixers before including them in your commit.
+
+Example: `HK_STAGE=0 git commit -m "test"` to prevent auto-staging of generated files.
+
 ### `stash`
 
 - Type: `enum`

--- a/settings.toml
+++ b/settings.toml
@@ -363,6 +363,22 @@ This is a convenience flag equivalent to `--profile=slow`.
 Useful for thorough checking in CI or before major releases.
 """
 
+[stage]
+type = "bool"
+default = true
+sources.env = ["HK_STAGE"]
+sources.git = ["hk.stage"]
+docs = """
+Controls whether hk automatically stages files that were fixed by pre-commit hooks.
+
+When enabled (default), files modified by fix commands will be automatically staged.
+When disabled (`HK_STAGE=0`), fixed files will remain as unstaged changes, allowing you to review them before committing.
+
+This is useful when you want to manually review changes made by auto-fixers before including them in your commit.
+
+Example: `HK_STAGE=0 git commit -m "test"` to prevent auto-staging of generated files.
+"""
+
 [stash]
 type = "enum"
 default = "auto"

--- a/src/step.rs
+++ b/src/step.rs
@@ -561,9 +561,11 @@ impl Step {
                 if !filtered.is_empty() {
                     // Snapshot pre-staging untracked set for classification
                     let pre_untracked: BTreeSet<PathBuf> = status.untracked_files.clone();
-                    // Only stage matched files; do NOT unstage other previously-staged files.
+                    // Only stage matched files if stage setting is enabled (default: true)
                     // Unintended staging caused by stash/apply is handled separately in git.pop_stash().
-                    ctx.hook_ctx.git.lock().await.add(&filtered)?;
+                    if Settings::get().stage {
+                        ctx.hook_ctx.git.lock().await.add(&filtered)?;
+                    }
                     // Classify staged files using pre-staging untracked snapshot
                     let filtered_set: BTreeSet<PathBuf> = filtered.iter().cloned().collect();
                     let created_paths: BTreeSet<PathBuf> =

--- a/test/stage_setting.bats
+++ b/test/stage_setting.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "HK_STAGE=0 prevents automatic staging of fixed files" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps {
+            ["generate"] {
+                glob = "src/*.txt"
+                stage = List("generated.txt")
+                fix = "echo 'generated content' > generated.txt"
+            }
+        }
+    }
+}
+EOF
+
+    mkdir -p src
+    echo "original content" > src/test.txt
+
+    git add hk.pkl src/test.txt
+    git commit -m "init"
+    hk install
+
+    # Make a change to trigger the hook
+    echo "modified content" > src/test.txt
+    git add src/test.txt
+
+    # Run with HK_STAGE=0 to prevent auto-staging
+    HK_STAGE=0 hk run pre-commit
+
+    # Verify that src/test.txt is still staged
+    run git diff --name-only --cached
+    assert_success
+    assert_output --partial "src/test.txt"
+
+    # Verify that generated.txt is NOT staged
+    refute_output --partial "generated.txt"
+
+    # Verify that generated.txt exists but is untracked
+    run git status --porcelain --untracked-files=all
+    assert_success
+    assert_output --partial "?? generated.txt"
+}
+
+@test "HK_STAGE=1 (default) stages fixed files automatically" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps {
+            ["generate"] {
+                glob = "src/*.txt"
+                stage = List("generated.txt")
+                fix = "echo 'generated content' > generated.txt"
+            }
+        }
+    }
+}
+EOF
+
+    mkdir -p src
+    echo "original content" > src/test.txt
+
+    git add hk.pkl src/test.txt
+    git commit -m "init"
+    hk install
+
+    # Make a change to trigger the hook
+    echo "modified content" > src/test.txt
+    git add src/test.txt
+
+    # Run with default HK_STAGE (should be 1)
+    hk run pre-commit
+
+    # Verify that src/test.txt is staged
+    run git diff --name-only --cached
+    assert_success
+    assert_output --partial "src/test.txt"
+
+    # Verify that generated.txt IS staged
+    assert_output --partial "generated.txt"
+
+    # Verify that generated.txt is staged (A = added)
+    run git status --porcelain
+    assert_success
+    assert_output --partial "A  generated.txt"
+}
+
+@test "git config hk.stage=false prevents automatic staging" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps {
+            ["generate"] {
+                glob = "src/*.txt"
+                stage = List("generated.txt")
+                fix = "echo 'generated content' > generated.txt"
+            }
+        }
+    }
+}
+EOF
+
+    mkdir -p src
+    echo "original content" > src/test.txt
+
+    git add hk.pkl src/test.txt
+    git commit -m "init"
+    hk install
+
+    # Set git config to disable staging
+    git config hk.stage false
+
+    # Make a change to trigger the hook
+    echo "modified content" > src/test.txt
+    git add src/test.txt
+
+    # Run pre-commit
+    hk run pre-commit
+
+    # Verify that src/test.txt is still staged
+    run git diff --name-only --cached
+    assert_success
+    assert_output --partial "src/test.txt"
+
+    # Verify that generated.txt is NOT staged
+    refute_output --partial "generated.txt"
+
+    # Verify that generated.txt exists but is untracked
+    run git status --porcelain --untracked-files=all
+    assert_success
+    assert_output --partial "?? generated.txt"
+}


### PR DESCRIPTION
## Summary
- Adds new `HK_STAGE` setting to control whether fixed files are automatically staged
- When `HK_STAGE=0` is set, files modified by fixers remain unstaged for manual review
- Addresses user request for v1 `PRESERVE_HUNKS=1` behavior

## Context
Users previously using v1 with `PRESERVE_HUNKS=1` were seeing different behavior in v2 where pre-commit hooks would automatically stage generated file changes. This PR introduces `HK_STAGE` setting (default: true) to allow users to opt out of automatic staging.

## Changes
- Added `stage` setting to `settings.toml` with env var `HK_STAGE` and git config `hk.stage`
- Modified `src/step.rs` to check the setting before staging files
- Added comprehensive bats tests in `test/stage_setting.bats`
- Updated documentation

## Test plan
- [x] Added new bats tests for HK_STAGE=0, HK_STAGE=1 (default), and git config
- [x] All tests pass with both libgit2 and shell git
- [x] Manual testing confirms files remain unstaged when HK_STAGE=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)