### PR TITLE
feat: add check_symlinks builtin

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -473,6 +473,13 @@ You can also customize builtins:
 
 ### Special Purpose
 
+#### `check_symlinks`
+- **Files:** All files
+- **Features:** Detect broken symlinks
+- **Commands:**
+  - Check: `hk util check-symlinks {{files}}`
+- **Notes:** Only flags symlinks that point to non-existent targets
+
 #### `mixed_line_ending`
 - **Files:** All text files
 - **Features:** Detect and fix mixed line endings (CRLF/LF in same file)

--- a/docs/cli/util.md
+++ b/docs/cli/util.md
@@ -6,6 +6,41 @@ Utility commands for file operations
 
 ## Subcommands
 
+### `check-symlinks`
+
+Check for broken symlinks
+
+**Usage**: `hk util check-symlinks <FILES>…`
+
+#### Arguments
+
+**`<FILES>…`**
+
+Files to check
+
+#### Examples
+
+```bash
+# Check for broken symlinks
+hk util check-symlinks link1 link2
+
+# Use in hk.pkl via builtin
+hooks {
+  ["pre-commit"] {
+    steps {
+      ["symlinks"] = Builtins.check_symlinks
+    }
+  }
+}
+```
+
+#### Features
+
+- Detects symlinks that point to non-existent targets
+- Works with both file and directory symlinks
+- Only flags broken symlinks, not regular files
+- Exit code 1 if broken symlinks found, 0 if clean
+
 ### `mixed-line-ending`
 
 Detect and fix mixed line endings

--- a/pkl/Builtins.pkl
+++ b/pkl/Builtins.pkl
@@ -10,6 +10,7 @@ bundle_audit = Builtins["builtins/bundle_audit.pkl"].bundle_audit
 cargo_check = Builtins["builtins/cargo_check.pkl"].cargo_check
 cargo_clippy = Builtins["builtins/cargo_clippy.pkl"].cargo_clippy
 cargo_fmt = Builtins["builtins/cargo_fmt.pkl"].cargo_fmt
+check_symlinks = Builtins["builtins/check_symlinks.pkl"].check_symlinks
 clang_format = Builtins["builtins/clang_format.pkl"].clang_format
 cpp_lint = Builtins["builtins/cpp_lint.pkl"].cpp_lint
 deno = Builtins["builtins/deno.pkl"].deno

