### PR TITLE
feat: Add check-merge-conflict util command and builtin

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -480,6 +480,13 @@ You can also customize builtins:
   - Check: `hk util check-executables-have-shebangs {{files}}`
 - **Notes:** Only checks files with execute permission, skips binary files
 
+#### `check_merge_conflict`
+- **Files:** All files
+- **Features:** Detect merge conflict markers
+- **Commands:**
+  - Check: `hk util check-merge-conflict {{files}}`
+- **Notes:** Detects `<<<<<<<`, `=======`, and `>>>>>>>` markers
+
 #### `check_symlinks`
 - **Files:** All files
 - **Features:** Detect broken symlinks

--- a/docs/cli/util.md
+++ b/docs/cli/util.md
@@ -42,6 +42,40 @@ hooks {
 - Accepts any shebang format (e.g., `#!/bin/bash`, `#!/usr/bin/env python`)
 - Exit code 1 if issues found, 0 if clean
 
+### `check-merge-conflict`
+
+Detect merge conflict markers in files
+
+**Usage**: `hk util check-merge-conflict <FILES>…`
+
+#### Arguments
+
+**`<FILES>…`**
+
+Files to check
+
+#### Examples
+
+```bash
+# Check for merge conflict markers
+hk util check-merge-conflict file1.txt file2.txt
+
+# Use in hk.pkl via builtin
+hooks {
+  ["pre-commit"] {
+    steps {
+      ["merge-conflict"] = Builtins.check_merge_conflict
+    }
+  }
+}
+```
+
+#### Features
+
+- Detects Git conflict markers: `<<<<<<<`, `=======`, `>>>>>>>`
+- Ignores markers in middle of lines
+- Exit code 1 if conflicts found, 0 if clean
+
 ### `check-symlinks`
 
 Check for broken symlinks

--- a/pkl/Builtins.pkl
+++ b/pkl/Builtins.pkl
@@ -11,6 +11,7 @@ cargo_check = Builtins["builtins/cargo_check.pkl"].cargo_check
 cargo_clippy = Builtins["builtins/cargo_clippy.pkl"].cargo_clippy
 cargo_fmt = Builtins["builtins/cargo_fmt.pkl"].cargo_fmt
 check_executables_have_shebangs = Builtins["builtins/check_executables_have_shebangs.pkl"].check_executables_have_shebangs
+check_merge_conflict = Builtins["builtins/check_merge_conflict.pkl"].check_merge_conflict
 check_symlinks = Builtins["builtins/check_symlinks.pkl"].check_symlinks
 clang_format = Builtins["builtins/clang_format.pkl"].clang_format
 cpp_lint = Builtins["builtins/cpp_lint.pkl"].cpp_lint

--- a/pkl/builtins/check_merge_conflict.pkl
+++ b/pkl/builtins/check_merge_conflict.pkl
@@ -1,0 +1,20 @@
+import "../Config.pkl"
+
+check_merge_conflict = new Config.Step {
+    glob = "**/*"
+    check = "hk util check-merge-conflict {{files}}"
+    tests {
+        ["detects conflict markers"] {
+            run = "check"
+            write { ["{{tmp}}/a.txt"] = "<<<<<<< HEAD\nconflict\n" }
+            files = List("{{tmp}}/a.txt")
+            expect { code = 1 }
+        }
+        ["passes clean files"] {
+            run = "check"
+            write { ["{{tmp}}/a.txt"] = "normal line\n" }
+            files = List("{{tmp}}/a.txt")
+            expect { code = 0 }
+        }
+    }
+}

--- a/src/cli/util/check_merge_conflict.rs
+++ b/src/cli/util/check_merge_conflict.rs
@@ -1,0 +1,105 @@
+use crate::Result;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+/// Check for merge conflict markers in files
+#[derive(Debug, clap::Args)]
+pub struct CheckMergeConflict {
+    /// Files to check
+    #[clap(required = true)]
+    pub files: Vec<PathBuf>,
+}
+
+impl CheckMergeConflict {
+    pub async fn run(&self) -> Result<()> {
+        let mut found_conflicts = false;
+
+        for file_path in &self.files {
+            if has_merge_conflict_markers(file_path)? {
+                println!("{}", file_path.display());
+                found_conflicts = true;
+            }
+        }
+
+        if found_conflicts {
+            std::process::exit(1);
+        }
+
+        Ok(())
+    }
+}
+
+/// Check if a file has merge conflict markers
+fn has_merge_conflict_markers(path: &PathBuf) -> Result<bool> {
+    let file = fs::File::open(path)?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+
+        // Check for conflict markers at the start of the line
+        if trimmed.starts_with("<<<<<<<")
+            || trimmed.starts_with("=======")
+            || trimmed.starts_with(">>>>>>>")
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_has_merge_conflict_markers() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "normal line").unwrap();
+        writeln!(file, "<<<<<<< HEAD").unwrap();
+        writeln!(file, "my changes").unwrap();
+        writeln!(file, "=======").unwrap();
+        writeln!(file, "their changes").unwrap();
+        writeln!(file, ">>>>>>> branch").unwrap();
+        file.flush().unwrap();
+
+        let path = file.path().to_path_buf();
+        assert!(has_merge_conflict_markers(&path).unwrap());
+    }
+
+    #[test]
+    fn test_no_merge_conflict_markers() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "normal line").unwrap();
+        writeln!(file, "another line").unwrap();
+        file.flush().unwrap();
+
+        let path = file.path().to_path_buf();
+        assert!(!has_merge_conflict_markers(&path).unwrap());
+    }
+
+    #[test]
+    fn test_merge_conflict_markers_with_whitespace() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "  <<<<<<< HEAD  ").unwrap();
+        file.flush().unwrap();
+
+        let path = file.path().to_path_buf();
+        assert!(has_merge_conflict_markers(&path).unwrap());
+    }
+
+    #[test]
+    fn test_ignores_markers_in_middle() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "this is not <<<<<<< a conflict").unwrap();
+        file.flush().unwrap();
+
+        let path = file.path().to_path_buf();
+        assert!(!has_merge_conflict_markers(&path).unwrap());
+    }
+}

