### PR TITLE
fix(step): preserve cmd.exe quoting for {{files}} on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,8 @@ jobs:
           # Run only basic tests that don't require pkl to avoid hangs
           ./e2e-win/run.ps1 -TestName "*version*"
           ./e2e-win/run.ps1 -TestName "*help*"
+          # Regression test for discussion #823 (cmd.exe {{files}} quoting)
+          ./e2e-win/run.ps1 -TestName "*{{files}} template*"
   final:
     needs:
       - build

--- a/e2e-win/check.Tests.ps1
+++ b/e2e-win/check.Tests.ps1
@@ -80,11 +80,13 @@ sys.exit(0)
             # Use Set-Content (no BOM) so python parses the script cleanly.
             Set-Content -Path "check_args.py" -Value $checker -Encoding ascii
 
-            # pkl amends URIs use forward slashes; normalize the Windows path
-            # from $env:PKL_PATH so pkl can resolve Config.pkl.
-            $pklPath = $env:PKL_PATH -replace '\\', '/'
+            # pkl's default `--allowed-modules` allowlist accepts `file:` URIs
+            # but rejects bare Windows absolute paths like `D:/a/hk/...`, so
+            # build an explicit `file:///` URI from `$env:PKL_PATH`.
+            $pklPath = (Resolve-Path $env:PKL_PATH).Path -replace '\\', '/'
+            $pklUri = "file:///$pklPath/Config.pkl"
             $config = @"
