### PR TITLE
refactor: Split util module into separate files

### DIFF
--- a/src/cli/util/mod.rs
+++ b/src/cli/util/mod.rs
@@ -1,0 +1,26 @@
+mod trailing_whitespace;
+
+pub use trailing_whitespace::TrailingWhitespace;
+
+use crate::Result;
+
+/// Utility commands for file operations
+#[derive(Debug, clap::Args)]
+pub struct Util {
+    #[clap(subcommand)]
+    command: UtilCommands,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum UtilCommands {
+    /// Check for and optionally fix trailing whitespace
+    TrailingWhitespace(TrailingWhitespace),
+}
+
+impl Util {
+    pub async fn run(&self) -> Result<()> {
+        match &self.command {
+            UtilCommands::TrailingWhitespace(cmd) => cmd.run().await,
+        }
+    }
+}

--- a/src/cli/util/trailing_whitespace.rs
+++ b/src/cli/util/trailing_whitespace.rs
@@ -3,37 +3,16 @@ use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 
-/// Utility commands for file operations
-#[derive(Debug, clap::Args)]
-pub struct Util {
-    #[clap(subcommand)]
-    command: UtilCommands,
-}
-
-#[derive(Debug, clap::Subcommand)]
-enum UtilCommands {
-    /// Check for and optionally fix trailing whitespace
-    TrailingWhitespace(TrailingWhitespace),
-}
-
 /// Check for and optionally fix trailing whitespace in files
 #[derive(Debug, clap::Args)]
 pub struct TrailingWhitespace {
     /// Fix trailing whitespace by removing it
     #[clap(short, long)]
-    fix: bool,
+    pub fix: bool,
 
     /// Files to check/fix
     #[clap(required = true)]
-    files: Vec<PathBuf>,
-}
-
-impl Util {
-    pub async fn run(&self) -> Result<()> {
-        match &self.command {
-            UtilCommands::TrailingWhitespace(cmd) => cmd.run().await,
-        }
-    }
+    pub files: Vec<PathBuf>,
 }
 
 impl TrailingWhitespace {
@@ -155,7 +134,6 @@ fn fix_trailing_whitespace(path: &PathBuf) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
     use tempfile::NamedTempFile;
 
     #[test]


### PR DESCRIPTION
Split src/cli/util.rs into:
- src/cli/util/mod.rs - module coordinator
- src/cli/util/trailing_whitespace.rs - trailing whitespace functionality

This makes the code more modular and easier to extend with new utility commands.

All existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Split `src/cli/util.rs` into `src/cli/util/mod.rs` (dispatcher) and `src/cli/util/trailing_whitespace.rs`, exposing `TrailingWhitespace` fields.
> 
> - **CLI/Module Restructure**:
>   - Add `src/cli/util/mod.rs` to coordinate `Util` commands and dispatch `TrailingWhitespace` via `run()`; re-export `TrailingWhitespace`.
>   - Move trailing whitespace functionality to `src/cli/util/trailing_whitespace.rs`; remove embedded `Util`/subcommand types from this file.
>   - Expose `TrailingWhitespace` fields `fix` and `files` as `pub`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33eb3cbf054d030c56dc2f1f87948c088323ea32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->