### PR TITLE
feat: add mixed_line_ending builtin

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -473,6 +473,14 @@ You can also customize builtins:
 
 ### Special Purpose
 
+#### `mixed_line_ending`
+- **Files:** All text files
+- **Features:** Detect and fix mixed line endings (CRLF/LF in same file)
+- **Commands:**
+  - Check: `hk util mixed-line-ending {{files}}`
+  - Fix: `hk util mixed-line-ending --fix {{files}}`
+- **Notes:** Normalizes to LF, automatically skips binary files
+
 #### `newlines`
 - **Files:** All text files
 - **Features:** Ensure files end with newline

--- a/docs/cli/util.md
+++ b/docs/cli/util.md
@@ -6,6 +6,52 @@ Utility commands for file operations
 
 ## Subcommands
 
+### `mixed-line-ending`
+
+Detect and fix mixed line endings
+
+**Usage**: `hk util mixed-line-ending [FLAGS] <FILES>…`
+
+#### Arguments
+
+**`<FILES>…`**
+
+Files to check or fix
+
+#### Flags
+
+**`-f --fix`**
+
+Fix mixed line endings by normalizing to LF
+
+#### Examples
+
+```bash
+# Check for mixed line endings
+hk util mixed-line-ending file.txt
+
+# Fix mixed line endings
+hk util mixed-line-ending --fix *.txt
+
+# Use in hk.pkl via builtin
+hooks {
+  ["pre-commit"] {
+    steps {
+      ["mixed-endings"] = Builtins.mixed_line_ending
+    }
+  }
+}
+```
+
+#### Features
+
+- Detects files with both CRLF and LF line endings
+- Normalizes to LF when fixing
+- Automatically skips binary files
+- Exit codes:
+  - Check mode: Exit 1 if mixed endings found, 0 if clean
+  - Fix mode: Exit 0 on success
+
 ### `trailing-whitespace`
 
 Detect and remove trailing whitespace from files

--- a/pkl/Builtins.pkl
+++ b/pkl/Builtins.pkl
@@ -33,6 +33,7 @@ jq = Builtins["builtins/jq.pkl"].jq
 ktlint = Builtins["builtins/ktlint.pkl"].ktlint
 luacheck = Builtins["builtins/luacheck.pkl"].luacheck
 markdown_lint = Builtins["builtins/markdown_lint.pkl"].markdown_lint
+mixed_line_ending = Builtins["builtins/mixed_line_ending.pkl"].mixed_line_ending
 mypy = Builtins["builtins/mypy.pkl"].mypy
 newlines = Builtins["builtins/newlines.pkl"].newlines
 nix_fmt = Builtins["builtins/nix_fmt.pkl"].nix_fmt

--- a/pkl/builtins/mixed_line_ending.pkl
+++ b/pkl/builtins/mixed_line_ending.pkl
@@ -1,0 +1,34 @@
+import "../Config.pkl"
+
+mixed_line_ending = new Config.Step {
+    glob = "*"
+    stage = "*"
+    check = "hk util mixed-line-ending {{files}}"
+    fix = "hk util mixed-line-ending --fix {{files}}"
+    tests {
+        ["detects mixed line endings"] {
+            run = "check"
+            write { ["{{tmp}}/a.txt"] = "line1\r\nline2\nline3\r\n" }
+            files = List("{{tmp}}/a.txt")
+            expect { code = 1 }
+        }
+        ["passes LF only"] {
+            run = "check"
+            write { ["{{tmp}}/a.txt"] = "line1\nline2\nline3\n" }
+            files = List("{{tmp}}/a.txt")
+            expect { code = 0 }
+        }
+        ["passes CRLF only"] {
+            run = "check"
+            write { ["{{tmp}}/a.txt"] = "line1\r\nline2\r\nline3\r\n" }
+            files = List("{{tmp}}/a.txt")
+            expect { code = 0 }
+        }
+        ["fixes mixed line endings"] {
+            run = "fix"
+            write { ["{{tmp}}/a.txt"] = "line1\r\nline2\nline3\r\n" }
+            files = List("{{tmp}}/a.txt")
+            expect { files { ["{{tmp}}/a.txt"] = "line1\nline2\nline3\n" } }
+        }
+    }
+}

