### PR TITLE
fix: use text progress in CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
  "ignore",
  "indexmap 2.14.0",
  "infer",
+ "is_ci",
  "itertools",
  "libc",
  "log",
@@ -1472,6 +1473,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ globset            = "0.4"
 ignore             = "0.4"
 indexmap           = { version = "2", features = ["serde"] }
 infer              = "0.19"
+is_ci              = "1"
 itertools          = "0.14"
 libc               = "0.2"
 log                = "0.4"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -98,7 +98,7 @@ pub async fn run() -> Result<()> {
         silent: args.silent,
     });
 
-    if !console::user_attended_stderr() || args.no_progress {
+    if is_ci::cached() || !console::user_attended_stderr() || args.no_progress {
         clx::progress::set_output(ProgressOutput::Text);
     }
     if args.verbose > 1 {


### PR DESCRIPTION
## Summary

- add `is_ci` detection to hk's CLI startup
- force clx progress into text mode in known CI environments, even when stderr appears interactive
- keep local interactive progress behavior unchanged outside CI

## Why

Some CI systems allocate a pseudo-TTY, so `console::user_attended_stderr()` can report an interactive stderr while the log collector still strips cursor-control escapes and records spinner frames as noisy log rows.

## Validation

- `cargo fmt --check`
- `cargo check`
- local pre-commit hook via `git commit`
- local pre-push hook via `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the CLI progress-output selection logic and adds a small dependency, with behavior primarily affecting CI output formatting.
> 
> **Overview**
> Forces `clx` progress output to `Text` when running under known CI environments (via `is_ci`), even if stderr appears to be attached to a TTY, reducing noisy spinner escape sequences in CI logs.
> 
> Adds the `is_ci` crate dependency and wires it into CLI startup progress-mode detection; local interactive behavior remains unchanged outside CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1edb211fbf5c34beb3fc4b784fd8cb8358ed8481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->