### PR TITLE
chore: remove swift from mise tools and skip swift tests when unavailable

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -128,6 +128,10 @@ checksum = "sha256:4cf9f2741e6c465ffdb7c26f38056a59e2a2544b51f7cc128ef28337eeae4
 size = 2566310
 url = "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz"
 
+[[tools.ruff]]
+version = "0.13.3"
+backend = "aqua:astral-sh/ruff"
+
 [[tools.shellcheck]]
 version = "0.11.0"
 backend = "ubi:koalaman/shellcheck"
@@ -144,14 +148,6 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellche
 
 [tools.shellcheck.platforms.macos-arm64-shellcheck]
 checksum = "blake3:dda081f041dedece533bf343f83422af6d478742fcb7b09f8875b787f4829f45"
-
-[[tools.swift]]
-version = "6.2"
-backend = "core:swift"
-
-[tools.swift.platforms.macos-arm64]
-checksum = "blake3:d9e22fb7495996e43d1565e61b9bd3009d8e72de9cdf73cd07d93acfaeed5abe"
-size = 1726141935
 
 [[tools.swiftlint]]
 version = "0.59.1"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,3 @@
-[settings]
-experimental = true
-
 [env]
 _.path = ["test/bats/bin", "{{ env.CARGO_TARGET_DIR | default(value='target') }}/debug", "node_modules/.bin"]
 
@@ -27,7 +24,6 @@ usage = "latest"
 vhs = "latest"
 taplo = "latest"
 uv = "latest"
-swift = "latest"
 
 [tasks.init]
 run = '''

--- a/test/migrate_precommit.bats
+++ b/test/migrate_precommit.bats
@@ -713,6 +713,10 @@ RUBY
 }
 
 @test "migrate precommit - vendor swift hooks (swift-format)" {
+    if ! command -v swift &> /dev/null; then
+        skip "swift not available"
+    fi
+
     cat <<PRECOMMIT > .pre-commit-config.yaml
 repos:
 -   repo: https://github.com/swiftlang/swift-format


### PR DESCRIPTION
## Summary
Removes swift from mise.toml and makes swift-related tests skip gracefully when swift is not available.

## Problem
Swift was added as an experimental tool to support `language: swift` hooks in pre-commit migration (#318). However:
- It requires `experimental = true` in mise settings
- Adds significant CI setup time
- May cause CI failures if the experimental feature changes

## Solution
1. Remove `swift = "latest"` from mise.toml tools
2. Remove `experimental = true` setting (no longer needed)
3. Add skip condition to swift vendoring test: checks if `swift` command is available before running
4. Update mise.lock

The migrate pre-commit functionality for swift hooks remains fully functional - it just won't be tested in CI unless swift happens to be available in the environment.

## Test plan
- [x] Verified `mise install` works without swift
- [x] Verified swift test skips gracefully when swift unavailable
- [x] CI will test this across platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove Swift from mise config and lockfile, add ruff to lock, and skip Swift-related test when `swift` is unavailable.
> 
> - **Config (mise)**:
>   - Remove `swift = "latest"` and `[settings] experimental = true` from `mise.toml`.
>   - Update `mise.lock`: drop `tools.swift`; add `tools.ruff@0.13.3`.
> - **Tests**:
>   - In `test/migrate_precommit.bats`, skip the Swift vendoring test if `swift` is not installed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bb456255794f825e55569d3907a9071355d849a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->