--- a/src/cli/util/mixed_line_ending.rs
+++ b/src/cli/util/mixed_line_ending.rs
@@ -1,0 +1,148 @@
+use crate::Result;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, clap::Args)]
+pub struct MixedLineEnding {
+    /// Fix mixed line endings by normalizing to LF
+    #[clap(short, long)]
+    pub fix: bool,
+
+    /// Files to check or fix
+    #[clap(required = true)]
+    pub files: Vec<PathBuf>,
+}
+
+impl MixedLineEnding {
+    pub async fn run(&self) -> Result<()> {
+        let mut found_mixed = false;
+
+        for file_path in &self.files {
+            if has_mixed_line_endings(file_path)? {
+                if self.fix {
+                    fix_line_endings(file_path)?;
+                } else {
+                    println!("{}", file_path.display());
+                    found_mixed = true;
+                }
+            }
+        }
+
+        if !self.fix && found_mixed {
+            std::process::exit(1);
+        }
+
+        Ok(())
+    }
+}
+
+fn has_mixed_line_endings(path: &PathBuf) -> Result<bool> {
+    let content = fs::read(path)?;
+
+    // Skip binary files
+    if content.contains(&0) {
+        return Ok(false);
+    }
+
+    let mut found_lf = false;
+    let mut found_crlf = false;
+
+    let mut i = 0;
+    while i < content.len() {
+        if content[i] == b'\n' {
+            // Check if preceded by \r
+            if i > 0 && content[i - 1] == b'\r' {
+                found_crlf = true;
+            } else {
+                found_lf = true;
+            }
+        }
+        i += 1;
+    }
+
+    Ok(found_lf && found_crlf)
+}
+
+fn fix_line_endings(path: &PathBuf) -> Result<()> {
+    let content = fs::read(path)?;
+
+    // Convert all CRLF to LF
+    let mut normalized = Vec::new();
+    let mut i = 0;
+    while i < content.len() {
+        if i + 1 < content.len() && content[i] == b'\r' && content[i + 1] == b'\n' {
+            // Skip the \r, keep only \n
+            normalized.push(b'\n');
+            i += 2;
+        } else {
+            normalized.push(content[i]);
+            i += 1;
+        }
+    }
+
+    fs::write(path, normalized)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_no_mixed_endings_lf_only() {
+        let file = NamedTempFile::new().unwrap();
+        fs::write(file.path(), b"line1\nline2\nline3\n").unwrap();
+
+        let result = has_mixed_line_endings(&file.path().to_path_buf()).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_no_mixed_endings_crlf_only() {
+        let file = NamedTempFile::new().unwrap();
+        fs::write(file.path(), b"line1\r\nline2\r\nline3\r\n").unwrap();
+
+        let result = has_mixed_line_endings(&file.path().to_path_buf()).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_mixed_endings() {
+        let file = NamedTempFile::new().unwrap();
+        fs::write(file.path(), b"line1\r\nline2\nline3\r\n").unwrap();
+
+        let result = has_mixed_line_endings(&file.path().to_path_buf()).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn test_fix_mixed_endings() {
+        let file = NamedTempFile::new().unwrap();
+        fs::write(file.path(), b"line1\r\nline2\nline3\r\n").unwrap();
+
+        fix_line_endings(&file.path().to_path_buf()).unwrap();
+
+        let content = fs::read(file.path()).unwrap();
+        assert_eq!(content, b"line1\nline2\nline3\n");
+    }
+
+    #[test]
+    fn test_binary_file_skipped() {
+        let file = NamedTempFile::new().unwrap();
+        fs::write(file.path(), b"binary\x00data\r\nwith\nlines").unwrap();
+
+        let result = has_mixed_line_endings(&file.path().to_path_buf()).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_file_with_no_line_endings() {
+        let file = NamedTempFile::new().unwrap();
+        fs::write(file.path(), b"just one line").unwrap();
+
+        let result = has_mixed_line_endings(&file.path().to_path_buf()).unwrap();
+        assert!(!result);
+    }
+}

--- a/src/cli/util/mod.rs
+++ b/src/cli/util/mod.rs
@@ -1,5 +1,7 @@
+mod mixed_line_ending;
 mod trailing_whitespace;
 
+pub use mixed_line_ending::MixedLineEnding;
 pub use trailing_whitespace::TrailingWhitespace;
 
 use crate::Result;
@@ -13,6 +15,8 @@ pub struct Util {
 
 #[derive(Debug, clap::Subcommand)]
 enum UtilCommands {
+    /// Detect and fix mixed line endings
+    MixedLineEnding(MixedLineEnding),
     /// Check for and optionally fix trailing whitespace
     TrailingWhitespace(TrailingWhitespace),
 }
@@ -20,6 +24,7 @@ enum UtilCommands {
 impl Util {
     pub async fn run(&self) -> Result<()> {
         match &self.command {
+            UtilCommands::MixedLineEnding(cmd) => cmd.run().await,
             UtilCommands::TrailingWhitespace(cmd) => cmd.run().await,
         }
     }

--- a/test/util_mixed_line_ending.bats
+++ b/test/util_mixed_line_ending.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+teardown() {
+    _common_teardown
+}
+
+@test "util mixed-line-ending - detects mixed endings" {
+    printf "line1\r\nline2\nline3\r\n" > file.txt
+
+    run hk util mixed-line-ending file.txt
+    assert_failure
+    assert_output "file.txt"
+}
+
+@test "util mixed-line-ending - passes LF only" {
+    printf "line1\nline2\nline3\n" > file.txt
+
+    run hk util mixed-line-ending file.txt
+    assert_success
+    refute_output
+}
+
+@test "util mixed-line-ending - passes CRLF only" {
+    printf "line1\r\nline2\r\nline3\r\n" > file.txt
+
+    run hk util mixed-line-ending file.txt
+    assert_success
+    refute_output
+}
+
+@test "util mixed-line-ending - fixes mixed endings" {
+    printf "line1\r\nline2\nline3\r\n" > file.txt
+
+    run hk util mixed-line-ending --fix file.txt
+    assert_success
+    refute_output
+
+    # Verify file was normalized to LF
+    run cat file.txt
+    assert_output "$(printf "line1\nline2\nline3\n")"
+}
+
+@test "util mixed-line-ending - multiple files" {
+    printf "line1\r\nline2\n" > file1.txt
+    printf "line1\nline2\r\n" > file2.txt
+
+    run hk util mixed-line-ending file1.txt file2.txt
+    assert_failure
+    assert_output --partial "file1.txt"
+    assert_output --partial "file2.txt"
+}
+
+@test "util mixed-line-ending - fix multiple files" {
+    printf "line1\r\nline2\n" > file1.txt
+    printf "line1\nline2\r\n" > file2.txt
+
+    run hk util mixed-line-ending --fix file1.txt file2.txt
+    assert_success
+    refute_output
+
+    # Verify both files normalized
+    run cat file1.txt
+    assert_output "$(printf "line1\nline2\n")"
+    run cat file2.txt
+    assert_output "$(printf "line1\nline2\n")"
+}
+
+@test "util mixed-line-ending - skips binary files" {
+    printf "binary\x00data\r\nwith\nlines" > binary.bin
+
+    run hk util mixed-line-ending binary.bin
+    assert_success
+    refute_output
+}
+
+@test "util mixed-line-ending - builtin integration" {
+    cat > hk.pkl <<HK
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+
+hooks {
+    ["check"] {
+        steps {
+            ["mixed-endings"] = Builtins.mixed_line_ending
+        }
+    }
+}
+HK
+
+    printf "line1\r\nline2\nline3\r\n" > test.txt
+
+    run hk check
+    assert_failure
+    assert_output --partial "test.txt"
+}
+
+@test "util mixed-line-ending - builtin fix integration" {
+    cat > hk.pkl <<HK
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+
+hooks {
+    ["fix"] {
+        steps {
+            ["mixed-endings"] = Builtins.mixed_line_ending
+        }
+    }
+}
+HK
+
+    printf "line1\r\nline2\nline3\r\n" > test.txt
+
+    run hk fix
+    assert_success
+
+    # Verify file was normalized
+    run cat test.txt
+    assert_output "$(printf "line1\nline2\nline3\n")"
+}


### PR DESCRIPTION
## Summary
- Adds `hk util mixed-line-ending` command to detect and fix mixed line endings
- Detects files with both CRLF and LF in the same file
- Normalizes to LF when fixing
- Automatically skips binary files
- Includes 6 unit tests and 9 bats integration tests

## Test plan
- [x] All 243 tests passing
- [x] CI green
- [x] Builtin integration tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)