### PR TITLE
fix: correct airflow migration test to expect local imports

### DIFF
--- a/test/migrate_precommit.bats
+++ b/test/migrate_precommit.bats
@@ -416,7 +416,9 @@ PRECOMMIT
 
     # Verify basic structure
     run cat hk.pkl
-    assert_output --partial 'import "package://github.com/jdx/hk'
+    # When using --hk-pkl-root with a local path, it should use local imports
+    assert_output --partial 'import "'
+    assert_output --partial 'Builtins.pkl'
     assert_output --partial 'hooks {'
 
     # Apache Airflow uses several common pre-commit hooks


### PR DESCRIPTION
## Summary
Fixes the "migrate precommit - apache airflow real-world config" test that was failing in CI.

## Problem
The test was checking for package URL imports (`import "package://github.com/jdx/hk`) even when using `--hk-pkl-root` with a local path. When a local pkl root is specified, the migrate command correctly generates local imports (e.g., `import "/path/to/pkl/Builtins.pkl"`) instead of package URLs.

## Solution
Updated the test assertion to check for the presence of import statements and `Builtins.pkl` rather than expecting a specific package URL format.

## Test plan
- [x] Verified the test passes locally with both HK_LIBGIT2=0 and HK_LIBGIT2=1
- [x] All migrate_precommit tests pass

Fixes the failing test introduced in #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust Airflow pre-commit migration test to assert local imports (e.g., Builtins.pkl) instead of package URLs when using a local hk-pkl-root.
> 
> - **Tests**:
>   - `test/migrate_precommit.bats` (Airflow real-world config):
>     - Replace package URL import assertion with checks for local imports (`import "..."`, `Builtins.pkl`) when `--hk-pkl-root` points to a local path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60a066370f62bd6966d2aec8df6dfa71b1082443. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->