--- a/pkl/builtins/check_symlinks.pkl
+++ b/pkl/builtins/check_symlinks.pkl
@@ -2,7 +2,6 @@ import "../Config.pkl"
 
 check_symlinks = new Config.Step {
     glob = "**/*"
-    stage = "*"
     check = "hk util check-symlinks {{files}}"
     tests {
         ["detects broken symlink"] {

--- a/pkl/builtins/check_symlinks.pkl
+++ b/pkl/builtins/check_symlinks.pkl
@@ -1,0 +1,29 @@
+import "../Config.pkl"
+
+check_symlinks = new Config.Step {
+    glob = "*"
+    stage = "*"
+    check = "hk util check-symlinks {{files}}"
+    tests {
+        ["detects broken symlink"] {
+            run = "check"
+            write { ["{{tmp}}/target.txt"] = "content" }
+            before = "ln -s {{tmp}}/nonexistent {{tmp}}/broken_link"
+            files = List("{{tmp}}/broken_link")
+            expect { code = 1 }
+        }
+        ["passes valid symlink"] {
+            run = "check"
+            write { ["{{tmp}}/target.txt"] = "content" }
+            before = "ln -s {{tmp}}/target.txt {{tmp}}/link"
+            files = List("{{tmp}}/link")
+            expect { code = 0 }
+        }
+        ["passes regular file"] {
+            run = "check"
+            write { ["{{tmp}}/file.txt"] = "content" }
+            files = List("{{tmp}}/file.txt")
+            expect { code = 0 }
+        }
+    }
+}

--- a/pkl/builtins/check_symlinks.pkl
+++ b/pkl/builtins/check_symlinks.pkl
@@ -1,7 +1,7 @@
 import "../Config.pkl"
 
 check_symlinks = new Config.Step {
-    glob = "*"
+    glob = "**/*"
     stage = "*"
     check = "hk util check-symlinks {{files}}"
     tests {

--- a/src/cli/util/check_symlinks.rs
+++ b/src/cli/util/check_symlinks.rs
@@ -1,0 +1,126 @@
+use crate::Result;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, clap::Args)]
+pub struct CheckSymlinks {
+    /// Files to check
+    #[clap(required = true)]
+    pub files: Vec<PathBuf>,
+}
+
+impl CheckSymlinks {
+    pub async fn run(&self) -> Result<()> {
+        let mut found_broken = false;
+
+        for file_path in &self.files {
+            if is_broken_symlink(file_path)? {
+                println!("{}", file_path.display());
+                found_broken = true;
+            }
+        }
+
+        if found_broken {
+            std::process::exit(1);
+        }
+
+        Ok(())
+    }
+}
+
+fn is_broken_symlink(path: &PathBuf) -> Result<bool> {
+    // Check if path is a symlink
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(_) => return Ok(false), // File doesn't exist or can't be accessed
+    };
+
+    if !metadata.is_symlink() {
+        return Ok(false);
+    }
+
+    // If it's a symlink, check if target exists
+    // Using fs::metadata (not symlink_metadata) will follow the symlink
+    match fs::metadata(path) {
+        Ok(_) => Ok(false), // Target exists, symlink is valid
+        Err(_) => Ok(true), // Target doesn't exist, symlink is broken
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_valid_symlink() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("target.txt");
+        let link = dir.path().join("link");
+
+        fs::write(&target, "content").unwrap();
+        symlink(&target, &link).unwrap();
+
+        let result = is_broken_symlink(&link).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_broken_symlink() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("target.txt");
+        let link = dir.path().join("link");
+
+        // Create symlink to non-existent target
+        symlink(&target, &link).unwrap();
+
+        let result = is_broken_symlink(&link).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn test_regular_file() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("file.txt");
+        fs::write(&file, "content").unwrap();
+
+        let result = is_broken_symlink(&file).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_nonexistent_file() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("nonexistent");
+
+        let result = is_broken_symlink(&file).unwrap();
+        assert!(!result); // Not a broken symlink, just doesn't exist
+    }
+
+    #[test]
+    fn test_symlink_to_directory() {
+        let dir = TempDir::new().unwrap();
+        let target_dir = dir.path().join("target_dir");
+        let link = dir.path().join("link");
+
+        fs::create_dir(&target_dir).unwrap();
+        symlink(&target_dir, &link).unwrap();
+
+        let result = is_broken_symlink(&link).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_broken_symlink_to_directory() {
+        let dir = TempDir::new().unwrap();
+        let target_dir = dir.path().join("nonexistent_dir");
+        let link = dir.path().join("link");
+
+        symlink(&target_dir, &link).unwrap();
+
+        let result = is_broken_symlink(&link).unwrap();
+        assert!(result);
+    }
+}

--- a/src/cli/util/mod.rs
+++ b/src/cli/util/mod.rs
@@ -1,6 +1,8 @@
+mod check_symlinks;
 mod mixed_line_ending;
 mod trailing_whitespace;
 
+pub use check_symlinks::CheckSymlinks;
 pub use mixed_line_ending::MixedLineEnding;
 pub use trailing_whitespace::TrailingWhitespace;
 
@@ -15,6 +17,8 @@ pub struct Util {
 
 #[derive(Debug, clap::Subcommand)]
 enum UtilCommands {
+    /// Check for broken symlinks
+    CheckSymlinks(CheckSymlinks),
     /// Detect and fix mixed line endings
     MixedLineEnding(MixedLineEnding),
     /// Check for and optionally fix trailing whitespace
@@ -24,6 +28,7 @@ enum UtilCommands {
 impl Util {
     pub async fn run(&self) -> Result<()> {
         match &self.command {
+            UtilCommands::CheckSymlinks(cmd) => cmd.run().await,
             UtilCommands::MixedLineEnding(cmd) => cmd.run().await,
             UtilCommands::TrailingWhitespace(cmd) => cmd.run().await,
         }

--- a/test/util_check_symlinks.bats
+++ b/test/util_check_symlinks.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+teardown() {
+    _common_teardown
+}
+
+@test "util check-symlinks - detects broken symlink" {
+    ln -s nonexistent broken_link
+
+    run hk util check-symlinks broken_link
+    assert_failure
+    assert_output "broken_link"
+}
+
+@test "util check-symlinks - passes valid symlink" {
+    echo "content" > target.txt
+    ln -s target.txt link
+
+    run hk util check-symlinks link
+    assert_success
+    refute_output
+}
+
+@test "util check-symlinks - passes regular file" {
+    echo "content" > file.txt
+
+    run hk util check-symlinks file.txt
+    assert_success
+    refute_output
+}
+
+@test "util check-symlinks - detects multiple broken symlinks" {
+    ln -s nonexistent1 broken1
+    ln -s nonexistent2 broken2
+
+    run hk util check-symlinks broken1 broken2
+    assert_failure
+    assert_output --partial "broken1"
+    assert_output --partial "broken2"
+}
+
+@test "util check-symlinks - mixed valid and broken" {
+    echo "content" > target.txt
+    ln -s target.txt valid_link
+    ln -s nonexistent broken_link
+
+    run hk util check-symlinks valid_link broken_link
+    assert_failure
+    assert_output "broken_link"
+    refute_output --partial "valid_link"
+}
+
+@test "util check-symlinks - symlink to directory" {
+    mkdir target_dir
+    ln -s target_dir link_to_dir
+
+    run hk util check-symlinks link_to_dir
+    assert_success
+    refute_output
+}
+
+@test "util check-symlinks - builtin integration" {
+    cat > hk.pkl <<HK
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+
+hooks {
+    ["check"] {
+        steps {
+            ["symlinks"] = Builtins.check_symlinks
+        }
+    }
+}
+HK
+
+    ln -s nonexistent broken_link
+    git add -A
+
+    run hk check --all
+    assert_failure
+    assert_output --partial "broken_link"
+}


### PR DESCRIPTION
## Summary
- Adds `hk util check-symlinks` command to detect broken symlinks
- Checks for symlinks pointing to non-existent targets
- Works with both file and directory symlinks
- Includes 6 unit tests and 7 bats integration tests

## Test plan
- [x] All 241 tests passing
- [x] CI green
- [x] Builtin integration tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `hk util check-symlinks` and `Builtins.check_symlinks` to detect broken symlinks, with docs and tests.
> 
> - **CLI**:
>   - Add `hk util check-symlinks` subcommand in `src/cli/util/check_symlinks.rs` and register it in `src/cli/util/mod.rs`.
> - **Builtins**:
>   - Introduce `pkl/builtins/check_symlinks.pkl` and export `Builtins.check_symlinks` in `pkl/Builtins.pkl`.
> - **Docs**:
>   - Document `check_symlinks` in `docs/cli/util.md` (usage, features, examples) and add builtin entry in `docs/builtins.md`.
> - **Tests**:
>   - Add Rust unit tests in `check_symlinks.rs` and Bats integration tests in `test/util_check_symlinks.bats`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17b0fbe28c0ce32e912f7972c3b519535b3b36c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->