### PR TITLE
chore(release): append en.dev sponsor blurb to release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,3 +174,24 @@ jobs:
           communique generate "$TAG_NAME" --github-release
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      - name: Append en.dev sponsor blurb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            TAG_NAME="v${{ inputs.version }}"
+          else
+            TAG_NAME="${{ github.ref_name }}"
+          fi
+          {
+            gh release view "$TAG_NAME" --json body --jq .body
+            cat <<'EOF'
+
+          ## 💚 Sponsor hk
+
+          hk is developed by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev) — a small independent studio behind developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Work on hk is funded by sponsorships.
+
+          If hk has sped up your pre-commit loop or made linting feel less painful, please consider [sponsoring at en.dev](https://en.dev). Sponsorships are what keep hk moving and the project independent.
+          EOF
+          } > /tmp/release-notes.md
+          gh release edit "$TAG_NAME" --notes-file /tmp/release-notes.md


### PR DESCRIPTION
## Summary

- Appends a **Sponsor hk** section to every GitHub Release body, run after `communique generate` in the `enhance-release` job in [`.github/workflows/release.yml`](.github/workflows/release.yml).
- Same pattern as [mise#9272](https://github.com/jdx/mise/pull/9272), adapted for hk.

## What it looks like

Rendered at the bottom of each release body:

> ## 💚 Sponsor hk
>
> hk is developed by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev) — a small independent studio behind developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Work on hk is funded by sponsorships.
>
> If hk has sped up your pre-commit loop or made linting feel less painful, please consider [sponsoring at en.dev](https://en.dev). Sponsorships are what keep hk moving and the project independent.

## Test plan

- [x] \`actionlint\` + \`yamllint\` pass on the modified workflow
- [ ] Next tagged release produces a GitHub Release whose body ends with the sponsor section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that appends static text to GitHub Release bodies, with minimal impact beyond requiring `gh` to be able to view/edit the release via `GITHUB_TOKEN`.
> 
> **Overview**
> Updates the `enhance-release` GitHub Actions job to append a static **“Sponsor hk”** section to the end of each GitHub Release body after `communique generate` runs.
> 
> This is done by fetching the current release notes via `gh release view`, concatenating the sponsor blurb, and writing the combined content back with `gh release edit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b764365ec68d360ee2b3d37603d3ec6aebccb55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->