### PR TITLE
Add `tera` to `hk test`'s `expect`

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -34,8 +34,15 @@ local linters = new Mapping<String, Step | Group> {
     glob = List("*.js", "*.ts", "*.yml", "*.yaml") // override the default globs
   }
   ["pkl-format"] = Builtins.pkl_format
-  ["taplo"] = Builtins.taplo
+  ["taplo"] = (Builtins.taplo) {
+    glob = "settings.toml"
+  }
   ["taplo-format"] = Builtins.taplo_format
+  ["docs"] = new Step {
+    glob = "docs/**"
+    check = "mise run docs:build"
+    output_summary = "hide"
+  }
 }
 
 hooks = new {

--- a/hk.pkl
+++ b/hk.pkl
@@ -34,15 +34,8 @@ local linters = new Mapping<String, Step | Group> {
     glob = List("*.js", "*.ts", "*.yml", "*.yaml") // override the default globs
   }
   ["pkl-format"] = Builtins.pkl_format
-  ["taplo"] = (Builtins.taplo) {
-    glob = "settings.toml"
-  }
+  ["taplo"] = Builtins.taplo
   ["taplo-format"] = Builtins.taplo_format
-  ["docs"] = new Step {
-    glob = "docs/**"
-    check = "mise run docs:build"
-    output_summary = "hide"
-  }
 }
 
 hooks = new {

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -826,6 +826,11 @@ class StepTestExpect {
 
   /// Expected files after run: path => full contents (exact match)
   files: Mapping<String, String> = new Mapping<String, String> {}
+
+  /// Expected value of tera variables). Some examples:
+  /// - files: string-escaped, space-separated list of files (can use {{tmp}}))
+  ///          (relevant if you aren't specifying the test `files`)
+  tera: Mapping<String, String> = new Mapping<String, String> {}
 }
 
 class Group {

--- a/pkl/builtins/test/helpers.pkl
+++ b/pkl/builtins/test/helpers.pkl
@@ -36,6 +36,9 @@ class TestMaker {
       files = new Mapping<String, String> {
         [sandboxFilename] = contentAfter
       }
+      tera = new Mapping<String, String> {
+        ["files"] = sandboxFilename
+      }
     }
   }
 

--- a/src/cli/test.rs
+++ b/src/cli/test.rs
@@ -70,11 +70,11 @@ impl Test {
         let jobs = crate::settings::Settings::try_get()?.jobs().get();
         let semaphore = std::sync::Arc::new(Semaphore::new(jobs));
         let mut handles = vec![];
-        for (step_name, step, test_name, test) in to_run {
+        for (step_name, mut step, test_name, test) in to_run {
             let sem = semaphore.clone();
             handles.push(tokio::spawn(async move {
                 let _permit = sem.acquire_owned().await.unwrap();
-                let r = crate::test_runner::run_test_named(&step, &test_name, &test).await;
+                let r = crate::test_runner::run_test_named(&mut step, &test_name, &test).await;
                 (step_name, test_name, r)
             }));
         }

--- a/src/step_test.rs
+++ b/src/step_test.rs
@@ -49,4 +49,7 @@ pub struct StepTestExpect {
     /// Map of path -> full expected file contents (exact match)
     #[serde(default)]
     pub files: IndexMap<String, String>,
+    /// Map of tera variable -> expected value
+    #[serde(default)]
+    pub tera: IndexMap<String, String>,
 }

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -24,7 +24,7 @@ static BASE_CONTEXT: LazyLock<tera::Context> = LazyLock::new(|| {
 
 #[derive(Clone)]
 pub struct Context {
-    ctx: tera::Context,
+    pub ctx: tera::Context,
 }
 
 impl Default for Context {


### PR DESCRIPTION
I'm hoping to move closer to a world where we can test the steps more (via `hk test`) to prove things are working as expected. One way to help with that is by adding expectations about the files in `{{ files }}`.

So this PR adds the ability to assert tera variables in a test's expectations.