### PR TITLE
chore: release v1.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [1.42.0](https://github.com/jdx/hk/compare/v1.41.1..v1.42.0) - 2026-04-12
+
+### 🚀 Features
+
+- add {{ hook_args }} template to pass to downstream commands by [@JohanLorenzo](https://github.com/JohanLorenzo) in [#807](https://github.com/jdx/hk/pull/807)
+
+### 🐛 Bug Fixes
+
+- **(step)** preserve cmd.exe quoting for {{files}} on Windows by [@jdx](https://github.com/jdx) in [#824](https://github.com/jdx/hk/pull/824)
+
+### 🛡️ Security
+
+- **(deps)** update dependency eslint to v10 by [@renovate[bot]](https://github.com/renovate[bot]) in [#813](https://github.com/jdx/hk/pull/813)
+
+### 📦️ Dependency Updates
+
+- update taiki-e/upload-rust-binary-action digest to 10c1cf6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#810](https://github.com/jdx/hk/pull/810)
+- update nick-fields/retry action to v4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#812](https://github.com/jdx/hk/pull/812)
+- update anthropics/claude-code-action digest to 657fb7c by [@renovate[bot]](https://github.com/renovate[bot]) in [#809](https://github.com/jdx/hk/pull/809)
+- update dependency typescript to v6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#814](https://github.com/jdx/hk/pull/814)
+- update rust crate demand to v2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#815](https://github.com/jdx/hk/pull/815)
+- update rust crate expr-lang to v1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#816](https://github.com/jdx/hk/pull/816)
+- update rust crate similar to v3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#817](https://github.com/jdx/hk/pull/817)
+- update rust crate toml to v1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#820](https://github.com/jdx/hk/pull/820)
+- update actions/upload-artifact digest to 043fb46 by [@renovate[bot]](https://github.com/renovate[bot]) in [#821](https://github.com/jdx/hk/pull/821)
+- update anthropics/claude-code-action digest to b47fd72 by [@renovate[bot]](https://github.com/renovate[bot]) in [#822](https://github.com/jdx/hk/pull/822)
+
+### New Contributors
+
+- @JohanLorenzo made their first contribution in [#807](https://github.com/jdx/hk/pull/807)
+
 ## [1.41.1](https://github.com/jdx/hk/compare/v1.41.0..v1.41.1) - 2026-04-10
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1297,7 +1297,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.41.1"
+version = "1.42.0"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -1332,7 +1332,7 @@ dependencies = [
  "serde_yaml",
  "shell-quote",
  "shell-words",
- "similar 3.0.0",
+ "similar 3.1.0",
  "siphasher",
  "strum 0.28.0",
  "tempfile",
@@ -1448,15 +1448,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1846,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2437,9 +2436,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pklr"
@@ -2567,7 +2566,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2627,9 +2626,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2637,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -2957,9 +2956,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3289,9 +3288,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "similar"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d0b06eba54f0ca0770f970a3e89823e766ca638dd940f8469fa0fa50c75396"
+checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
 dependencies = [
  "bstr",
 ]
@@ -3969,7 +3968,7 @@ dependencies = [
  "tera",
  "thiserror 2.0.18",
  "versions",
- "xx 2.5.3",
+ "xx 2.5.4",
 ]
 
 [[package]]
@@ -4067,9 +4066,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4080,9 +4079,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4090,9 +4089,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4100,9 +4099,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4113,9 +4112,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4156,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4760,7 +4759,7 @@ dependencies = [
  "miette",
  "once_cell",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "reqwest 0.13.2",
  "serde",
@@ -4781,16 +4780,16 @@ dependencies = [
 
 [[package]]
 name = "xx"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cdbadb4cf2151c38b7c07c1383284bcf63b51baac062c83bd8286962b41dd9"
+checksum = "d61141ccbc979c1421bc450f1a800196abc073e0deccb0adcb100c96238b33e2"
 dependencies = [
  "duct",
  "filetime",
  "homedir",
  "log",
  "miette",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "strsim",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ license = "MIT"
 name = "hk"
 repository = "https://github.com/jdx/hk"
 rust-version = "1.88.0"
-version = "1.41.1"
+version = "1.42.0"
 
 [[bin]]
 name = "generate-docs"

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 90+ pre-configured linters and formatters through the `Builtins` mod
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3804,7 +3804,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.41.1",
+  "version": "1.42.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.41.1
+**Version**: 1.42.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // linters can be manually defined
@@ -208,8 +208,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -242,7 +242,7 @@ Add steps to your hkrc. hk merges them into every project's hooks — steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -335,7 +335,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,8 +51,8 @@ The global configuration file follows the same format as `hk.pkl` and can be use
 This will generate a `hk.pkl` file in the root of the repository, here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // linters can be manually defined

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -43,7 +43,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
 
 `pre-commit` {
     ["prelint"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,8 +3,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,8 +3,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,8 +3,8 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,8 +4,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -7,8 +7,8 @@
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
 
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -7,8 +7,8 @@
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
 
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -7,8 +7,8 @@
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -8,8 +8,8 @@
 /// * Sorts imports with isort
 /// * Validates with flake8
 
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.41.1/hk@1.41.1#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
 amends "pkl/Config.pkl"
 import "pkl/Builtins.pkl"
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.41.1"
+version "1.42.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)" hide=#true global=#true {


### PR DESCRIPTION
### 🚀 Features

- add {{ hook_args }} template to pass to downstream commands by [@JohanLorenzo](https://github.com/JohanLorenzo) in [#807](https://github.com/jdx/hk/pull/807)

### 🐛 Bug Fixes

- **(step)** preserve cmd.exe quoting for {{files}} on Windows by [@jdx](https://github.com/jdx) in [#824](https://github.com/jdx/hk/pull/824)

### 🛡️ Security

- **(deps)** update dependency eslint to v10 by [@renovate[bot]](https://github.com/renovate[bot]) in [#813](https://github.com/jdx/hk/pull/813)

### 📦️ Dependency Updates

- update taiki-e/upload-rust-binary-action digest to 10c1cf6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#810](https://github.com/jdx/hk/pull/810)
- update nick-fields/retry action to v4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#812](https://github.com/jdx/hk/pull/812)
- update anthropics/claude-code-action digest to 657fb7c by [@renovate[bot]](https://github.com/renovate[bot]) in [#809](https://github.com/jdx/hk/pull/809)
- update dependency typescript to v6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#814](https://github.com/jdx/hk/pull/814)
- update rust crate demand to v2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#815](https://github.com/jdx/hk/pull/815)
- update rust crate expr-lang to v1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#816](https://github.com/jdx/hk/pull/816)
- update rust crate similar to v3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#817](https://github.com/jdx/hk/pull/817)
- update rust crate toml to v1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#820](https://github.com/jdx/hk/pull/820)
- update actions/upload-artifact digest to 043fb46 by [@renovate[bot]](https://github.com/renovate[bot]) in [#821](https://github.com/jdx/hk/pull/821)
- update anthropics/claude-code-action digest to b47fd72 by [@renovate[bot]](https://github.com/renovate[bot]) in [#822](https://github.com/jdx/hk/pull/822)

### New Contributors

- @JohanLorenzo made their first contribution in [#807](https://github.com/jdx/hk/pull/807)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: version bumps, regenerated CLI/docs, and routine dependency lockfile updates with no functional code changes in this PR.
> 
> **Overview**
> Bumps `hk` to **v1.42.0** and adds the corresponding `CHANGELOG.md` release notes.
> 
> Regenerates versioned docs/CLI artifacts (`docs/cli/*`, `hk.usage.kdl`) and updates all documentation/examples to reference the `v1.42.0` Pkl package URLs. Updates `Cargo.lock` for minor dependency revisions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9834f9d17a1d966e009989fc63684f5f2d6963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->