### PR TITLE
feat: add check_added_large_files builtin

### DIFF
--- a/pkl/builtins/check_added_large_files.pkl
+++ b/pkl/builtins/check_added_large_files.pkl
@@ -1,0 +1,36 @@
+import "../Config.pkl"
+
+check_added_large_files = new Config.Step {
+    glob = "**/*"
+    check = "hk util check-added-large-files {{files}}"
+    tests {
+        ["detects large file with default 500KB limit"] {
+            run = "check"
+            before = "dd if=/dev/zero of={{tmp}}/large.bin bs=1024 count=501 2>/dev/null"
+            files = List("{{tmp}}/large.bin")
+            expect { code = 1 }
+        }
+        ["passes small file"] {
+            run = "check"
+            write {
+                ["{{tmp}}/small.txt"] = "small content"
+            }
+            files = List("{{tmp}}/small.txt")
+            expect { code = 0 }
+        }
+        ["respects custom limit"] {
+            run = "check"
+            before = "dd if=/dev/zero of={{tmp}}/medium.bin bs=1024 count=50 2>/dev/null"
+            files = List("{{tmp}}/medium.bin")
+            check = "hk util check-added-large-files --maxkb 100 {{files}}"
+            expect { code = 0 }
+        }
+        ["detects file over custom limit"] {
+            run = "check"
+            before = "dd if=/dev/zero of={{tmp}}/medium.bin bs=1024 count=50 2>/dev/null"
+            files = List("{{tmp}}/medium.bin")
+            check = "hk util check-added-large-files --maxkb 10 {{files}}"
+            expect { code = 1 }
+        }
+    }
+}

--- a/src/cli/util/check_added_large_files.rs
+++ b/src/cli/util/check_added_large_files.rs
@@ -1,0 +1,125 @@
+use crate::Result;
+use std::fs;
+use std::path::PathBuf;
+
+const DEFAULT_MAX_SIZE_KB: u64 = 500;
+
+#[derive(Debug, clap::Args)]
+pub struct CheckAddedLargeFiles {
+    /// Maximum file size in kilobytes (default: 500)
+    #[clap(long, default_value_t = DEFAULT_MAX_SIZE_KB)]
+    pub maxkb: u64,
+
+    /// Files to check
+    #[clap(required = true)]
+    pub files: Vec<PathBuf>,
+}
+
+impl CheckAddedLargeFiles {
+    pub async fn run(&self) -> Result<()> {
+        let max_size_bytes = self.maxkb * 1024;
+        let mut found_large = false;
+
+        for file_path in &self.files {
+            if is_too_large(file_path, max_size_bytes)? {
+                println!("{}", file_path.display());
+                found_large = true;
+            }
+        }
+
+        if found_large {
+            std::process::exit(1);
+        }
+
+        Ok(())
+    }
+}
+
+fn is_too_large(path: &PathBuf, max_size: u64) -> Result<bool> {
+    let metadata = match fs::metadata(path) {
+        Ok(m) => m,
+        Err(_) => return Ok(false), // File doesn't exist or can't be accessed
+    };
+
+    // Skip directories
+    if metadata.is_dir() {
+        return Ok(false);
+    }
+
+    Ok(metadata.len() > max_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_small_file() {
+        let file = NamedTempFile::new().unwrap();
+        fs::write(file.path(), "small content").unwrap();
+
+        let result = is_too_large(&file.path().to_path_buf(), 1024).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_large_file() {
+        let file = NamedTempFile::new().unwrap();
+        // Create a 2KB file
+        let large_content = vec![b'x'; 2048];
+        fs::write(file.path(), large_content).unwrap();
+
+        let result = is_too_large(&file.path().to_path_buf(), 1024).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn test_file_exactly_at_limit() {
+        let file = NamedTempFile::new().unwrap();
+        // Create exactly 1024 bytes
+        let content = vec![b'x'; 1024];
+        fs::write(file.path(), content).unwrap();
+
+        let result = is_too_large(&file.path().to_path_buf(), 1024).unwrap();
+        assert!(!result); // Equal to limit is OK
+    }
+
+    #[test]
+    fn test_file_one_byte_over_limit() {
+        let file = NamedTempFile::new().unwrap();
+        // Create 1025 bytes
+        let content = vec![b'x'; 1025];
+        fs::write(file.path(), content).unwrap();
+
+        let result = is_too_large(&file.path().to_path_buf(), 1024).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn test_empty_file() {
+        let file = NamedTempFile::new().unwrap();
+        fs::write(file.path(), "").unwrap();
+
+        let result = is_too_large(&file.path().to_path_buf(), 1024).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_nonexistent_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("nonexistent");
+
+        let result = is_too_large(&file, 1024).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_directory() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let result = is_too_large(&dir.path().to_path_buf(), 1024).unwrap();
+        assert!(!result); // Directories should be skipped
+    }
+}


### PR DESCRIPTION
Adds the `check_added_large_files` utility builtin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a CLI utility to detect files exceeding a size limit (default 500KB) and a builtin step that wraps it, both with tests.
> 
> - **CLI Utility**:
>   - Adds `src/cli/util/check_added_large_files.rs` providing `check-added-large-files` with `--maxkb` (default 500KB) to scan provided `files`, print offenders, and exit with code 1; skips directories/nonexistent files.
>   - Includes unit tests covering small/large files, exact limit, over limit, empty files, nonexistent files, and directories.
> - **Builtin**:
>   - Introduces `pkl/builtins/check_added_large_files.pkl` implementing `check_added_large_files` step that runs `hk util check-added-large-files {{files}}`.
>   - Adds tests for default limit detection, small file pass, custom limit, and over-limit detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a119fa7fb24e116888f40c70101a8ba68dcb92e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->