-amends "$pklPath/Config.pkl"
+amends "$pklUri"
 
 hooks {
     ["check"] {

--- a/e2e-win/check.Tests.ps1
+++ b/e2e-win/check.Tests.ps1
@@ -77,10 +77,14 @@ if missing:
 print('OK', sys.argv[1:])
 sys.exit(0)
 "@
-            $checker | Out-File -FilePath "check_args.py" -Encoding utf8
+            # Use Set-Content (no BOM) so python parses the script cleanly.
+            Set-Content -Path "check_args.py" -Value $checker -Encoding ascii
 
+            # pkl amends URIs use forward slashes; normalize the Windows path
+            # from $env:PKL_PATH so pkl can resolve Config.pkl.
+            $pklPath = $env:PKL_PATH -replace '\\', '/'
             $config = @"
-amends "$env:PKL_PATH/Config.pkl"
+amends "$pklPath/Config.pkl"
 
 hooks {
     ["check"] {
@@ -93,16 +97,25 @@ hooks {
     }
 }
 "@
-            $config | Out-File -FilePath "hk.pkl" -Encoding utf8
+            Set-Content -Path "hk.pkl" -Value $config -Encoding ascii
 
-            "simple" | Out-File -FilePath "simple.txt" -Encoding utf8
-            "spaced" | Out-File -FilePath "hello world.txt" -Encoding utf8
+            Set-Content -Path "simple.txt" -Value "simple" -Encoding ascii
+            Set-Content -Path "hello world.txt" -Value "spaced" -Encoding ascii
 
             git add -A
             git commit -m "initial" | Out-Null
 
             $output = hk check --all 2>&1 | Out-String
-            $LASTEXITCODE | Should -Be 0
+            $exit = $LASTEXITCODE
+            if ($exit -ne 0 -or $output -notmatch 'OK ') {
+                Write-Host "=== hk check --all exit: $exit ==="
+                Write-Host $output
+                Write-Host "=== hk.pkl ==="
+                Write-Host (Get-Content hk.pkl -Raw)
+                Write-Host "=== files ==="
+                Get-ChildItem | ForEach-Object { Write-Host $_.Name }
+            }
+            $exit | Should -Be 0 -Because "hk check --all should succeed; output:`n$output"
             $output | Should -Not -Match 'LITERAL QUOTES IN ARGS'
             $output | Should -Not -Match 'MISSING FILES'
             # Positive assertion: if `{{files}}` silently expanded to nothing,

--- a/e2e-win/check.Tests.ps1
+++ b/e2e-win/check.Tests.ps1
@@ -45,4 +45,69 @@ hooks {
             Remove-Item -Path $testDir -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
+
+    It '{{files}} template passes clean arguments on Windows (no literal quotes)' {
+        # Regression test for https://github.com/jdx/hk/discussions/823
+        # Rust's `Command::arg` on Windows applies MSVCRT-style argv escaping
+        # which conflicts with cmd.exe's own quoting, mangling the already
+        # shell-quoted `{{files}}` string into args with literal `"` chars.
+        $testDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $testDir | Out-Null
+        Set-Location $testDir
+
+        try {
+            git init | Out-Null
+            git config user.email "test@test.com"
+            git config user.name "Test"
+
+            # A helper script that fails if any argument contains a literal
+            # double-quote character, and also fails if any claimed file path
+            # does not actually exist on disk.
+            $checker = @"
+import sys
+bad = [a for a in sys.argv[1:] if '"' in a]
+if bad:
+    print('LITERAL QUOTES IN ARGS:', bad)
+    sys.exit(2)
+import os
+missing = [a for a in sys.argv[1:] if not os.path.exists(a)]
+if missing:
+    print('MISSING FILES:', missing)
+    sys.exit(3)
+print('OK', sys.argv[1:])
+sys.exit(0)
+"@
+            $checker | Out-File -FilePath "check_args.py" -Encoding utf8
+
+            $config = @"
+amends "$env:PKL_PATH/Config.pkl"
+
+hooks {
+    ["check"] {
+        steps {
+            ["files-template"] {
+                glob = "*.txt"
+                check = "python check_args.py {{files}}"
+            }
+        }
+    }
+}
+"@
+            $config | Out-File -FilePath "hk.pkl" -Encoding utf8
+
+            "simple" | Out-File -FilePath "simple.txt" -Encoding utf8
+            "spaced" | Out-File -FilePath "hello world.txt" -Encoding utf8
+
+            git add -A
+            git commit -m "initial" | Out-Null
+
+            $output = hk check --all 2>&1 | Out-String
+            $LASTEXITCODE | Should -Be 0
+            $output | Should -Not -Match 'LITERAL QUOTES IN ARGS'
+            $output | Should -Not -Match 'MISSING FILES'
+        } finally {
+            Set-Location $script:originalPath
+            Remove-Item -Path $testDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
 }

--- a/e2e-win/check.Tests.ps1
+++ b/e2e-win/check.Tests.ps1
@@ -105,6 +105,11 @@ hooks {
             $LASTEXITCODE | Should -Be 0
             $output | Should -Not -Match 'LITERAL QUOTES IN ARGS'
             $output | Should -Not -Match 'MISSING FILES'
+            # Positive assertion: if `{{files}}` silently expanded to nothing,
+            # check_args.py would print `OK []` and the negative matches above
+            # would still pass. Require both files to show up in the OK line.
+            $output | Should -Match 'OK .*simple\.txt'
+            $output | Should -Match 'OK .*hello world\.txt'
         } finally {
             Set-Location $script:originalPath
             Remove-Item -Path $testDir -Recurse -Force -ErrorAction SilentlyContinue

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -152,14 +152,21 @@ impl Step {
             for arg in shell[1..].iter() {
                 cmd = cmd.arg(arg);
             }
-            cmd
+            cmd.arg(&run)
         } else if cfg!(windows) {
-            CmdLineRunner::new("cmd.exe").arg("/c")
+            // Use `raw_arg` so cmd-appropriate quoting produced by
+            // `ShellType::Cmd::quote` (e.g. rendered `{{files}}` paths) is
+            // passed through verbatim, bypassing Rust's MSVCRT-style
+            // re-escaping which cmd.exe does not understand.
+            CmdLineRunner::new_direct("cmd.exe").arg("/c").raw_arg(&run)
         } else {
-            CmdLineRunner::new("sh").arg("-o").arg("errexit").arg("-c")
+            CmdLineRunner::new("sh")
+                .arg("-o")
+                .arg("errexit")
+                .arg("-c")
+                .arg(&run)
         };
         cmd = cmd
-            .arg(&run)
             .with_pr(job.progress.as_ref().unwrap().clone())
             .with_cancel_token(ctx.hook_ctx.failed.clone())
             .show_stderr_on_error(false)

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -145,19 +145,30 @@ impl Step {
                 trace!("{self}: {}", file.display());
             }
         }
+        // On Windows, `cmd.exe` has its own quoting rules that collide with
+        // Rust's MSVCRT-style argv escaping. `ShellType::Cmd::quote` produces
+        // cmd-appropriate quoting for rendered `{{files}}` / `{{workspace_files}}`
+        // strings, so we must append the final command line verbatim via
+        // `raw_arg` — otherwise Rust re-escapes the already-quoted payload and
+        // cmd.exe delivers tools arguments with literal `"` characters embedded.
+        let use_raw_cmd = cfg!(windows) && matches!(self.shell_type(), ShellType::Cmd);
         let mut cmd = if let Some(shell) = &self.shell {
             let shell = shell.to_string();
             let shell = shell.split_whitespace().collect_vec();
-            let mut cmd = CmdLineRunner::new(shell[0]);
+            let mut cmd = if use_raw_cmd {
+                CmdLineRunner::new_direct(shell[0])
+            } else {
+                CmdLineRunner::new(shell[0])
+            };
             for arg in shell[1..].iter() {
                 cmd = cmd.arg(arg);
             }
-            cmd.arg(&run)
-        } else if cfg!(windows) {
-            // Use `raw_arg` so cmd-appropriate quoting produced by
-            // `ShellType::Cmd::quote` (e.g. rendered `{{files}}` paths) is
-            // passed through verbatim, bypassing Rust's MSVCRT-style
-            // re-escaping which cmd.exe does not understand.
+            if use_raw_cmd {
+                cmd.raw_arg(&run)
+            } else {
+                cmd.arg(&run)
+            }
+        } else if use_raw_cmd {
             CmdLineRunner::new_direct("cmd.exe").arg("/c").raw_arg(&run)
         } else {
             CmdLineRunner::new("sh")


### PR DESCRIPTION
Fixes #823.

## Summary

- On Windows, Rust's `Command::arg` applies MSVCRT-style argv escaping that collides with `cmd.exe`'s own quoting, so a rendered `{{files}}` payload (already quoted via `ShellType::Cmd::quote`) reaches tools with literal `"` characters in the arguments. In practice this silently broke `ruff`, `biome`, and any other `{{files}}`-based check — they'd exit 0 while processing zero files, so hk would report success on malformed invocations.
- Switch the Windows `cmd.exe /c` path in `src/step/runner.rs` to use a new `CmdLineRunner::raw_arg` (paired with `new_direct` to avoid the implicit `cmd.exe /c` wrapping), so the rendered command string is appended verbatim via `CommandExt::raw_arg` and cmd.exe can parse its own quoting without Rust interference. Also covers `{{workspace_files}}`, which goes through the same shell-quoting path.
- Requires ensembler PR: jdx/ensembler#89 (submodule pointer bumped in this PR).

## Test plan

- [x] `cargo check` (linux) passes.
- [x] `cargo check --target x86_64-pc-windows-gnu` passes.
- [x] Added a Pester regression test `{{files}} template passes clean arguments on Windows (no literal quotes)` in `e2e-win/check.Tests.ps1`: materializes files including `hello world.txt`, renders `python check_args.py {{files}}`, and fails if any arg contains a literal `"` or references a missing path.
- [x] Wired the new Pester test into the `ci-windows` job in `.github/workflows/ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how step commands are executed on Windows `cmd.exe` by switching to a raw-argument path; this can affect argument parsing/escaping and could alter behavior for existing Windows hooks.
> 
> **Overview**
> Fixes Windows `cmd.exe` execution so rendered `{{files}}`/`{{workspace_files}}` strings are passed *verbatim* to the shell (using `CmdLineRunner::new_direct` + `raw_arg`) instead of being re-escaped by Rust, preventing literal quote characters from reaching tools and silently dropping files.
> 
> Adds a Windows Pester regression test that validates `{{files}}` expands to real paths (including spaces) without embedded quotes, and wires that test into the `ci-windows` GitHub Actions job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6693338538706d9180734ba78ce820f285fc5d59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->