### PR TITLE
fix(release): add linux musl targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,12 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             build-tool: cargo
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            build-tool: cross
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            build-tool: cross
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             build-tool: cross


### PR DESCRIPTION
## Summary
- add `x86_64-unknown-linux-musl` to the release workflow
- add `aarch64-unknown-linux-musl` to the release workflow
- publish Alpine-friendly release artifacts alongside the existing GNU Linux builds

## Validation
- `cross build --target x86_64-unknown-linux-musl --features git2/vendored-libgit2,git2/vendored-openssl`
- `actionlint .github/workflows/release.yml`

Closes #828

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that expands the CI build matrix; main risk is longer builds or target-specific build failures.
> 
> **Overview**
> The release workflow now builds additional Linux *musl* binaries by adding `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` to the `build-binaries` matrix (using `cross`).
> 
> This expands the set of published artifacts to include Alpine-friendly builds alongside the existing GNU Linux, macOS, and Windows targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3acff03dff5215ac5b2bb23350a33310f9b6e40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->