### PR TITLE
chore: release v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [1.18.0](https://github.com/jdx/hk/compare/v1.17.0..v1.18.0) - 2025-10-05
+
+### 🚀 Features
+
+- add fix-smart-quotes util by [@joonas](https://github.com/joonas) in [#348](https://github.com/jdx/hk/pull/348)
+
+### 🐛 Bug Fixes
+
+- add Windows support by guarding Unix-specific file permission APIs by [@jdx](https://github.com/jdx) in [#349](https://github.com/jdx/hk/pull/349)
+- handle missing files in update-version script by [@jdx](https://github.com/jdx) in [#350](https://github.com/jdx/hk/pull/350)
+- rewrite update-version script to avoid pipefail issues by [@jdx](https://github.com/jdx) in [211b1ac](https://github.com/jdx/hk/commit/211b1ac4850a5634e5bc6f11fb70cf7ad8f6d7cb)
+- run render before update-version in release script by [@jdx](https://github.com/jdx) in [35d2df3](https://github.com/jdx/hk/commit/35d2df37c2e453fe4587a56452da6906ebeb2c66)
+- use [0-9] instead of \d in ripgrep pattern for better compatibility by [@jdx](https://github.com/jdx) in [cf8ebb0](https://github.com/jdx/hk/commit/cf8ebb08036f105fed6eb787254ebd1c468208cc)
+- explicitly specify search path for ripgrep in update-version script by [@jdx](https://github.com/jdx) in [5666f96](https://github.com/jdx/hk/commit/5666f96d1fdbecd507f24034e5ec7d98c793f342)
+
+### 🔍 Other Changes
+
+- add diagnostic output to update-version script by [@jdx](https://github.com/jdx) in [aaeea63](https://github.com/jdx/hk/commit/aaeea63c071d4709dcab69a5bae4a56a6752da18)
+- add more file existence checks by [@jdx](https://github.com/jdx) in [cbace40](https://github.com/jdx/hk/commit/cbace4055e2aaafadb53ae0db81275da7bbe7333)
+- test rg pattern matching in CI environment by [@jdx](https://github.com/jdx) in [a52ea46](https://github.com/jdx/hk/commit/a52ea4663655a41afb6abf9c8e112308f5314af4)
+
+### New Contributors
+
+- @joonas made their first contribution in [#348](https://github.com/jdx/hk/pull/348)
+
 ## [1.17.0](https://github.com/jdx/hk/compare/v1.16.0..v1.17.0) - 2025-10-05
 
 ### 🚀 Features
@@ -28,10 +53,16 @@
 - correct airflow migration test to expect local imports by [@jdx](https://github.com/jdx) in [#343](https://github.com/jdx/hk/pull/343)
 - make final CI check always run and fail if dependencies fail by [@jdx](https://github.com/jdx) in [#344](https://github.com/jdx/hk/pull/344)
 - add ruff format to ruff builtin by [@jdx](https://github.com/jdx) in [#340](https://github.com/jdx/hk/pull/340)
+- update release-plz to automatically update version refs in docs by [@jdx](https://github.com/jdx) in [#339](https://github.com/jdx/hk/pull/339)
+- enable rename detection in git status by [@jdx](https://github.com/jdx) in [#347](https://github.com/jdx/hk/pull/347)
 
 ### 🚜 Refactor
 
 - Split util module into separate files by [@jdx](https://github.com/jdx) in [#321](https://github.com/jdx/hk/pull/321)
+
+### 🧪 Testing
+
+- remove flaky ruby vendoring test by [@jdx](https://github.com/jdx) in [#345](https://github.com/jdx/hk/pull/345)
 
 ### 🛡️ Security
 
@@ -41,6 +72,7 @@
 
 - split CI runs into parallel jobs and add docs-sync mise task by [@jdx](https://github.com/jdx) in [#337](https://github.com/jdx/hk/pull/337)
 - remove v0 pkl files from docs/public by [@jdx](https://github.com/jdx) in [#341](https://github.com/jdx/hk/pull/341)
+- remove swift from mise tools and skip swift tests when unavailable by [@jdx](https://github.com/jdx) in [#346](https://github.com/jdx/hk/pull/346)
 
 ## [1.16.0](https://github.com/jdx/hk/compare/v1.15.7..v1.16.0) - 2025-10-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,9 +840,9 @@ checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
 
 [[package]]
 name = "flate2"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04bcaeafafdd3cd1cb5d986ff32096ad1136630207c49b9091e3ae541090d938"
+checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
 dependencies = [
  "crc32fast",
  "libz-rs-sys",
@@ -1117,7 +1117,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "hk"
-version = "1.17.0"
+version = "1.18.0"
 edition = "2024"
 description = "A tool for managing git hooks"
 license = "MIT"

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 70+ pre-configured linters and formatters through the `Builtins` mod
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -2605,7 +2605,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.17.0",
+  "version": "1.18.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.17.0
+**Version**: 1.18.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,8 +11,8 @@ hk is configured via `hk.pkl` which is written in [pkl-lang](https://pkl-lang.or
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // linters can be manually defined
@@ -105,7 +105,7 @@ exclude = "node_modules"
 
 // Exclude using regex pattern (for complex matching)
 // First import Types.pkl to use the Regex helper
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Types.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Types.pkl"
 exclude = Types.Regex(#".*\.(test|spec)\.(js|ts)$"#)
 ```
 
@@ -497,8 +497,8 @@ Notes:
 The `Regex()` helper function is available by importing Types.pkl:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Types.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Types.pkl"
 
 // Use it like:
 exclude = Types.Regex(#".*\.test\.js$"#)
@@ -743,8 +743,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,8 +47,8 @@ The global configuration file follows the same format as `hk.pkl` and can be use
 This will generate a `hk.pkl` file in the root of the repository, here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // linters can be manually defined

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -39,7 +39,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
 
 `pre-commit` {
     ["prelint"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -173,7 +173,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -4,8 +4,8 @@
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
 
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -4,8 +4,8 @@
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
 
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -4,8 +4,8 @@
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -5,8 +5,8 @@
 /// * Sorts imports with isort
 /// * Validates with flake8
 
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -7,8 +7,8 @@
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
 
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -7,8 +7,8 @@
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
 
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -7,8 +7,8 @@
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -8,8 +8,8 @@
 /// * Sorts imports with isort
 /// * Validates with flake8
 
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -517,8 +517,8 @@ Common builtins:
 ### Basic JavaScript/TypeScript Project
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {
@@ -542,8 +542,8 @@ hooks {
 ### Monorepo with Multiple Languages
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 local frontend_linters = new Mapping<String, Step> {
   ["prettier"] = (Builtins.prettier) {
@@ -579,7 +579,7 @@ hooks {
 ### Custom Linter with Platform-Specific Commands
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
 
 hooks {
   ["pre-commit"] {
@@ -605,8 +605,8 @@ hooks {
 ### Step with Dependencies and Conditions
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {
@@ -631,8 +631,8 @@ hooks {
 ### Profile-Based Configuration
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 hooks {
   ["check"] {

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
 amends "pkl/Config.pkl"
 import "pkl/Builtins.pkl"
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.17.0"
+version "1.18.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file" global=#true {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -20,8 +20,8 @@ impl Init {
     pub async fn run(&self) -> Result<()> {
         let hk_file = PathBuf::from("hk.pkl");
         let hook_content = r#"
-amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // uses builtin prettier linter config

--- a/src/config.rs
+++ b/src/config.rs
@@ -248,7 +248,7 @@ fn handle_pkl_error(output: &std::process::Output, path: &Path) -> Result<()> {
             Make sure your 'amends' declaration uses a valid path or package URL.\n\
             Examples:\n\
             • amends \"pkl/Config.pkl\" (if vendored)\n\
-            • amends \"package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl\"",
+            • amends \"package://github.com/jdx/hk/releases/download/v1.18.0/hk@1.18.0#/Config.pkl\"",
             path.display()
         );
     }


### PR DESCRIPTION
## [1.18.0](https://github.com/jdx/hk/compare/v1.17.0..v1.18.0) - 2025-10-05

### 🚀 Features

- add fix-smart-quotes util by [@joonas](https://github.com/joonas) in [#348](https://github.com/jdx/hk/pull/348)

### 🐛 Bug Fixes

- add Windows support by guarding Unix-specific file permission APIs by [@jdx](https://github.com/jdx) in [#349](https://github.com/jdx/hk/pull/349)
- handle missing files in update-version script by [@jdx](https://github.com/jdx) in [#350](https://github.com/jdx/hk/pull/350)
- rewrite update-version script to avoid pipefail issues by [@jdx](https://github.com/jdx) in [211b1ac](https://github.com/jdx/hk/commit/211b1ac4850a5634e5bc6f11fb70cf7ad8f6d7cb)
- run render before update-version in release script by [@jdx](https://github.com/jdx) in [35d2df3](https://github.com/jdx/hk/commit/35d2df37c2e453fe4587a56452da6906ebeb2c66)
- use [0-9] instead of \d in ripgrep pattern for better compatibility by [@jdx](https://github.com/jdx) in [cf8ebb0](https://github.com/jdx/hk/commit/cf8ebb08036f105fed6eb787254ebd1c468208cc)
- explicitly specify search path for ripgrep in update-version script by [@jdx](https://github.com/jdx) in [5666f96](https://github.com/jdx/hk/commit/5666f96d1fdbecd507f24034e5ec7d98c793f342)

### 🔍 Other Changes

- add diagnostic output to update-version script by [@jdx](https://github.com/jdx) in [aaeea63](https://github.com/jdx/hk/commit/aaeea63c071d4709dcab69a5bae4a56a6752da18)
- add more file existence checks by [@jdx](https://github.com/jdx) in [cbace40](https://github.com/jdx/hk/commit/cbace4055e2aaafadb53ae0db81275da7bbe7333)
- test rg pattern matching in CI environment by [@jdx](https://github.com/jdx) in [a52ea46](https://github.com/jdx/hk/commit/a52ea4663655a41afb6abf9c8e112308f5314af4)

### New Contributors

- @joonas made their first contribution in [#348](https://github.com/jdx/hk/pull/348)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps hk to 1.18.0, updates docs/CLI/templates to new Pkl package URLs, and refreshes a dependency.
> 
> - **Version bump**:
>   - Set crate/app version to `1.18.0` in `Cargo.toml`, `Cargo.lock` (package `hk`), `hk.usage.kdl`, `docs/cli/commands.json`, and `docs/cli/index.md`.
> - **Docs/examples**:
>   - Update `amends`/`import` URLs from `v1.2.0` to `v1.18.0` across `docs/*`, `hk-example.pkl`, and example `.pkl` files.
>   - Add `CHANGELOG.md` entry for `1.18.0`.
> - **CLI/templates**:
>   - Update init template in `src/cli/init.rs` to use `v1.18.0` URLs.
>   - Refresh error hint URL in `src/config.rs` to `v1.18.0`.
> - **Dependencies**:
>   - Bump `flate2` to `1.1.4` in `Cargo.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc59481840e94210e74d980d92a93096ee2b2857. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->