### PR TITLE
fix: Add validation for stage attribute requiring fix command

### DIFF
--- a/pkl/builtins/mix_compile.pkl
+++ b/pkl/builtins/mix_compile.pkl
@@ -2,7 +2,6 @@ import "../Config.pkl"
 
 mix_compile = new Config.Step {
     glob = "*.ex"
-    stage = glob
     exclude = List("deps/**/*")
     check = "mix compile --warnings-as-errors --strict-errors {{files}}"
 }

--- a/pkl/builtins/mix_test.pkl
+++ b/pkl/builtins/mix_test.pkl
@@ -2,7 +2,6 @@ import "../Config.pkl"
 
 mix_test = new Config.Step {
     glob = List("*.ex", "*.exs")
-    stage = glob
     exclude = List("deps/**/*")
     check = "mix test --warnings-as-errors {{files}}"
 }

--- a/pkl/builtins/pkl.pkl
+++ b/pkl/builtins/pkl.pkl
@@ -2,6 +2,5 @@ import "../Config.pkl"
 
 pkl = new Config.Step {
     glob = "*.pkl"
-    stage = glob
     check = "pkl eval {{files}} >/dev/null"
 }

--- a/pkl/builtins/shellcheck.pkl
+++ b/pkl/builtins/shellcheck.pkl
@@ -3,6 +3,5 @@ import "../Config.pkl"
 shellcheck = new Config.Step {
     batch = true
     glob = List("*.sh", "*.bash")
-    stage = glob
     check = "shellcheck {{ files }}"
 } 

--- a/test/depends.bats
+++ b/test/depends.bats
@@ -46,7 +46,6 @@ hooks {
             ["c"] { fix = "cat b.txt > c.txt"; depends = List("b"); stage = "c.txt"; glob = "b.txt" }
             ["d"] { fix = "cat c.txt > d.txt"; depends = List("c"); stage = "d.txt"; glob = "c.txt" }
             ["e"] { depends = List("d")
-                    stage = "e.txt"
                     glob = "d.txt"
                     check = """
 if [ \$(cat d.txt) = "ITWORKS" ]; then

--- a/test/validation_errors.bats
+++ b/test/validation_errors.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+teardown() {
+    _common_teardown
+}
+
+@test "validation fails when step has stage but no fix" {
+    # Create config with step that has stage but no fix
+    cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["test-step"] {
+                glob = "*.txt"
+                check = "echo checking"
+                stage = "*"
+            }
+        }
+    }
+}
+EOF
+
+    # Any command that loads config should fail
+    run hk check
+    assert_failure
+    assert_output --partial "Step 'test-step' in hook 'pre-commit' has 'stage' attribute but no 'fix' command"
+    assert_output --partial "Steps that stage files must have a fix command"
+}
+
+@test "validation passes when step has stage and fix" {
+    # Create config with step that has both stage and fix
+    cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["test-step"] {
+                glob = "*.txt"
+                check = "echo checking"
+                fix = "echo fixing"
+                stage = "*"
+            }
+        }
+    }
+}
+EOF
+
+    # Should not fail
+    run hk validate
+    assert_success
+}
+
+@test "validation passes when step has fix but no stage" {
+    # Create config with step that has fix but no stage
+    cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["test-step"] {
+                glob = "*.txt"
+                check = "echo checking"
+                fix = "echo fixing"
+            }
+        }
+    }
+}
+EOF
+
+    # Should not fail
+    run hk validate
+    assert_success
+}
+
+@test "validation passes when step has neither stage nor fix" {
+    # Create config with step that has neither stage nor fix (check only)
+    cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["test-step"] {
+                glob = "*.txt"
+                check = "echo checking"
+            }
+        }
+    }
+}
+EOF
+
+    # Should not fail
+    run hk validate
+    assert_success
+}
+
+@test "validation fails when step in group has stage but no fix" {
+    # Create config with step in a group that has stage but no fix
+    cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["test-group"] = new Group {
+                steps {
+                    ["test-step"] {
+                        glob = "*.txt"
+                        check = "echo checking"
+                        stage = "*"
+                    }
+                }
+            }
+        }
+    }
+}
+EOF
+
+    # Any command that loads config should fail
+    run hk check
+    assert_failure
+    assert_output --partial "Step 'test-step' in group 'test-group' of hook 'pre-commit' has 'stage' attribute but no 'fix' command"
+    assert_output --partial "Steps that stage files must have a fix command"
+}
+
+@test "validation validates all hooks" {
+    # Create config with invalid step in a different hook
+    cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["pre-push"] {
+        steps {
+            ["test-step"] {
+                glob = "*.txt"
+                check = "echo checking"
+                stage = "*"
+            }
+        }
+    }
+}
+EOF
+
+    # Should fail for pre-push hook
+    run hk check
+    assert_failure
+    assert_output --partial "Step 'test-step' in hook 'pre-push' has 'stage' attribute but no 'fix' command"
+}


### PR DESCRIPTION
## Summary

Implements validation logic to ensure that steps with a `stage` attribute must also have a `fix` command. This prevents misconfiguration where steps attempt to stage files without providing a way to fix them.

Addresses the requirement mentioned in recent discussion: "We should actually add some logic in hk that bails if a step has stage set without a fixer."

## Changes

- **Config validation**: Added logic in `Config::validate()` that iterates through all hooks and steps (including those in groups) to check for this condition
- **Early validation**: Calls `validate()` in `Config::get()` so validation runs every time config is loaded, not just when explicitly running `hk validate`
- **Clear error messages**: Provides specific error messages indicating which step in which hook (or group) has the invalid configuration

## Test Coverage

Added comprehensive test suite in `test/validation_errors.bats` covering:
- ✅ Steps with `stage` but no `fix` (should fail validation)
- ✅ Steps with both `stage` and `fix` (should pass)
- ✅ Steps with `fix` but no `stage` (should pass)
- ✅ Steps with neither `stage` nor `fix` (should pass - check-only steps)
- ✅ Steps in groups with `stage` but no `fix` (should fail validation)
- ✅ Validation across multiple hooks (pre-commit, pre-push, etc.)

All 249 tests passing (including 6 new validation tests).

## Example Error Message

```
Error: Step 'test-step' in hook 'pre-commit' has 'stage' attribute but no 'fix' command. Steps that stage files must have a fix command.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces validation that any step with `stage` must also define `fix`, runs it on config load, removes `stage` from built-in Pkl steps without fix, and adds focused tests.
> 
> - **Config Validation**
>   - Add `Config::validate()` to error when a step (or grouped step) has `stage` without `fix`.
>   - Invoke `validate()` in `Config::get()` so validation runs on every load.
> - **Built-ins**
>   - Remove `stage = glob` from `pkl/builtins/{mix_compile.pkl,mix_test.pkl,pkl.pkl,shellcheck.pkl}` to avoid invalid config (no `fix`).
> - **Tests**
>   - Add `test/validation_errors.bats` covering valid/invalid `stage`+`fix` combinations and groups.
>   - Adjust `test/depends.bats` to avoid staging in the non-fix check step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 214ee1d6bcf2cac1cc18de382548c42109049f82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->