### PR TITLE
docs: add cross-site announcement banner

### DIFF
--- a/docs/.vitepress/theme/EndevFooter.vue
+++ b/docs/.vitepress/theme/EndevFooter.vue
@@ -1,0 +1,58 @@
+<template>
+  <footer class="EndevFooter">
+    <span>MIT License</span>
+    <span aria-hidden="true">·</span>
+    <span>Copyright © {{ year }}</span>
+    <span aria-hidden="true">·</span>
+    <a class="EndevFooterLink" href="https://en.dev">
+      <img
+        alt=""
+        class="EndevFooterLogo"
+        height="28"
+        src="https://github.com/endevco.png?size=96"
+        width="28"
+      />
+      <span>en.dev</span>
+    </a>
+  </footer>
+</template>
+
+<script setup>
+const year = new Date().getFullYear();
+</script>
+
+<style scoped>
+.EndevFooter {
+  align-items: center;
+  border-top: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-2);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 14px;
+  gap: 8px;
+  justify-content: center;
+  line-height: 28px;
+  margin-top: auto;
+  padding: 22px 24px 26px;
+  text-align: center;
+}
+.EndevFooterLink {
+  align-items: center;
+  color: inherit;
+  display: inline-flex;
+  gap: 8px;
+  line-height: 28px;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+.EndevFooterLink:hover {
+  color: var(--vp-c-brand-1);
+}
+.EndevFooterLogo {
+  border-radius: 8px;
+  display: inline-block;
+  height: 28px;
+  vertical-align: middle;
+  width: 28px;
+}
+</style>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,16 +1,15 @@
 <template>
   <Layout>
-    <!-- Custom header banner removed - using HomePage component instead -->
-
-    <!-- Removed nav-bar-title-after to avoid duplicate "hk" -->
-
-    <!-- Removed footer decoration to prevent visual issues -->
+    <template #layout-bottom>
+      <EndevFooter />
+    </template>
   </Layout>
 </template>
 
 <script setup lang="ts">
 import DefaultTheme from 'vitepress/theme'
 import { useData } from 'vitepress'
+import EndevFooter from './EndevFooter.vue'
 
 const { Layout } = DefaultTheme
 const { page } = useData()

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -3,31 +3,31 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 60;
+  z-index: 1001;
   display: flex;
   gap: 0.75rem;
   align-items: center;
   padding: 0.5rem 1rem;
   background: var(--vp-c-brand-1, #3451b2);
-  color: #fff;
+  color: #000;
   font-size: 0.9rem;
   line-height: 1.4;
 }
 .jdx-banner a {
-  color: #fff;
+  color: #000;
   text-decoration: underline;
-  font-weight: 500;
+  font-weight: 600;
 }
 .jdx-banner button {
   margin-left: auto;
   background: transparent;
   border: 0;
-  color: #fff;
+  color: inherit;
   font-size: 1.25rem;
   cursor: pointer;
   line-height: 1;
   padding: 0 0.25rem;
-  opacity: 0.85;
+  opacity: 0.7;
 }
 .jdx-banner button:hover {
   opacity: 1;

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -1,5 +1,8 @@
 .jdx-banner {
-  position: relative;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
   z-index: 60;
   display: flex;
   gap: 0.75rem;

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -1,0 +1,37 @@
+.jdx-banner {
+  position: relative;
+  z-index: 60;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: var(--vp-c-brand-1, #3451b2);
+  color: #fff;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+.jdx-banner a {
+  color: #fff;
+  text-decoration: underline;
+  font-weight: 500;
+}
+.jdx-banner button {
+  margin-left: auto;
+  background: transparent;
+  border: 0;
+  color: #fff;
+  font-size: 1.25rem;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 0.25rem;
+  opacity: 0.85;
+}
+.jdx-banner button:hover {
+  opacity: 1;
+}
+@media (max-width: 640px) {
+  .jdx-banner {
+    font-size: 0.85rem;
+    padding: 0.4rem 0.75rem;
+  }
+}

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -8,7 +8,7 @@
   gap: 0.75rem;
   align-items: center;
   justify-content: center;
-  padding: 0.5rem 2.75rem 0.5rem 1rem;
+  padding: 0.5rem 2.75rem;
   background: var(--vp-c-brand-1, #3451b2);
   color: #000;
   font-size: 0.9rem;
@@ -40,6 +40,6 @@
 @media (max-width: 640px) {
   .jdx-banner {
     font-size: 0.85rem;
-    padding: 0.4rem 2.5rem 0.4rem 0.75rem;
+    padding: 0.4rem 2.5rem;
   }
 }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -7,11 +7,13 @@
   display: flex;
   gap: 0.75rem;
   align-items: center;
-  padding: 0.5rem 1rem;
+  justify-content: center;
+  padding: 0.5rem 2.75rem 0.5rem 1rem;
   background: var(--vp-c-brand-1, #3451b2);
   color: #000;
   font-size: 0.9rem;
   line-height: 1.4;
+  text-align: center;
 }
 .jdx-banner a {
   color: #000;
@@ -19,14 +21,17 @@
   font-weight: 600;
 }
 .jdx-banner button {
-  margin-left: auto;
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
   background: transparent;
   border: 0;
   color: inherit;
   font-size: 1.25rem;
   cursor: pointer;
   line-height: 1;
-  padding: 0 0.25rem;
+  padding: 0 0.5rem;
   opacity: 0.7;
 }
 .jdx-banner button:hover {
@@ -35,6 +40,6 @@
 @media (max-width: 640px) {
   .jdx-banner {
     font-size: 0.85rem;
-    padding: 0.4rem 0.75rem;
+    padding: 0.4rem 2.5rem 0.4rem 0.75rem;
   }
 }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -9,7 +9,7 @@
   align-items: center;
   justify-content: center;
   padding: 0.5rem 2.75rem;
-  background: var(--vp-c-brand-1, #3451b2);
+  background: var(--vp-c-brand-1, #3abff8);
   color: #000;
   font-size: 0.9rem;
   line-height: 1.4;

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -46,7 +46,7 @@ function render(b: BannerData): void {
     const a = document.createElement("a");
     a.href = b.link;
     a.target = "_blank";
-    a.rel = "noopener noreferrer";
+    a.rel = "noopener";
     a.textContent = b.linkText || "Learn more";
     el.appendChild(a);
   }

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -51,12 +51,25 @@ function render(b: BannerData): void {
     el.appendChild(a);
   }
 
+  const syncHeight = () => {
+    document.documentElement.style.setProperty(
+      "--vp-layout-top-height",
+      `${el.offsetHeight}px`,
+    );
+  };
+
+  const observer =
+    typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(syncHeight)
+      : null;
+
   const btn = document.createElement("button");
   btn.type = "button";
   btn.setAttribute("aria-label", "Dismiss");
   btn.textContent = "\u00d7";
   btn.addEventListener("click", () => {
     localStorage.setItem(STORAGE_KEY, b.id);
+    observer?.disconnect();
     el.remove();
     document.documentElement.style.removeProperty("--vp-layout-top-height");
   });
@@ -64,10 +77,6 @@ function render(b: BannerData): void {
 
   document.body.prepend(el);
 
-  requestAnimationFrame(() => {
-    document.documentElement.style.setProperty(
-      "--vp-layout-top-height",
-      `${el.offsetHeight}px`,
-    );
-  });
+  requestAnimationFrame(syncHeight);
+  observer?.observe(el);
 }

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -13,7 +13,7 @@ const STORAGE_KEY = "jdx-banner-dismissed";
 
 export function initBanner(): void {
   if (typeof window === "undefined") return;
-  fetch(ENDPOINT, { cache: "no-cache" })
+  fetch(ENDPOINT)
     .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
     .then((b) => {
       if (!b || !b.enabled) return;

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -1,64 +1,73 @@
-import './banner.css'
+import "./banner.css";
 
 interface BannerData {
-  id: string
-  enabled: boolean
-  message: string
-  link?: string
-  linkText?: string
+  id: string;
+  enabled: boolean;
+  message: string;
+  link?: string;
+  linkText?: string;
 }
 
-const ENDPOINT = 'https://jdx.dev/banner.json'
-const STORAGE_KEY = 'jdx-banner-dismissed'
+const ENDPOINT = "https://jdx.dev/banner.json";
+const STORAGE_KEY = "jdx-banner-dismissed";
 
 export function initBanner(): void {
-  if (typeof window === 'undefined') return
-  fetch(ENDPOINT, { cache: 'no-cache' })
+  if (typeof window === "undefined") return;
+  fetch(ENDPOINT, { cache: "no-cache" })
     .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
     .then((b) => {
-      if (!b || !b.enabled) return
-      if (localStorage.getItem(STORAGE_KEY) === b.id) return
-      render(b)
+      if (!b || !b.enabled) return;
+      if (localStorage.getItem(STORAGE_KEY) === b.id) return;
+      render(b);
     })
-    .catch(() => {})
+    .catch(() => {});
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const u = new URL(value, window.location.href);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 function render(b: BannerData): void {
-  const el = document.createElement('div')
-  el.className = 'jdx-banner'
-  el.setAttribute('role', 'region')
-  el.setAttribute('aria-label', 'Site announcement')
+  const el = document.createElement("div");
+  el.className = "jdx-banner";
+  el.setAttribute("role", "region");
+  el.setAttribute("aria-label", "Site announcement");
 
-  const msg = document.createElement('span')
-  msg.textContent = b.message
-  el.appendChild(msg)
+  const msg = document.createElement("span");
+  msg.textContent = b.message;
+  el.appendChild(msg);
 
-  if (b.link) {
-    const a = document.createElement('a')
-    a.href = b.link
-    a.target = '_blank'
-    a.rel = 'noopener'
-    a.textContent = b.linkText || 'Learn more'
-    el.appendChild(a)
+  if (b.link && isHttpUrl(b.link)) {
+    const a = document.createElement("a");
+    a.href = b.link;
+    a.target = "_blank";
+    a.rel = "noopener noreferrer";
+    a.textContent = b.linkText || "Learn more";
+    el.appendChild(a);
   }
 
-  const btn = document.createElement('button')
-  btn.type = 'button'
-  btn.setAttribute('aria-label', 'Dismiss')
-  btn.textContent = '\u00d7'
-  btn.addEventListener('click', () => {
-    localStorage.setItem(STORAGE_KEY, b.id)
-    el.remove()
-    document.documentElement.style.removeProperty('--vp-layout-top-height')
-  })
-  el.appendChild(btn)
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.setAttribute("aria-label", "Dismiss");
+  btn.textContent = "\u00d7";
+  btn.addEventListener("click", () => {
+    localStorage.setItem(STORAGE_KEY, b.id);
+    el.remove();
+    document.documentElement.style.removeProperty("--vp-layout-top-height");
+  });
+  el.appendChild(btn);
 
-  document.body.prepend(el)
+  document.body.prepend(el);
 
   requestAnimationFrame(() => {
     document.documentElement.style.setProperty(
-      '--vp-layout-top-height',
+      "--vp-layout-top-height",
       `${el.offsetHeight}px`,
-    )
-  })
+    );
+  });
 }

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -1,0 +1,64 @@
+import './banner.css'
+
+interface BannerData {
+  id: string
+  enabled: boolean
+  message: string
+  link?: string
+  linkText?: string
+}
+
+const ENDPOINT = 'https://jdx.dev/banner.json'
+const STORAGE_KEY = 'jdx-banner-dismissed'
+
+export function initBanner(): void {
+  if (typeof window === 'undefined') return
+  fetch(ENDPOINT, { cache: 'no-cache' })
+    .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
+    .then((b) => {
+      if (!b || !b.enabled) return
+      if (localStorage.getItem(STORAGE_KEY) === b.id) return
+      render(b)
+    })
+    .catch(() => {})
+}
+
+function render(b: BannerData): void {
+  const el = document.createElement('div')
+  el.className = 'jdx-banner'
+  el.setAttribute('role', 'region')
+  el.setAttribute('aria-label', 'Site announcement')
+
+  const msg = document.createElement('span')
+  msg.textContent = b.message
+  el.appendChild(msg)
+
+  if (b.link) {
+    const a = document.createElement('a')
+    a.href = b.link
+    a.target = '_blank'
+    a.rel = 'noopener'
+    a.textContent = b.linkText || 'Learn more'
+    el.appendChild(a)
+  }
+
+  const btn = document.createElement('button')
+  btn.type = 'button'
+  btn.setAttribute('aria-label', 'Dismiss')
+  btn.textContent = '\u00d7'
+  btn.addEventListener('click', () => {
+    localStorage.setItem(STORAGE_KEY, b.id)
+    el.remove()
+    document.documentElement.style.removeProperty('--vp-layout-top-height')
+  })
+  el.appendChild(btn)
+
+  document.body.prepend(el)
+
+  requestAnimationFrame(() => {
+    document.documentElement.style.setProperty(
+      '--vp-layout-top-height',
+      `${el.offsetHeight}px`,
+    )
+  })
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme-without-fonts'
 import Layout from './Layout.vue'
 import HomePage from './HomePage.vue'
+import { initBanner } from './banner'
 import './style.css'
 
 export default {
@@ -10,5 +11,6 @@ export default {
   Layout,
   enhanceApp({ app, router, siteData }) {
     app.component('HomePage', HomePage)
+    initBanner()
   },
 } satisfies Theme


### PR DESCRIPTION
## Summary
- Adds `docs/.vitepress/theme/banner.ts` + `banner.css` \u2014 fetches banner config from `https://jdx.dev/banner.json` and renders a dismissible announcement bar at the top of the docs
- Wires it into the existing `enhanceApp` hook
- Dismissals persist per banner id in `localStorage`; bumping the id re-shows it

Used to announce en.dev, and any future cross-site announcements.

## Test plan
- [ ] Run docs dev server, confirm banner appears at top of page
- [ ] Click the \u00d7 \u2014 banner disappears and stays dismissed across reloads
- [ ] Clear localStorage `jdx-banner-dismissed`, reload \u2014 banner returns

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds client-side DOM injection that fetches remote banner content and persists dismissal in `localStorage`, which can affect layout and introduces a new external dependency for docs pages.
> 
> **Overview**
> Introduces a cross-site, dismissible announcement banner for the docs theme: `initBanner()` fetches config from `https://jdx.dev/banner.json`, renders a fixed top bar with optional outbound link, adjusts `--vp-layout-top-height`, and stores per-banner dismissals in `localStorage`.
> 
> Adds a new `EndevFooter` component and wires it into `Layout.vue` via the `layout-bottom` slot to display license/copyright and an `en.dev` link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 622e8dbbaa41f215120b5dd1a6808978482e3858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->