### PR TITLE
feat: add {{ hook_stdin }} for pre-push stdin forwarding

### DIFF
--- a/src/cli/run/post_rewrite.rs
+++ b/src/cli/run/post_rewrite.rs
@@ -1,3 +1,6 @@
+use std::io::IsTerminal;
+use std::io::Read;
+
 use crate::Result;
 use crate::hook_options::HookOptions;
 
@@ -12,6 +15,14 @@ pub struct PostRewrite {
 impl PostRewrite {
     pub async fn run(mut self) -> Result<()> {
         self.hook.tctx.insert("hook_args", &self.command);
+        let hook_stdin = if std::io::stdin().is_terminal() {
+            String::new()
+        } else {
+            let mut input = String::new();
+            std::io::stdin().read_to_string(&mut input)?;
+            input
+        };
+        self.hook.tctx.insert("hook_stdin", &hook_stdin);
         self.hook.run("post-rewrite").await
     }
 }

--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -42,10 +42,12 @@ impl PrePush {
             ),
         );
         let to_be_updated_refs = if std::io::stdin().is_terminal() {
+            self.hook.tctx.insert("hook_stdin", "");
             vec![]
         } else {
             let mut input = String::new();
             std::io::stdin().read_to_string(&mut input)?;
+            self.hook.tctx.insert("hook_stdin", &input);
             input
                 .lines()
                 .filter(|line| !line.is_empty())

--- a/test/hook_stdin.bats
+++ b/test/hook_stdin.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+teardown() {
+    _common_teardown
+}
+
+@test "post-rewrite hook_stdin contains old and new SHAs on amend" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["post-rewrite"] {
+        steps {
+            ["capture"] {
+                check = "cat > hook_stdin.txt"
+                stdin = "{{ hook_stdin }}"
+            }
+        }
+    }
+}
+EOF
+    hk install
+    echo "a" > a.txt && git add a.txt && git commit -m "init"
+    OLD_SHA=$(git rev-parse HEAD)
+    git commit --amend -m "amended"
+    NEW_SHA=$(git rev-parse HEAD)
+    run cat hook_stdin.txt
+    assert_output --partial "$OLD_SHA"
+    assert_output --partial "$NEW_SHA"
+}
+
+@test "pre-push hook_stdin forwards git ref data to steps" {
+    if [ "$HK_LIBGIT2" = "0" ]; then
+        skip "libgit2 is not installed"
+    fi
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-push"] {
+        steps {
+            ["capture"] {
+                check = "cat > hook_stdin.txt"
+                stdin = "{{ hook_stdin }}"
+            }
+        }
+    }
+}
+EOF
+    echo "a" > a.txt && git add a.txt && git commit -m "init"
+    git init --bare ../remote.git
+    git remote add origin ../remote.git
+    git push -u origin main
+    hk install
+    echo "b" > b.txt && git add b.txt && git commit -m "second"
+    git push origin main
+    run cat hook_stdin.txt
+    assert_output --regexp "refs/heads/main [a-f0-9]+ refs/heads/main [a-f0-9]+"
+}
+
+@test "pre-push hook_stdin works with git-lfs" {
+    if [ "$HK_LIBGIT2" = "0" ]; then
+        skip "libgit2 is not installed"
+    fi
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-push"] {
+        steps {
+            ["git-lfs"] {
+                check = "git lfs pre-push {{ hook_args }}"
+                stdin = "{{ hook_stdin }}"
+            }
+        }
+    }
+}
+EOF
+    echo "*.bin filter=lfs diff=lfs merge=lfs -text" > .gitattributes
+    git lfs install --local
+    git config lfs.standalonetransferagent lfs-standalone-file
+    dd if=/dev/urandom bs=1024 count=1 of=test.bin 2>/dev/null
+    git add .gitattributes test.bin && git commit -m "init with lfs"
+    git init --bare ../lfs-remote.git
+    git remote add origin ../lfs-remote.git
+    git push -u origin main
+    hk install
+    dd if=/dev/urandom bs=1024 count=1 of=test2.bin 2>/dev/null
+    git add test2.bin && git commit -m "second lfs file"
+    run git push origin main
+    assert_success
+    # Verify LFS objects were actually transferred to the remote
+    local remote_lfs_count
+    remote_lfs_count=$(find ../lfs-remote.git/lfs/objects -type f 2>/dev/null | wc -l | tr -d ' ')
+    [ "$remote_lfs_count" -eq 2 ]
+}


### PR DESCRIPTION
Hey again! Thank you very much for merging and releasing #807! It's been working great with almost all `git lfs` hooks. There's one I missed in my original PR: `pre-push`.  While `{{ hook_args }}` solved positional argument forwarding, `git lfs pre-push` also needs **stdin**. `git` pipes ref data through it so LFS knows which objects to upload.

  Currently, hk's `PrePush` handler consumes stdin for its own ref resolution, leaving nothing for step commands. This PR preserves the raw stdin as `{{ hook_stdin }}` so steps can pipe it via the existing `stdin` field.

  ## The problem

  `git lfs pre-push` receives ref data via stdin:
  refs/heads/main  refs/heads/main

  Without it, `git lfs pre-push` exits 0 silently and uploads nothing. The remote then rejects the push:

```
  $ git push origin main
    files - Fetching git status
  ✔ files - Fetching files between refs/remotes/origin/main and HEAD (1 file)
  ❯ git-lfs
    git-lfs – 0 files –  – git lfs pre-push origin URL
  ✔ git-lfs
  remote: LFS objects are missing. Ensure LFS is properly set up or try a manual "git lfs push --all".
   ! [remote rejected]   main -> main (pre-receive hook declined)
```

  ## After the fix

```
  $ git push origin main
    files - Fetching git status
  ✔ files - Fetching files between refs/remotes/origin/main and HEAD (1 file)
  ❯ git-lfs
    git-lfs – 0 files –  – git lfs pre-push origin URL
    git-lfs – Uploading LFS objects: 100% (1/1), 0 B | 0 B/s, done.
  ✔ git-lfs
  To URL
     cdd0595..21798fe  main -> main
```

  ## Steps to reproduce locally

```
  mkdir /tmp/hk-lfs-test && cd /tmp/hk-lfs-test
  git init && git lfs install
  echo "*.bin filter=lfs diff=lfs merge=lfs -text" > .gitattributes

  cat > hk.pkl << 'EOF'
  amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
  hooks {
      ["pre-push"] {
          steps {
              ["git-lfs"] {
                  check = "git lfs pre-push {{ hook_args }}"
                  stdin = "{{ hook_stdin }}"
              }
          }
      }
  }
  EOF

  dd if=/dev/urandom bs=1024 count=5 of=big.bin 2>/dev/null
  git add .gitattributes hk.pkl big.bin && git commit -m "init"
  git init --bare ../hk-lfs-remote.git
  git remote add origin ../hk-lfs-remote.git
  HK=0 git push -u origin main          # initial push without hk
  git remote set-head origin main

  hk install
  dd if=/dev/urandom bs=1024 count=5 of=big2.bin 2>/dev/null
  git add big2.bin && git commit -m "second"
  git push origin main                   # should show "Uploading LFS objects"
```

  ## Usage

  ```pkl
  hooks {
      ["pre-push"] {
          steps {
              ["git-lfs"] {
                  check = "git lfs pre-push {{ hook_args }}"
                  stdin = "{{ hook_stdin }}"
              }
          }
      }
  }
```