### PR TITLE
fix: add ruff format to ruff builtin

### DIFF
--- a/pkl/builtins/ruff.pkl
+++ b/pkl/builtins/ruff.pkl
@@ -3,6 +3,6 @@ import "../Config.pkl"
 ruff = new Config.Step {
     glob = "*.py"
     stage = "*.py"
-    check = "ruff check {{ files }}"
-    fix = "ruff check --fix {{ files }}"
+    check = "ruff check {{ files }} && ruff format --check {{ files }}"
+    fix = "ruff check --fix {{ files }} && ruff format {{ files }}"
 } 


### PR DESCRIPTION
## Summary
- Adds `ruff format` commands to the ruff builtin step to match the documented behavior
- The builtin was only running `ruff check`, but the documentation specifies it should also run `ruff format`

## Changes
Updated `pkl/builtins/ruff.pkl`:
- Check: `ruff check {{files}} && ruff format --check {{files}}`
- Fix: `ruff check --fix {{files}} && ruff format {{files}}`

## Test plan
- [x] All Rust unit tests pass
- [x] All bats integration tests pass (both libgit2 and shell git modes)
- [x] `mise run ci` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)