### PR TITLE
fix: update release-plz to automatically update version refs in docs

### DIFF
--- a/mise-tasks/release-plz
+++ b/mise-tasks/release-plz
@@ -50,6 +50,9 @@ git submodule update --init --recursive
 
 # Do not touch sub-crate versions/changelogs in this repository
 
+# Update version references in docs and source files
+VERSION="${version#v}" mise run update-version
+
 # Regenerate rendered artifacts (CLI docs, usage, etc.) for the release
 mise run render
 git add \


### PR DESCRIPTION
## Summary
- Modifies `release-plz` script to call `update-version` before `render`
- Ensures docs always reference the current version in amends/import statements
- Fixes issue where docs reference v1.2.0 even when newer features are required

## Problem
Documentation files currently have hardcoded v1.2.0 references in amends and import statements:
```pkl
amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
```

This is problematic when:
- Newer features are added that require a later version (e.g. `fail_fast` added after v1.2.0)
- Users following docs may try to use features not available in v1.2.0
- The current version is 1.16.0, making the v1.2.0 references very outdated

## Solution
The `mise-tasks/update-version.sh` script already exists and uses ripgrep to find and replace all version references. It's called by the `pre-release` task but wasn't being called by `release-plz`.

This PR adds a call to `VERSION="${version#v}" mise run update-version` in the release-plz script, right before the `render` step. This ensures all version references are updated whenever a new release is prepared.

## Test plan
- [x] Ran `mise run ci` successfully
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Run `update-version` in `mise-tasks/release-plz` (with `VERSION="${version#v}"`) before `render` to refresh version refs across docs/source during release PRs.
> 
> - **Release automation** (`mise-tasks/release-plz`):
>   - Invoke `VERSION="${version#v}" mise run update-version` before `mise run render` to update version references in docs and source prior to regenerating artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e17d58f9ce78a8d0cdd7c48be000a7def77c5797. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->