### PR TITLE
feat: Add more `test` `run` commands

### DIFF
--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -789,8 +789,13 @@ class Step {
 }
 
 class StepTest {
-  /// What to run: "check", "fix", or "command"
-  run: "check" | "fix" = "check"
+  /// What to run: "check", "check_diff", "fix"
+  /// - "check": Prefer "check" command (if defined), otherwise uses "check_diff" or "check_list_files".
+  /// - "check_list_files": Runs the "check_list_files".
+  /// - "check_diff": Runs the "check_diff" command.
+  /// - "fix": Runs the "fix" command.
+  /// - "fix+check_diff": Runs the "check_diff" command and attempts to apply the diff (a la "fix").
+  run: "check" | "check_list_files" | "check_diff" | "fix" | "fix+check_diff" = "check"
 
   /// Files to pass to the command (used to render {{ files }})
   files: (String | List<String>)?
@@ -826,6 +831,10 @@ class StepTestExpect {
 
   /// Expected files after run: path => full contents (exact match)
   files: Mapping<String, String> = new Mapping<String, String> {}
+
+  /// If `run` was `check_list_files` or `check_diff`, then expect `hk` to have
+  /// parsed these files out of the output.
+  listed_files: List<String>?
 }
 
 class Group {

--- a/pkl/builtins/ruff.pkl
+++ b/pkl/builtins/ruff.pkl
@@ -25,6 +25,8 @@ ruff = new Config.Step {
     ["check good file"] = testMaker.checkPass(after)
     ["fix bad file"] = testMaker.fixPass(before, after)
     ["fix good file"] = testMaker.fixPass(after, after)
+    ["fix+check_diff bad file"] = testMaker.fixWithDiffPass(before, after)
+    ["fix+check_diff good file"] = testMaker.fixWithDiffPass(after, after)
     ["check respects config exclude"] = testMaker.withFilename("excluded.py").checkPass(before)
     ["fix respects config exclude"] = testMaker.withFilename("excluded.py").fixPass(before, before)
   }

--- a/pkl/builtins/test/helpers.pkl
+++ b/pkl/builtins/test/helpers.pkl
@@ -54,6 +54,17 @@ class TestMaker {
   function fixFail(contentsBefore: String, contentsAfter: String, code: Int): Config.StepTest =
     makeTest("fix", contentsBefore, contentsAfter, code)
 
+  /// Make a "fix" test, where the output of `check_diff` should be used
+  function fixWithDiffPass(contentsBefore: String, contentsAfter: String): Config.StepTest =
+    makeTest("fix+check_diff", contentsBefore, contentsAfter, 0)
+
+  /// Make a "fix" test, where the output of `check_diff` should be used
+  function fixWithDiffFail(
+    contentsBefore: String,
+    contentsAfter: String,
+    code: Int,
+  ): Config.StepTest = makeTest("fix+check_diff", contentsBefore, contentsAfter, code)
+
   /// Make a TestMaker (same as this one) but using the provided filename
   function withFilename(newFilename: String): TestMaker = (this) {
     filename = newFilename

--- a/src/cli/test.rs
+++ b/src/cli/test.rs
@@ -70,11 +70,11 @@ impl Test {
         let jobs = crate::settings::Settings::try_get()?.jobs().get();
         let semaphore = std::sync::Arc::new(Semaphore::new(jobs));
         let mut handles = vec![];
-        for (step_name, step, test_name, test) in to_run {
+        for (step_name, mut step, test_name, test) in to_run {
             let sem = semaphore.clone();
             handles.push(tokio::spawn(async move {
                 let _permit = sem.acquire_owned().await.unwrap();
-                let r = crate::test_runner::run_test_named(&step, &test_name, &test).await;
+                let r = crate::test_runner::run_test_named(&mut step, &test_name, &test).await;
                 (step_name, test_name, r)
             }));
         }

--- a/src/step_test.rs
+++ b/src/step_test.rs
@@ -33,7 +33,11 @@ pub struct StepTest {
 pub enum RunKind {
     #[default]
     Check,
+    CheckDiff,
+    CheckListFiles,
     Fix,
+    #[serde(rename = "fix+check_diff")]
+    FixCheckDiff,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
@@ -49,4 +53,6 @@ pub struct StepTestExpect {
     /// Map of path -> full expected file contents (exact match)
     #[serde(default)]
     pub files: IndexMap<String, String>,
+    /// Files expected to be listed (in `check_list_files`/`check_diff` mode)
+    pub listed_files: Option<Vec<String>>,
 }


### PR DESCRIPTION
In pursuit of adding more testing to `hk test`, this PR adds `check_list_files`, `check_diff`, and `fix+check_diff` to the `run` command in `test`.

- `check_diff` just runs `check_diff`. Easy-peasy
- `check_list_files` runs `check_list_files`, and also allows the user to expect `listed_files`.
- `fix+check_diff` runs `check_diff` and attempts to apply the output. If it can't its a failure.