### PR TITLE
chore: release v1.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [1.43.0](https://github.com/jdx/hk/compare/v1.42.0..v1.43.0) - 2026-04-16
+
+### 🚀 Features
+
+- **(harper)** add harper-cli config to hk builtin config by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#714](https://github.com/jdx/hk/pull/714)
+- add {{ hook_stdin }} for pre-push stdin forwarding by [@JohanLorenzo](https://github.com/JohanLorenzo) in [#825](https://github.com/jdx/hk/pull/825)
+
+### 🐛 Bug Fixes
+
+- **(release)** add linux musl targets by [@jdx](https://github.com/jdx) in [#829](https://github.com/jdx/hk/pull/829)
+
+### 🔍 Other Changes
+
+- drop sub-crate submodules and publish hk to crates.io by [@jdx](https://github.com/jdx) in [#830](https://github.com/jdx/hk/pull/830)
+
+### 📦️ Dependency Updates
+
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#826](https://github.com/jdx/hk/pull/826)
+
 ## [1.42.0](https://github.com/jdx/hk/compare/v1.41.1..v1.42.0) - 2026-04-12
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,7 +1071,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.42.0"
+version = "1.43.0"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "hk"
 repository = "https://github.com/jdx/hk"
 rust-version = "1.88.0"
-version = "1.42.0"
+version = "1.43.0"
 
 [[bin]]
 name = "generate-docs"

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 90+ pre-configured linters and formatters through the `Builtins` mod
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -3804,7 +3804,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.42.0",
+  "version": "1.43.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.42.0
+**Version**: 1.43.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // linters can be manually defined
@@ -208,8 +208,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -242,7 +242,7 @@ Add steps to your hkrc. hk merges them into every project's hooks — steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -335,7 +335,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,8 +51,8 @@ The global configuration file follows the same format as `hk.pkl` and can be use
 This will generate a `hk.pkl` file in the root of the repository, here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // linters can be manually defined

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -43,7 +43,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
 
 `pre-commit` {
     ["prelint"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,8 +3,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,8 +3,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,8 +3,8 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,8 +4,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -7,8 +7,8 @@
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
 
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -7,8 +7,8 @@
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
 
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -7,8 +7,8 @@
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -8,8 +8,8 @@
 /// * Sorts imports with isort
 /// * Validates with flake8
 
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.43.0/hk@1.43.0#/Config.pkl"
 amends "pkl/Config.pkl"
 import "pkl/Builtins.pkl"
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.42.0"
+version "1.43.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)" hide=#true global=#true {


### PR DESCRIPTION
### 🚀 Features

- **(harper)** add harper-cli config to hk builtin config by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#714](https://github.com/jdx/hk/pull/714)
- add {{ hook_stdin }} for pre-push stdin forwarding by [@JohanLorenzo](https://github.com/JohanLorenzo) in [#825](https://github.com/jdx/hk/pull/825)

### 🐛 Bug Fixes

- **(release)** add linux musl targets by [@jdx](https://github.com/jdx) in [#829](https://github.com/jdx/hk/pull/829)

### 🔍 Other Changes

- drop sub-crate submodules and publish hk to crates.io by [@jdx](https://github.com/jdx) in [#830](https://github.com/jdx/hk/pull/830)

### 📦️ Dependency Updates

- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#826](https://github.com/jdx/hk/pull/826)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version bumps and documentation/URL updates) with no functional code changes shown in the diff.
> 
> **Overview**
> Updates the project to **v1.43.0** by bumping the crate/version metadata (`Cargo.toml`, `Cargo.lock`, `hk.usage.kdl`) and regenerating CLI docs/versioned artifacts (`docs/cli/*`).
> 
> Refreshes documentation and example configs to reference the new release Pkl package URLs (`v1.43.0`) and adds the `1.43.0` entry to `CHANGELOG.md` with the release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 609fc1ddb8cdbaf60f030cc717dd0d36b95c672f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->