### PR TITLE
fix: --slow flag now properly enables slow profile

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -510,12 +510,12 @@ impl Settings {
             if let Some(j) = snapshot.jobs {
                 map.insert("jobs", SettingValue::Usize(j));
             }
-            if !snapshot.profiles.is_empty() {
-                let set: IndexSet<String> = snapshot.profiles.into_iter().collect();
-                map.insert("profiles", SettingValue::StringList(set));
-            }
+            let mut profiles: IndexSet<String> = snapshot.profiles.into_iter().collect();
             if snapshot.slow {
-                map.insert("slow", SettingValue::Bool(true));
+                profiles.insert("slow".to_string());
+            }
+            if !profiles.is_empty() {
+                map.insert("profiles", SettingValue::StringList(profiles));
             }
             if snapshot.quiet {
                 map.insert("quiet", SettingValue::Bool(true));

--- a/test/profile_skip_summary.bats
+++ b/test/profile_skip_summary.bats
@@ -3,6 +3,7 @@
 setup() {
     load 'test_helper/common_setup'
     _common_setup
+    unset HK_HIDE_WARNINGS
 }
 
 teardown() {

--- a/test/slow_flag_bug.bats
+++ b/test/slow_flag_bug.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "check --slow should enable slow profile for setup-pnpm-install" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["setup-pnpm-install"] {
+                profiles = List("slow")
+                check = "echo 'SETUP PNPM INSTALL'"
+            }
+            ["fast-test"] {
+                check = "echo 'FAST TEST'"
+            }
+        }
+    }
+}
+EOF
+    echo "test" > test.js
+    run hk check --slow test.js
+    assert_success
+    assert_output --partial "SETUP PNPM INSTALL"
+    assert_output --partial "FAST TEST"
+    refute_output --partial "skipped: profile not enabled (slow)"
+}
+
+@test "check --slow should enable slow profile" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["eslint-web-bazel"] {
+                profiles = List("slow")
+                check = "echo 'ESLINT WEB BAZEL'"
+            }
+            ["prettier"] {
+                check = "echo 'PRETTIER'"
+            }
+        }
+    }
+}
+EOF
+    echo "test" > test.js
+    run hk check --slow test.js
+    assert_success
+    assert_output --partial "ESLINT WEB BAZEL"
+    assert_output --partial "PRETTIER"
+    refute_output --partial "skipped: profile not enabled (slow)"
+}
+
+@test "--slow flag adds slow to enabled profiles" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["slow-step"] {
+                profiles = List("slow")
+                check = "echo 'SLOW STEP RAN'"
+            }
+        }
+    }
+}
+EOF
+    echo "test" > test.js
+    run hk check --slow test.js
+    assert_success
+    assert_output --partial "SLOW STEP RAN"
+}


### PR DESCRIPTION
## Summary
Fixed a bug where the `--slow` flag was not enabling the slow profile, causing steps with `profiles = List("slow")` to be skipped even when `--slow` was passed.

## Changes
- Updated `collect_cli_map()` in `src/settings.rs` to add "slow" to the profiles list when `snapshot.slow` is true
- Added `test/slow_flag_bug.bats` with 3 tests to verify the fix
- Fixed `test/profile_skip_summary.bats` by unsetting `HK_HIDE_WARNINGS` in setup to ensure warning messages display correctly

## Test plan
- [x] Added new test `test/slow_flag_bug.bats` that reproduces the bug and verifies the fix
- [x] All new tests pass
- [x] Fixed and verified existing `profile_skip_summary.bats` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> --slow now adds "slow" to CLI profiles so slow-profile steps run; adds Bats tests and ensures warnings show in profile skip summary tests.
> 
> - **Settings**:
>   - Update `collect_cli_map()` in `src/settings.rs` to build `profiles` from CLI snapshot and append `"slow"` when `snapshot.slow` is true, then write back `profiles` (no separate `slow` flag handling).
> - **Tests**:
>   - Add `test/slow_flag_bug.bats` with 3 cases verifying `--slow` enables slow-profile steps.
>   - Update `test/profile_skip_summary.bats` to ensure warnings display (unset `HK_HIDE_WARNINGS`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23737b6e73aeeb8bdfbe1f34bae05050bb6e571f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->