### PR TITLE
fix: enable experimental settings in mise.toml for swift support

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,6 @@
+[settings]
+experimental = true
+
 [env]
 _.path = ["test/bats/bin", "{{ env.CARGO_TARGET_DIR | default(value='target') }}/debug", "node_modules/.bin"]
 


### PR DESCRIPTION
## Summary
Enables experimental settings in mise.toml to fix CI failures caused by the swift tool being marked as experimental in the latest version of mise.

## Problem
After merging #318 which added `swift = "latest"` to mise.toml to support `language: swift` in pre-commit migrations, the CI build job started failing with:

```
ERROR Failed to install core:swift@latest: 
swift is experimental. Enable it with `mise settings experimental=true`
```

## Solution
Added `[settings]` section with `experimental = true` to mise.toml to allow installation of experimental tools like swift.

## Test plan
- [x] Verified `mise install` works locally with the change
- [x] CI will verify the build succeeds

Fixes the build failure on main branch from commit 00da295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable `experimental = true` in `[settings]` of `mise.toml` to allow installing experimental tools (e.g., `swift`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b79f68c5e040b91031f62dc2af42bcd4d0c71f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->