### PR TITLE
fix: handle missing files in update-version script

### DIFF
--- a/mise-tasks/update-version.sh
+++ b/mise-tasks/update-version.sh
@@ -12,6 +12,6 @@ else
     SED="sed"
 fi
 
-rg 'package://github\.com/jdx/hk/releases/download/v[\d\.]+/hk@[\d\.]+#/' --files-with-matches -0 | xargs -0 "$SED" -i "s|package://github\.com/jdx/hk/releases/download/v[0-9.]\+/hk@[0-9.]\+#|package://github.com/jdx/hk/releases/download/v$VERSION/hk@$VERSION#|g"
+rg 'package://github\.com/jdx/hk/releases/download/v[\d\.]+/hk@[\d\.]+#/' --files-with-matches -0 | xargs -0 -r "$SED" -i "s|package://github\.com/jdx/hk/releases/download/v[0-9.]\+/hk@[0-9.]\+#|package://github.com/jdx/hk/releases/download/v$VERSION/hk@$VERSION#|g"
 
 git add .


### PR DESCRIPTION
## Summary
Fixes the release-plz workflow failure by handling the case where ripgrep finds no matching files.

## Problem
The `update-version.sh` script was failing with:
```
sed: no input files
```

This happened when `rg` didn't find any matching package:// URLs in the repository. When `rg` returns no results, `xargs` would still try to run `sed` with no input, causing it to fail.

This blocked the release workflow: https://github.com/jdx/hk/actions/runs/18262051312/job/51991277623

## Solution
Added the `-r` (or `--no-run-if-empty`) flag to `xargs`, which prevents it from running the command when there's no input from stdin.

This is a standard practice for pipelines where the input may be empty:
```bash
# Before (fails if rg finds nothing):
rg pattern --files-with-matches -0 | xargs -0 sed ...

# After (succeeds even if rg finds nothing):
rg pattern --files-with-matches -0 | xargs -0 -r sed ...
```

## Behavior
- **When files match**: Works exactly as before - updates version strings
- **When no files match**: Exits successfully without running sed (no error)

## Test Plan
- [x] Tested locally with pattern that matches no files
- [x] Tested locally with pattern that matches files
- [x] Will verify release-plz workflow succeeds in CI

Related to #349 (Windows build fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add -r to xargs in update-version.sh so sed isn't run when rg finds no matches, avoiding failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76f7ba822fcd38d950b573a463f98d9bb4ec6749. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->