### PR TITLE
feat: add no_commit_to_branch builtin

### DIFF
--- a/pkl/builtins/no_commit_to_branch.pkl
+++ b/pkl/builtins/no_commit_to_branch.pkl
@@ -1,0 +1,23 @@
+import "../Config.pkl"
+
+no_commit_to_branch = new Config.Step {
+    check = "hk util no-commit-to-branch"
+    tests {
+        ["passes on feature branch"] {
+            run = "check"
+            before = "git checkout -b feature-branch 2>/dev/null || git checkout feature-branch"
+            expect { code = 0 }
+        }
+        ["fails on main branch"] {
+            run = "check"
+            before = "git checkout main 2>/dev/null || git checkout -b main"
+            expect { code = 1 }
+        }
+        ["respects custom branch list"] {
+            run = "check"
+            before = "git checkout -b production 2>/dev/null || git checkout production"
+            check = "hk util no-commit-to-branch --branch main,master,production"
+            expect { code = 1 }
+        }
+    }
+}

--- a/src/cli/util/no_commit_to_branch.rs
+++ b/src/cli/util/no_commit_to_branch.rs
@@ -1,0 +1,70 @@
+use crate::Result;
+use std::process::Command;
+
+#[derive(Debug, clap::Args)]
+pub struct NoCommitToBranch {
+    /// Branch names to protect (default: main, master)
+    #[clap(long, value_delimiter = ',')]
+    pub branch: Option<Vec<String>>,
+}
+
+impl NoCommitToBranch {
+    pub async fn run(&self) -> Result<()> {
+        let protected_branches = self
+            .branch
+            .clone()
+            .unwrap_or_else(|| vec!["main".to_string(), "master".to_string()]);
+
+        let current_branch = get_current_branch()?;
+
+        if protected_branches.contains(&current_branch) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "Cannot commit directly to protected branch '{}'",
+                    current_branch
+                ),
+            )
+            .into());
+        }
+
+        Ok(())
+    }
+}
+
+fn get_current_branch() -> Result<String> {
+    let output = Command::new("git")
+        .args(&["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Failed to get current git branch",
+        )
+        .into());
+    }
+
+    let branch = String::from_utf8(output.stdout)?
+        .trim()
+        .to_string();
+
+    Ok(branch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_current_branch() {
+        // This test will only pass in a git repository
+        // In CI or non-git environments, it might fail
+        let result = get_current_branch();
+        if result.is_ok() {
+            let branch = result.unwrap();
+            // Branch name should not be empty
+            assert!(!branch.is_empty());
+        }
+    }
+}


### PR DESCRIPTION
Adds the `no_commit_to_branch` utility builtin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a CLI guard and builtin step to prevent committing directly to protected branches (default main/master) with optional custom branch list.
> 
> - **CLI / Utility**:
>   - Add `hk util no-commit-to-branch` in `src/cli/util/no_commit_to_branch.rs` to block commits on protected branches.
>     - Defaults to `main`/`master`; supports `--branch main,master,production` (comma-delimited) to override.
>     - Uses `git rev-parse --abbrev-ref HEAD` to detect current branch; returns error on protected branches.
>     - Includes minimal unit test for `get_current_branch`.
> - **Builtins / Config**:
>   - Introduce `pkl/builtins/no_commit_to_branch.pkl` defining `Config.Step` wired to `hk util no-commit-to-branch` with tests for feature pass, main fail, and custom branch list behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 053748bc846bd06b1da0b0642909286b03ce8906. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->