--- a/src/cli/util/mod.rs
+++ b/src/cli/util/mod.rs
@@ -1,9 +1,11 @@
 mod check_executables_have_shebangs;
+mod check_merge_conflict;
 mod check_symlinks;
 mod mixed_line_ending;
 mod trailing_whitespace;
 
 pub use check_executables_have_shebangs::CheckExecutablesHaveShebangs;
+pub use check_merge_conflict::CheckMergeConflict;
 pub use check_symlinks::CheckSymlinks;
 pub use mixed_line_ending::MixedLineEnding;
 pub use trailing_whitespace::TrailingWhitespace;
@@ -21,6 +23,8 @@ pub struct Util {
 enum UtilCommands {
     /// Check that executable files have shebangs
     CheckExecutablesHaveShebangs(CheckExecutablesHaveShebangs),
+    /// Check for merge conflict markers
+    CheckMergeConflict(CheckMergeConflict),
     /// Check for broken symlinks
     CheckSymlinks(CheckSymlinks),
     /// Detect and fix mixed line endings
@@ -33,6 +37,7 @@ impl Util {
     pub async fn run(&self) -> Result<()> {
         match &self.command {
             UtilCommands::CheckExecutablesHaveShebangs(cmd) => cmd.run().await,
+            UtilCommands::CheckMergeConflict(cmd) => cmd.run().await,
             UtilCommands::CheckSymlinks(cmd) => cmd.run().await,
             UtilCommands::MixedLineEnding(cmd) => cmd.run().await,
             UtilCommands::TrailingWhitespace(cmd) => cmd.run().await,

--- a/test/util_check_merge_conflict.bats
+++ b/test/util_check_merge_conflict.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+teardown() {
+    _common_teardown
+}
+
+@test "util check-merge-conflict - detects conflict markers" {
+    cat > file1.txt <<EOF
+normal line
+<<<<<<< HEAD
+my changes
+=======
+their changes
+>>>>>>> branch
+EOF
+
+    run hk util check-merge-conflict file1.txt
+    assert_failure
+    assert_output "file1.txt"
+}
+
+@test "util check-merge-conflict - passes clean files" {
+    echo "normal line" > file1.txt
+    echo "another line" >> file1.txt
+
+    run hk util check-merge-conflict file1.txt
+    assert_success
+    refute_output
+}
+
+@test "util check-merge-conflict - detects only start marker" {
+    cat > file1.txt <<EOF
+normal line
+<<<<<<< HEAD
+some changes
+EOF
+
+    run hk util check-merge-conflict file1.txt
+    assert_failure
+    assert_output "file1.txt"
+}
+
+@test "util check-merge-conflict - detects middle marker" {
+    cat > file1.txt <<EOF
+normal line
+=======
+some changes
+EOF
+
+    run hk util check-merge-conflict file1.txt
+    assert_failure
+    assert_output "file1.txt"
+}
+
+@test "util check-merge-conflict - detects end marker" {
+    cat > file1.txt <<EOF
+normal line
+>>>>>>> branch
+EOF
+
+    run hk util check-merge-conflict file1.txt
+    assert_failure
+    assert_output "file1.txt"
+}
+
+@test "util check-merge-conflict - multiple files" {
+    cat > file1.txt <<EOF
+<<<<<<< HEAD
+conflict
+EOF
+    cat > file2.txt <<EOF
+=======
+conflict
+EOF
+
+    run hk util check-merge-conflict file1.txt file2.txt
+    assert_failure
+    assert_output --partial "file1.txt"
+    assert_output --partial "file2.txt"
+}
+
+@test "util check-merge-conflict - ignores markers in middle of line" {
+    echo "this is not <<<<<<< a conflict" > file1.txt
+
+    run hk util check-merge-conflict file1.txt
+    assert_success
+    refute_output
+}
+
+@test "util check-merge-conflict - detects with leading whitespace" {
+    echo "  <<<<<<< HEAD  " > file1.txt
+
+    run hk util check-merge-conflict file1.txt
+    assert_failure
+    assert_output "file1.txt"
+}
+
+@test "util check-merge-conflict - builtin integration" {
+    cat > hk.pkl <<HK
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+
+hooks {
+    ["check"] {
+        steps {
+            ["merge-conflict"] = Builtins.check_merge_conflict
+        }
+    }
+}
+HK
+
+    cat > test.txt <<EOF
+<<<<<<< HEAD
+conflict
+EOF
+
+    run hk check
+    assert_failure
+    assert_output --partial "test.txt"
+}


### PR DESCRIPTION
Implements detection of Git merge conflict markers in files.

## Changes

- Add `hk util check-merge-conflict` command
- Add `Builtins.check_merge_conflict`
- Add Rust unit tests (4 tests)
- Add bats integration tests (9 tests)
- Add documentation

## Features

- Detects `<<<<<<<`, `=======`, and `>>>>>>>` markers
- Ignores markers in middle of lines
- Exit code 1 if conflicts found, 0 if clean

All tests passing (243 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `hk util check-merge-conflict` and `Builtins.check_merge_conflict` to detect Git merge conflict markers in files.
> 
> - **CLI/Backend**:
>   - Add `check-merge-conflict` subcommand (`src/cli/util/check_merge_conflict.rs`) to scan files for `<<<<<<<`, `=======`, `>>>>>>>` markers; exits with code 1 on detection.
>   - Wire into `util` module (`src/cli/util/mod.rs`).
> - **Builtins**:
>   - New builtin `check_merge_conflict` (`pkl/builtins/check_merge_conflict.pkl`); added export in `pkl/Builtins.pkl`.
> - **Docs**:
>   - Document builtin in `docs/builtins.md` and CLI usage in `docs/cli/util.md`.
> - **Tests**:
>   - Rust unit tests for marker detection.
>   - Bats integration tests covering single/multiple files, whitespace, and builtin integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2104f85c3a25a0efe286f01a4c4d77ea5277ef74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->