### PR TITLE
fix: stash untracked files during partial stashes when HK_STASH_UNTRACKED=true

### DIFF
--- a/test/stash_untracked_with_partial_stash.bats
+++ b/test/stash_untracked_with_partial_stash.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+    export HK_STASH_UNTRACKED=true
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "partial stash should include untracked files when HK_STASH_UNTRACKED=true" {
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+    steps = new Mapping<String, Step> {
+      ["test-step"] {
+        glob = "tracked.txt"
+        stage = "tracked.txt"
+        fix = "echo 'modified' > tracked.txt"
+      }
+    }
+  }
+}
+PKL
+    git add hk.pkl
+    git commit -m 'init'
+    hk install
+
+    # Create a tracked file with staged changes
+    echo 'original' > tracked.txt
+    git add tracked.txt
+    git commit -m 'add tracked file'
+
+    # Make changes to tracked file and stage them
+    echo 'staged change' > tracked.txt
+    git add tracked.txt
+
+    # Create an untracked file that should be stashed away
+    echo 'untracked content' > untracked_should_be_stashed.txt
+
+    # Verify untracked file exists before commit
+    run test -f untracked_should_be_stashed.txt
+    assert_success
+
+    # Run pre-commit hook - should stash untracked file
+    run git commit -m 'test commit'
+    assert_success
+
+    # The untracked file should NOT have been added to the commit
+    run bash -c "git show HEAD --name-only | grep untracked_should_be_stashed.txt"
+    assert_failure
+
+    # After commit, untracked file should still exist (restored from stash)
+    run test -f untracked_should_be_stashed.txt
+    assert_success
+
+    # Verify untracked file has original content
+    run cat untracked_should_be_stashed.txt
+    assert_output 'untracked content'
+}
+
+@test "untracked files not staged by broad glob when they should have been stashed" {
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+    steps = new Mapping<String, Step> {
+      ["test-formatter"] {
+        glob = "*.txt"
+        stage = "**/*"
+        fix = "cat"
+      }
+    }
+  }
+}
+PKL
+    git add hk.pkl
+    git commit -m 'init'
+    hk install
+
+    # Create a tracked file with changes
+    echo 'tracked' > tracked.txt
+    git add tracked.txt
+    git commit -m 'add tracked'
+
+    # Modify the tracked file
+    echo 'modified' > tracked.txt
+    git add tracked.txt
+
+    # Create an untracked file that matches the stage glob
+    echo 'untracked' > untracked.txt
+
+    # Verify untracked file exists before commit
+    run test -f untracked.txt
+    assert_success
+
+    # Run pre-commit hook
+    run git commit -m 'test commit'
+    assert_success
+
+    # Check what was committed - untracked.txt should NOT be in the commit
+    run bash -c "git show HEAD --name-only | grep untracked.txt"
+    assert_failure
+
+    # Untracked file should still exist in worktree (restored from stash)
+    run test -f untracked.txt
+    assert_success
+}


### PR DESCRIPTION
## Summary

Fixes a bug where untracked files were not being stashed during partial stashes when `HK_STASH_UNTRACKED=true` (the default). This caused untracked files to remain in the working directory during hook execution, which could lead to them being incorrectly staged by steps with broad stage globs like `stage = "**/*"`.

## Changes

1. **In `stash_unstaged()`**: Now includes untracked files in `files_to_stash` when `HK_STASH_UNTRACKED=true`, so the stash operation is triggered even when there are only untracked files.

2. **In `push_stash()`**: When `HK_STASH_UNTRACKED=true`, avoid passing pathspecs to `git stash push --include-untracked`. This allows git to stash all untracked files automatically, rather than trying to specify them as pathspecs (which would fail since untracked files aren't known to git).

## Test

Added `test/stash_untracked_with_partial_stash.bats` to verify the fix.

## Example Issue

Before this fix:
```bash
# Create a staged file
echo 'staged' > tracked.txt
git add tracked.txt

# Create an untracked file
echo 'untracked' > foo

# Commit with a step that has stage = "**/*"
git commit -m 'test'

# Result: foo was incorrectly added to the commit
```

After this fix, `foo` is properly stashed before the hook runs and restored afterward, preventing it from being staged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures partial stashes include and correctly restore untracked files when HK_STASH_UNTRACKED=true, with tests validating the behavior.
> 
> - **Git stash logic**:
>   - `stash_unstaged()`: Includes `status.untracked_files` in `files_to_stash` when `HK_STASH_UNTRACKED=true`.
>   - `push_stash()`: Filters untracked from pathspecs; if no tracked paths and `HK_STASH_UNTRACKED=true`, performs full stash (no pathspecs). Sets `--include-untracked`/`INCLUDE_UNTRACKED` and keeps index.
>   - `pop_stash()`: Uses `git stash show --include-untracked` and restores untracked files directly from `stash^3`, skipping normal merge; retains existing large-file and fixer merge logic.
> - **Tests**:
>   - Adds `test/stash_untracked_with_partial_stash.bats` with two cases ensuring untracked files are stashed, not committed, and restored after partial stashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5e05b345b892578e7d98e17dbd7be7ab6d298be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->