### PR TITLE
chore: split CI runs into parallel jobs and add docs-sync mise task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,30 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          #- ubuntu-24.04-arm
+          #- windows-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          submodules: recursive
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+      - run: mise run build
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+        with:
+          name: hk-${{ matrix.os }}
+          path: target/debug/hk
   ci-libgit2:
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -34,8 +57,12 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           submodules: recursive
-      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: hk-${{ matrix.os }}
+          path: target/debug
+      - run: chmod +x target/debug/hk
       - run: mise x -- bun i
       - name: mise run test:bats:libgit2
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
@@ -44,6 +71,7 @@ jobs:
           max_attempts: 3
           command: mise run test:bats:libgit2
   ci-nolibgit2:
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -60,8 +88,12 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           submodules: recursive
-      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: hk-${{ matrix.os }}
+          path: target/debug
+      - run: chmod +x target/debug/hk
       - run: mise x -- bun i
       - name: mise run test:bats:nolibgit2
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
@@ -105,3 +137,13 @@ jobs:
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
       - run: mise run msrv
+  final:
+    needs:
+      - ci-libgit2
+      - ci-nolibgit2
+      - ci-other
+      - msrv
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: echo "All CI jobs completed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  ci:
+  ci-libgit2:
     strategy:
       fail-fast: false
       matrix:
@@ -37,12 +37,64 @@ jobs:
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
       - run: mise x -- bun i
-      - name: mise run ci
+      - name: mise run test:bats:libgit2
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: mise run ci
+          command: mise run test:bats:libgit2
+  ci-nolibgit2:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          #- ubuntu-24.04-arm
+          #- windows-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - run: brew install parallel
+        if: ${{ matrix.os == 'macos-latest' }}
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          submodules: recursive
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+      - run: mise x -- bun i
+      - name: mise run test:bats:nolibgit2
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: mise run test:bats:nolibgit2
+  ci-other:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          #- ubuntu-24.04-arm
+          #- windows-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - run: brew install parallel
+        if: ${{ matrix.os == 'macos-latest' }}
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          submodules: recursive
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+      - run: mise x -- bun i
+      - name: mise run test:cargo
+        run: mise run test:cargo
+      - name: mise run lint
+        run: mise run lint
+      - name: mise run docs-sync
+        run: mise run docs-sync
   msrv:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -53,10 +105,3 @@ jobs:
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
       - run: mise run msrv
-  docs-sync:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - name: Check documentation sync
-        run: ./scripts/check-docs-sync.sh

--- a/mise.toml
+++ b/mise.toml
@@ -105,6 +105,9 @@ run = "bun i && bun run docs:build"
 
 
 
+[tasks."docs-sync"]
+run = "./scripts/check-docs-sync.sh"
+
 [tasks.render]
 depends = ["render:*"]
 


### PR DESCRIPTION
## Summary
- Split CI workflow into 3 separate jobs for better parallelization:
  - `ci-libgit2`: Runs bats tests with `HK_LIBGIT2=1`
  - `ci-nolibgit2`: Runs bats tests with `HK_LIBGIT2=0`
  - `ci-other`: Runs cargo tests, lint checks, and docs-sync
- Added `docs-sync` mise task that runs `./scripts/check-docs-sync.sh`
- Moved docs-sync from standalone GitHub Actions job to the `ci-other` job

## Benefits
- Better CI parallelization by running libgit2 and non-libgit2 tests concurrently
- Clearer separation of test concerns
- docs-sync now integrated into mise tasks for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Parallelizes CI into build, libgit2/non-libgit2 test jobs, and other checks using shared build artifacts; adds a `docs-sync` mise task and a final aggregator job.
> 
> - **CI Workflow**:
>   - **Build Artifacts**: New `build` job compiles `hk` on `macos-latest` and `ubuntu-latest` and uploads `target/debug/hk`.
>   - **Test Split**:
>     - `ci-libgit2`: downloads artifact and runs `mise run test:bats:libgit2` with retry.
>     - `ci-nolibgit2`: downloads artifact and runs `mise run test:bats:nolibgit2` with retry.
>   - **Other Checks**: `ci-other` runs `mise run test:cargo`, `mise run lint`, and `mise run docs-sync`.
>   - **Final Aggregation**: New `final` job depends on `ci-libgit2`, `ci-nolibgit2`, `ci-other`, and `msrv`, then echoes success; removes standalone `docs-sync` job.
> - **Mise Tasks**:
>   - Adds `docs-sync` task executing `./scripts/check-docs-sync.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6442a5a16a83c06dc896b43a01e6796857e187e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->