### PR TITLE
feat(cocogitto): add cocogitto conventional commits config to hk builtin config

### DIFF
--- a/pkl/builtins/cocogitto_commit_msg.pkl
+++ b/pkl/builtins/cocogitto_commit_msg.pkl
@@ -1,0 +1,14 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+
+@Builtins.meta {
+  category = "Special Purpose"
+  description = "Conventional commits linter"
+  project_indicators {
+    new { file = "cog.toml" }
+  }
+}
+cocogitto_commit_msg = new Config.Step {
+  // Reference: https://github.com/cocogitto/cocogitto/blob/7.0.0/cog.toml#L62-L63
+  check = "cog --quiet verify --file {{commit_msg_file}}"
+}


### PR DESCRIPTION
Add [cocogitto](https://docs.cocogitto.io/) as a new builtin linter for commit messages.

Add `cocogitto_commit_msg` builtin for validating commit messages against the Conventional Commits specification using `cog verify`.

The builtin is named `cocogitto_commit_msg` to distinguish it from other potential cocogitto builtins (e.g., `cog check` for history validation). It uses the `{{commit_msg_file}}` template variable, making it suitable for use in the `commit-msg` git hook.

``` console
$ cat foo.txt
feat: foobar
$ cog --quiet verify --file foo.txt

$ echo $?
0
$ cat bar.txt
eat: foobar
$ cog --quiet verify --file bar.txt
Error: Errored commit: not committed <hituzi no sippo>
        Commit message:'eat: foobar'
        Error:Commit type `eat` not allowed
$ echo $?
1
```