### PR TITLE
feat(git): support GIT_DIR/GIT_WORK_TREE for bare-repo dotfile managers

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -147,9 +147,11 @@ pub async fn run() -> Result<()> {
     // - Migrate: avoid errors during migration with potentially invalid configs
     // - Completion/Usage: shell completion generation shouldn't require valid config
     // - Version: just prints version info
+    // - Builtins: just lists compiled-in builtin names, no project config needed
     let settings = if matches!(
         args.command,
-        Commands::Init(_)
+        Commands::Builtins(_)
+            | Commands::Init(_)
             | Commands::Migrate(_)
             | Commands::Completion(_)
             | Commands::Usage(_)

--- a/src/git.rs
+++ b/src/git.rs
@@ -106,20 +106,41 @@ pub enum StashMethod {
 
 impl Git {
     pub fn new() -> Result<Self> {
-        let cwd = std::env::current_dir()?;
-        let root = xx::file::find_up(&cwd, &[".git"])
-            .and_then(|p| p.parent().map(|p| p.to_path_buf()))
-            .ok_or(eyre!("failed to find git repository"))?;
-        std::env::set_current_dir(&root)?;
+        // Respect GIT_DIR / GIT_WORK_TREE so hk works with bare-repo dotfile
+        // managers like YADM where there is no `.git` in the work tree.
+        let has_git_env =
+            std::env::var_os("GIT_DIR").is_some() || std::env::var_os("GIT_WORK_TREE").is_some();
+
+        if !has_git_env {
+            let cwd = std::env::current_dir()?;
+            let root = xx::file::find_up(&cwd, &[".git"])
+                .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+                .ok_or(eyre!("failed to find git repository"))?;
+            std::env::set_current_dir(&root)?;
+        }
         let repo = if *env::HK_LIBGIT2 {
             debug!("libgit2: true");
-            let repo = Repository::open(".").wrap_err("failed to open repository")?;
-            if let Some(index_file) = &*env::GIT_INDEX_FILE {
-                // sets index to .git/index.lock which is used in the case of `git commit -a`
-                let mut index = git2::Index::open(index_file).wrap_err("failed to get index")?;
-                repo.set_index(&mut index)?;
+            let repo = if has_git_env {
+                Repository::open_from_env().wrap_err("failed to open repository")?
+            } else {
+                Repository::open(".").wrap_err("failed to open repository")?
+            };
+            // libgit2 status/diff APIs refuse to operate on a bare repository.
+            // For bare-repo dotfile managers (YADM, etc.) the work tree is
+            // provided via GIT_WORK_TREE but libgit2 still flags the repo as
+            // bare — fall back to the shell-git path so those operations work.
+            if repo.is_bare() {
+                debug!("libgit2: bare repo detected, falling back to shell git");
+                None
+            } else {
+                if let Some(index_file) = &*env::GIT_INDEX_FILE {
+                    // sets index to .git/index.lock which is used in the case of `git commit -a`
+                    let mut index =
+                        git2::Index::open(index_file).wrap_err("failed to get index")?;
+                    repo.set_index(&mut index)?;
+                }
+                Some(repo)
             }
-            Some(repo)
         } else {
             debug!("libgit2: false");
             None

--- a/src/git.rs
+++ b/src/git.rs
@@ -111,13 +111,32 @@ impl Git {
         let has_git_env =
             std::env::var_os("GIT_DIR").is_some() || std::env::var_os("GIT_WORK_TREE").is_some();
 
-        if !has_git_env {
+        let root = if has_git_env {
+            // Absolutize relative GIT_DIR / GIT_WORK_TREE before we change
+            // directory, otherwise libgit2 and downstream git commands will
+            // resolve them against the new cwd and look in the wrong place.
             let cwd = std::env::current_dir()?;
-            let root = xx::file::find_up(&cwd, &[".git"])
+            for var in ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"] {
+                if let Some(val) = std::env::var_os(var) {
+                    let p = std::path::Path::new(&val);
+                    if p.is_relative() {
+                        // SAFETY: set_var is only unsafe because other threads
+                        // may read the environment concurrently; we run this
+                        // before any worker threads are spawned.
+                        unsafe { std::env::set_var(var, cwd.join(p)) };
+                    }
+                }
+            }
+            crate::git_util::find_work_tree_root()
+        } else {
+            let cwd = std::env::current_dir()?;
+            xx::file::find_up(&cwd, &[".git"])
                 .and_then(|p| p.parent().map(|p| p.to_path_buf()))
-                .ok_or(eyre!("failed to find git repository"))?;
-            std::env::set_current_dir(&root)?;
-        }
+                .ok_or(eyre!("failed to find git repository"))?
+        };
+        // Always cd into the work tree root so libgit2 and shell-git return
+        // relative paths that resolve against the correct directory.
+        std::env::set_current_dir(&root)?;
         let repo = if *env::HK_LIBGIT2 {
             debug!("libgit2: true");
             let repo = if has_git_env {

--- a/src/git_util.rs
+++ b/src/git_util.rs
@@ -28,7 +28,7 @@ pub fn find_git_path() -> Result<PathBuf> {
 /// (for bare-repo setups like YADM). Falls back to walking up for `.git`, and
 /// finally to `cwd` if no repository is found.
 pub fn find_work_tree_root() -> PathBuf {
-    let cwd = std::env::current_dir().unwrap_or_default();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     if let Some(wt) = std::env::var_os("GIT_WORK_TREE") {
         let p = PathBuf::from(&wt);
         return if p.is_absolute() { p } else { cwd.join(p) };

--- a/src/git_util.rs
+++ b/src/git_util.rs
@@ -5,10 +5,37 @@ use eyre::eyre;
 use crate::Result;
 
 /// Find the `.git` path from the current working directory by searching upward.
+///
+/// Honors `GIT_DIR` if set (used by bare-repo dotfile managers like YADM), in
+/// which case the returned path may be a bare repository directory rather than
+/// a `.git` file/dir.
 pub fn find_git_path() -> Result<PathBuf> {
+    if let Some(git_dir) = std::env::var_os("GIT_DIR") {
+        let p = PathBuf::from(&git_dir);
+        let p = if p.is_absolute() {
+            p
+        } else {
+            std::env::current_dir()?.join(p)
+        };
+        return Ok(p);
+    }
     let cwd = std::env::current_dir()?;
     xx::file::find_up(&cwd, &[".git"])
         .ok_or_else(|| eyre!("No .git found in this or any parent directory"))
+}
+
+/// Return the effective working-tree root, honoring `GIT_WORK_TREE` when set
+/// (for bare-repo setups like YADM). Falls back to walking up for `.git`, and
+/// finally to `cwd` if no repository is found.
+pub fn find_work_tree_root() -> PathBuf {
+    let cwd = std::env::current_dir().unwrap_or_default();
+    if let Some(wt) = std::env::var_os("GIT_WORK_TREE") {
+        let p = PathBuf::from(&wt);
+        return if p.is_absolute() { p } else { cwd.join(p) };
+    }
+    xx::file::find_up(&cwd, &[".git"])
+        .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+        .unwrap_or(cwd)
 }
 
 /// Given a `.git` path (found by find_up), resolve the actual git directory.

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, sync::LazyLock};
 
-use crate::{Result, step::ShellType};
+use crate::{Result, git_util, step::ShellType};
 use itertools::Itertools;
 use serde::Serialize;
 use tera::Tera;
@@ -13,10 +13,7 @@ pub fn render(input: &str, ctx: &Context) -> Result<String> {
 
 static BASE_CONTEXT: LazyLock<tera::Context> = LazyLock::new(|| {
     let mut ctx = tera::Context::new();
-    let cwd = std::env::current_dir().expect("failed to get current directory");
-    let root = xx::file::find_up(&cwd, &[".git"])
-        .and_then(|p| p.parent().map(|p| p.to_path_buf()))
-        .unwrap_or(cwd);
+    let root = git_util::find_work_tree_root();
     ctx.insert("color", &console::colors_enabled_stderr());
     ctx.insert("root", &root.display().to_string());
     ctx

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use crate::{
-    Result,
+    Result, git_util,
     step::RunType,
     step::Step,
     step_test::{RunKind, StepTest},
@@ -169,14 +169,10 @@ pub async fn run_test_named(step: &Step, name: &str, test: &StepTest) -> Result<
         files = step.filter_files(&files)?;
     }
 
-    let cwd = std::env::current_dir().unwrap_or_default();
-    let root = xx::file::find_up(&cwd, &[".git"])
-        .and_then(|p| p.parent().map(|p| p.to_path_buf()))
-        .unwrap_or(cwd);
     let base_dir = if uses_sandbox {
         sandbox.to_path_buf()
     } else {
-        root
+        git_util::find_work_tree_root()
     };
     if let Some(fixture) = &test.fixture {
         let src = PathBuf::from(fixture);

--- a/test/bare_repo_env_vars.bats
+++ b/test/bare_repo_env_vars.bats
@@ -85,3 +85,25 @@ EOF
     assert_success
     assert_file_not_exists "$BARE_DIR/hooks/pre-commit"
 }
+
+@test "hk check picks up modified files when run from a subdirectory" {
+    # Regression for the reviewer-flagged bug: when GIT_DIR/GIT_WORK_TREE is
+    # set and cwd is a subdirectory of the work tree, Git::new() must cd to
+    # the work-tree root so path.exists() checks in status() resolve against
+    # the right directory. Without this, modified files silently disappear
+    # from the file list.
+    _write_hk_config
+    mkdir -p sub
+    echo "original" > top.txt
+    git add hk.pkl top.txt
+    git commit -m "add tracked file"
+
+    # Modify the file at the work tree root, then run hk check from a subdir.
+    echo "modified" > top.txt
+
+    cd sub
+    run hk check
+    assert_success
+    assert_output --partial "checked"
+    assert_output --partial "top.txt"
+}

--- a/test/bare_repo_env_vars.bats
+++ b/test/bare_repo_env_vars.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+
+# Regression tests for #831 — support bare-repo dotfile managers (YADM, etc.)
+# that set GIT_DIR and GIT_WORK_TREE instead of using a `.git` in the worktree.
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+
+    BARE_DIR="$TEST_TEMP_DIR/bare.git"
+    WORK_TREE="$TEST_TEMP_DIR/home"
+    git init --bare "$BARE_DIR"
+    mkdir -p "$WORK_TREE"
+
+    export GIT_DIR="$BARE_DIR"
+    export GIT_WORK_TREE="$WORK_TREE"
+    cd "$WORK_TREE"
+
+    echo "initial" > file.txt
+    git add file.txt
+    git commit -m "initial commit"
+}
+
+teardown() {
+    unset GIT_DIR
+    unset GIT_WORK_TREE
+    _common_teardown
+}
+
+_write_hk_config() {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] { steps { ["echo"] { check = "echo checked {{files}}" } } }
+    ["pre-commit"] { steps { ["echo"] { check = "echo pre-commit {{files}}" } } }
+}
+EOF
+}
+
+@test "hk builtins works with no repo config" {
+    # Outside any repo, with no hk.pkl, should not panic
+    cd "$TEST_TEMP_DIR"
+    unset GIT_DIR
+    unset GIT_WORK_TREE
+    run hk builtins
+    assert_success
+    assert_output --partial "prettier"
+}
+
+@test "hk check honors GIT_DIR/GIT_WORK_TREE" {
+    _write_hk_config
+    git add hk.pkl
+    git commit -m "add hk config"
+
+    run hk check --all
+    assert_success
+    assert_output --partial "checked"
+}
+
+@test "hk check with HK_LIBGIT2=0 honors GIT_DIR/GIT_WORK_TREE" {
+    _write_hk_config
+    git add hk.pkl
+    git commit -m "add hk config"
+
+    HK_LIBGIT2=0 run hk check --all
+    assert_success
+    assert_output --partial "checked"
+}
+
+@test "hk install writes hooks to the bare-repo hooks dir" {
+    _write_hk_config
+
+    run hk install
+    assert_success
+    assert_file_exists "$BARE_DIR/hooks/pre-commit"
+}
+
+@test "hk uninstall removes hooks from the bare-repo hooks dir" {
+    _write_hk_config
+
+    hk install
+    assert_file_exists "$BARE_DIR/hooks/pre-commit"
+
+    run hk uninstall
+    assert_success
+    assert_file_not_exists "$BARE_DIR/hooks/pre-commit"
+}


### PR DESCRIPTION
## Summary
- Honor `GIT_DIR` / `GIT_WORK_TREE` env vars during repository discovery so hk works with YADM and other bare-repo dotfile managers where there is no `.git` in the work tree
- Fall back to shell-git when libgit2 opens a bare repo (libgit2 refuses status/diff on bare repos even with a `GIT_WORK_TREE` override)
- `hk builtins` no longer loads project settings, so it works outside a repo instead of panicking

Fixes #831.

## Changes
- `src/git.rs` — `Git::new()` uses `Repository::open_from_env()` when either env var is set; bare repos fall back to shell git
- `src/git_util.rs` — `find_git_path()` returns `$GIT_DIR` when set; new `find_work_tree_root()` helper
- `src/tera.rs`, `src/test_runner.rs` — use `find_work_tree_root()` instead of walking up for `.git`
- `src/cli/mod.rs` — add `Commands::Builtins` to the settings-skip list

## Test plan
- [x] `hk check`, `hk fix`, `hk install`, `hk uninstall`, `hk builtins` all work against a bare repo + `GIT_WORK_TREE` setup
- [x] Verified on both `HK_LIBGIT2=1` (default) and `HK_LIBGIT2=0`
- [x] Regression-tested against a normal (non-bare) repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes repository discovery and working-directory behavior in `Git::new()`, which can affect path resolution and git operations across many commands; mitigated by explicit fallbacks and new regression tests.
> 
> **Overview**
> Enables `hk` to operate in bare-repo dotfile-manager setups (e.g., YADM) by honoring `GIT_DIR`/`GIT_WORK_TREE`, normalizing relative git env vars, and always `cd`ing to the effective work-tree root during `Git::new()`.
> 
> When libgit2 opens a bare repo, git status/diff now **falls back to shell `git`** to keep operations working. `find_git_path()` and a new `find_work_tree_root()` helper are added/used to resolve roots consistently, and `hk builtins` now skips project settings loading so it runs outside a repo. Adds `bats` regression tests covering check/install/uninstall and subdirectory execution under bare-repo env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 379931658c82ab8ff49a2237f86cd98dc2767b29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->