### PR TITLE
chore: release v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [1.16.0](https://github.com/jdx/hk/compare/v1.15.7..v1.16.0) - 2025-10-02
+
+### 🚀 Features
+
+- add HK_STAGE setting to control automatic staging of fixed files by [@jdx](https://github.com/jdx) in [#313](https://github.com/jdx/hk/pull/313)
+- suppress check output_summary when fixer runs with check_first by [@jdx](https://github.com/jdx) in [#315](https://github.com/jdx/hk/pull/315)
+
+### 🐛 Bug Fixes
+
+- --slow flag now properly enables slow profile by [@jdx](https://github.com/jdx) in [#317](https://github.com/jdx/hk/pull/317)
+
+### 📚 Documentation
+
+- Update getting_started.md by [@jdx](https://github.com/jdx) in [a8c1a35](https://github.com/jdx/hk/commit/a8c1a355e7770dbbf8a98b16678bef82e7490817)
+
+### 🔍 Other Changes
+
+- Update getting_started.md by [@jdx](https://github.com/jdx) in [58c0564](https://github.com/jdx/hk/commit/58c0564e0197e7cd655a385ff4563e2ccaef6188)
+
 ## [1.15.7](https://github.com/jdx/hk/compare/v1.15.6..v1.15.7) - 2025-09-29
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -590,9 +590,9 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deflate64"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
 name = "deranged"
@@ -1097,7 +1097,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.15.7"
+version = "1.16.0"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -2053,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.2.2"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "parking_lot"
@@ -2320,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -2583,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3479,9 +3479,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ucd-trie"
@@ -3589,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dbcdb58cb72b4e3d627382c661036bbe1372a9f652fbd82156b55f381bdd73b"
+checksum = "6c4a3170e9c1ba01392d385c73a5ab8aea52d7578c8c83778c04a05369a77a3b"
 dependencies = [
  "clap",
  "heck",
@@ -4360,9 +4360,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.15.7"
+version = "1.16.0"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2052,7 +2052,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.15.7",
+  "version": "1.16.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.15.7
+**Version**: 1.16.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.15.7"
+version "1.16.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {


### PR DESCRIPTION
## [1.16.0](https://github.com/jdx/hk/compare/v1.15.7..v1.16.0) - 2025-10-02

### 🚀 Features

- add HK_STAGE setting to control automatic staging of fixed files by [@jdx](https://github.com/jdx) in [#313](https://github.com/jdx/hk/pull/313)
- suppress check output_summary when fixer runs with check_first by [@jdx](https://github.com/jdx) in [#315](https://github.com/jdx/hk/pull/315)

### 🐛 Bug Fixes

- --slow flag now properly enables slow profile by [@jdx](https://github.com/jdx) in [#317](https://github.com/jdx/hk/pull/317)

### 📚 Documentation

- Update getting_started.md by [@jdx](https://github.com/jdx) in [a8c1a35](https://github.com/jdx/hk/commit/a8c1a355e7770dbbf8a98b16678bef82e7490817)

### 🔍 Other Changes

- Update getting_started.md by [@jdx](https://github.com/jdx) in [58c0564](https://github.com/jdx/hk/commit/58c0564e0197e7cd655a385ff4563e2ccaef6188)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Release v1.16.0 with new staging control, output suppression tweak, a --slow flag fix, docs update, and version/dependency bumps.
> 
> - **Release `1.16.0`**
>   - **Features**: add `HK_STAGE` setting; suppress `check` output_summary when fixer runs with `check_first`.
>   - **Bug Fix**: `--slow` flag now enables the `slow` profile.
>   - **Docs**: update `getting_started.md`.
>   - **Versioning**: bump crate to `1.16.0` in `Cargo.toml`; update CLI version in `docs/cli/commands.json`, `docs/cli/index.md`, and `hk.usage.kdl`.
>   - **Dependencies**: update crates in `Cargo.lock` (e.g., `anstyle`, `deflate64`, `owo-colors`, `quote`, `rustls-webpki`, `typenum`, `usage-lib`, `zeroize`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bffe2fc7d248aff0351e07283df0834b13ed3fc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->