### PR TITLE
fix: display stderr when check_list_files returns empty list

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,5 +7,6 @@ pub enum Error {
         #[source]
         source: eyre::Error,
         stdout: String,
+        stderr: String,
     },
 }

--- a/test/check_list_files_empty_with_stderr.bats
+++ b/test/check_list_files_empty_with_stderr.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "check_list_files with empty file list and stderr should display stderr" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    steps {
+      ["go-fmt"] {
+        check_first = true
+        glob = List("*.go")
+        stage = List("*.go")
+        check_list_files = """
+# Simulate gofmt behavior: when gofmt has syntax errors, it writes to stderr
+# but the wrapper script sees empty FILES and exits 0
+echo "test.go:1:1: syntax error" 1>&2
+echo "test.go:2:5: expected operand, found return" 1>&2
+# Exit 0 because no files need formatting (FILES is empty)
+"""
+        fix = "echo 'would format' {{files}}"
+      }
+      ["other-step"] {
+        glob = List("*.go")
+        stage = List("*.go")
+        fix = "echo 'other'"
+      }
+    }
+  }
+}
+EOF
+    # Create a go file
+    echo 'package main' > test.go
+    git add test.go
+
+    run hk fix
+    assert_failure
+    # Should display the stderr output from check_list_files
+    assert_output --partial "test.go:1:1: syntax error"
+    assert_output --partial "test.go:2:5: expected operand, found return"
+    assert_output --partial "check_list_files returned no files and produced errors"
+}
+
+@test "check_list_files with empty file list but no stderr should not fail" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    steps {
+      ["format"] {
+        check_first = true
+        glob = List("*.txt")
+        stage = List("*.txt")
+        check_list_files = """
+# Return empty list with no stderr (files are already formatted)
+# Exit 0 with empty stdout - no files need formatting
+"""
+        fix = "echo 'would format' {{files}}"
+      }
+      ["other-step"] {
+        glob = List("*.txt")
+        fix = "echo 'other'"
+      }
+    }
+  }
+}
+EOF
+    echo 'content' > test.txt
+    git add test.txt
+
+    run hk fix
+    assert_success
+    # Should not run format fix since no files need formatting
+    refute_output --partial "would format"
+    # But other-step should run
+    assert_output --partial "other"
+}
+
+@test "check_list_files with files and stderr should process files" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    steps {
+      ["format"] {
+        check_first = true
+        glob = List("*.txt")
+        stage = List("*.txt")
+        check_list_files = """
+# Return file list with some warnings in stderr
+echo "test.txt"
+echo "warning: some formatting issue" 1>&2
+exit 1
+"""
+        fix = "echo 'formatted' {{files}}"
+      }
+    }
+  }
+}
+EOF
+    echo 'content' > test.txt
+    git add test.txt
+
+    run hk fix
+    assert_success
+    # Should run fix since files were returned
+    assert_output --partial "formatted test.txt"
+}


### PR DESCRIPTION
## Summary

When `check_list_files` commands (like `gofmt`) encounter syntax errors, they often write errors to stderr but return an empty file list on stdout. Previously, hk would then run the fix command with no files, leading to confusing errors like "cannot use -w with standard input".

This change detects when `check_list_files` returns an empty list but has stderr output, and fails immediately with the actual error messages displayed to the user.

## Example

**Before:** User sees misleading error
```
✗ go-fmt – ERROR
go-fmt stderr:
error: cannot use -w with standard input
```

**After:** User sees actual Go syntax errors
```
✗ go-fmt – ERROR
go-fmt: check_list_files returned no files and produced errors:
deploys/v2/internal/gate/deploywindow/gate.go:108:26: string literal not terminated
deploys/v2/internal/gate/deploywindow/gate.go:109:4: expected operand, found '%'
...
```

## Changes

- Add `stderr` field to `CheckListFailed` error type
- Check for empty stdout + non-empty stderr in successful `check_list_files` runs
- Display stderr when `check_first` fails with empty file list
- Add comprehensive test suite covering all scenarios

## Test Plan

Added `test/check_list_files_empty_with_stderr.bats` with 3 tests:
- ✅ Empty file list with stderr → fails and displays errors
- ✅ Empty file list without stderr → succeeds (files already formatted)
- ✅ Non-empty file list with stderr → processes files (warnings are OK)

All tests pass.

## Related Issue

Fixes the issue reported where Go syntax errors were hidden behind misleading gofmt error messages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates and displays `stderr` when `check_list_files` yields no files (empty stdout), failing early and adding tests to cover empty/no-empty combinations.
> 
> - **Core behavior**:
>   - Add `stderr` to `Error::CheckListFailed` in `src/error.rs`.
>   - In `src/step.rs`:
>     - Treat `check_list_files` success with empty `stdout` and non-empty `stderr` as an error, returning `Error::CheckListFailed { stdout, stderr }`.
>     - When `check_first` fails with `CheckListFailed`, filter files; if none remain and `stderr` exists, fail early, surfacing `stderr`.
>     - Populate `stderr` on script failure for `CheckListFailed`.
> - **Tests**:
>   - Add `test/check_list_files_empty_with_stderr.bats` covering:
>     - Empty list + `stderr` → fail and display errors.
>     - Empty list + no `stderr` → succeed (no files to format).
>     - Non-empty list + `stderr` → proceed with files (warnings).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit befaa71995598bc5eb4dce12b80431095144d839. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->