### PR TITLE
fix(hook): preserve configured output_summary label on failure

### DIFF
--- a/src/step/output.rs
+++ b/src/step/output.rs
@@ -46,12 +46,14 @@ impl Step {
             return;
         }
 
-        // On failure, show combined output so diagnostic messages are never
-        // lost regardless of which stream the tool writes to — unless the
-        // step explicitly opted out with `output_summary = "hide"`.
+        // On failure, use combined output so diagnostic messages are never
+        // lost regardless of which stream the tool writes to — but keep
+        // the configured label so tests/users see the expected header.
+        // If the step explicitly opted out with `output_summary = "hide"`,
+        // respect that even on failure.
         if is_failure && self.output_summary != OutputSummary::Hide {
             ctx.hook_ctx
-                .append_step_output(&self.name, OutputSummary::Combined, combined)
+                .append_step_output(&self.name, self.output_summary.clone(), combined)
         } else {
             match self.output_summary {
                 OutputSummary::Stderr => {


### PR DESCRIPTION
## Summary
- PR #772 forced `Combined` output on failure to avoid losing diagnostics, but this changed the summary header label (e.g., `lint output:` instead of `lint stderr:`), breaking #784's tests.
- Uses combined *content* on failure (preserving #772's intent) but keeps the configured *label* so the header matches `output_summary`.
- Fixes CI failures on #806.

## Test plan
- [x] `test/output_summary_no_duplicate.bats` passes locally (both tests)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small change limited to end-of-run output summarization; main risk is subtle behavior differences in how failure output is labeled (and stored) for downstream consumers/tests.
> 
> **Overview**
> On step failure, the summary now saves **combined output content** to avoid losing diagnostics, but preserves the step’s configured `output_summary` *mode/label* instead of forcing `Combined`.
> 
> `output_summary = "hide"` is still respected even on failure, preventing any summary output from being recorded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0090e4bdda407caf28b9af1573fedbea6faf99e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->