### PR TITLE
fix(git): skip untracked scan when HK_STASH_UNTRACKED=false

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -145,6 +145,8 @@ Default: `true`
 
 If set to `true`, hk will stash untracked files when stashing before running hooks.
 
+When set to `false`, hk also skips the untracked-file scan entirely (`git status --untracked-files=no`). This is the recommended setting when `GIT_WORK_TREE` points at a very large directory such as `$HOME` (e.g. a YADM dotfiles repo), where scanning for untracked files can take tens of seconds. Untracked files will not appear in reports or `hk check --all` results in this mode.
+
 ## `HK_FAIL_FAST`
 
 Type: `bool`

--- a/src/git.rs
+++ b/src/git.rs
@@ -410,10 +410,14 @@ impl Git {
     pub fn status(&self, pathspec: Option<&[OsString]>) -> Result<GitStatus> {
         // Refresh index stat information to avoid stale mtime/size causing mis-detection
         let _ = git_run(["update-index", "-q", "--refresh"]);
+        // When stashing untracked files is disabled, skip the untracked-file scan.
+        // This avoids catastrophic scans when GIT_WORK_TREE points at a large tree
+        // (e.g. YADM dotfile repos where the worktree is $HOME). See #860.
+        let include_untracked = *env::HK_STASH_UNTRACKED;
         if let Some(repo) = &self.repo {
             let mut status_options = StatusOptions::new();
-            status_options.include_untracked(true);
-            status_options.recurse_untracked_dirs(true);
+            status_options.include_untracked(include_untracked);
+            status_options.recurse_untracked_dirs(include_untracked);
             status_options.renames_head_to_index(true);
 
             if let Some(pathspec) = pathspec {
@@ -508,7 +512,12 @@ impl Git {
                 unstaged_renamed_files,
             })
         } else {
-            let mut args = vec!["status", "--porcelain", "--untracked-files=all", "-z"]
+            let untracked_arg = if include_untracked {
+                "--untracked-files=all"
+            } else {
+                "--untracked-files=no"
+            };
+            let mut args = vec!["status", "--porcelain", untracked_arg, "-z"]
                 .into_iter()
                 .filter(|&arg| !arg.is_empty())
                 .map(OsString::from)
@@ -666,13 +675,21 @@ impl Git {
                 }
             }
         }
-        // 3) Parse porcelain to catch nuanced mixed states
+        // 3) Parse porcelain to catch nuanced mixed states.
+        // We only look at worktree-side markers (M/T/R), so untracked entries
+        // are irrelevant here. Skip the untracked scan entirely when
+        // HK_STASH_UNTRACKED=false to avoid scanning a huge worktree (see #860).
         {
+            let untracked_arg = if *env::HK_STASH_UNTRACKED {
+                "--untracked-files=all"
+            } else {
+                "--untracked-files=no"
+            };
             let args: Vec<OsString> = vec![
                 "status".into(),
                 "--porcelain".into(),
                 "--no-renames".into(),
-                "--untracked-files=all".into(),
+                untracked_arg.into(),
                 "-z".into(),
             ];
             let out = git_read(args).unwrap_or_default();

--- a/test/bare_repo_env_vars.bats
+++ b/test/bare_repo_env_vars.bats
@@ -86,6 +86,28 @@ EOF
     assert_file_not_exists "$BARE_DIR/hooks/pre-commit"
 }
 
+@test "HK_STASH_UNTRACKED=false skips untracked scan in large worktree (#860)" {
+    # Regression for #860: when GIT_WORK_TREE points at $HOME (e.g. YADM), the
+    # unconditional `git status --untracked-files=all` scans the entire home
+    # dir. Setting HK_STASH_UNTRACKED=false must skip the untracked scan.
+    _write_hk_config
+    git add hk.pkl
+    git commit -m "add hk config"
+
+    # Seed a deep tree of untracked junk. If the scan runs, this inflates the
+    # status output; if it's skipped, these files never appear.
+    mkdir -p junk/a/b/c
+    for i in 1 2 3 4 5; do
+        echo "noise" > "junk/a/b/c/untracked_$i.txt"
+    done
+
+    HK_STASH_UNTRACKED=false HK_LOG=trace run hk check --all
+    assert_success
+    # The fix should pass --untracked-files=no (libgit2 path also skips untracked).
+    # None of the seeded junk files should reach the file list.
+    refute_output --partial "junk/a/b/c/untracked_1.txt"
+}
+
 @test "hk check picks up modified files when run from a subdirectory" {
     # Regression for the reviewer-flagged bug: when GIT_DIR/GIT_WORK_TREE is
     # set and cwd is a subdirectory of the work tree, Git::new() must cd to


### PR DESCRIPTION
## Summary

- When `GIT_WORK_TREE` points at a large directory (e.g. a YADM dotfile repo where the worktree is `$HOME`), the unconditional `git status --untracked-files=all` scan takes tens of seconds and emits hundreds of megabytes of output on every hk invocation.
- `HK_STASH_UNTRACKED=false` previously had no effect on the status scan — it only suppressed stashing. This change honors it in `Git::status()` (and the internal stash porcelain parse, which already ignores untracked entries) so users of large worktrees can opt out of the scan entirely. Both the libgit2 and shell-git paths are updated.
- Fixes [#860](https://github.com/jdx/hk/discussions/860).

## Test plan

- [x] `mise run test:bats test/bare_repo_env_vars.bats` (7 tests × 2 modes)
- [x] `mise run test:bats test/stash_untracked_with_partial_stash.bats`, `test/stash_preservation_on_error.bats`, `test/pre_commit_does_not_stash_staged_only_files.bats`, `test/git_status_ad_deleted.bats`, `test/cargo_fmt_does_not_stage_manifest.bats`
- [x] `mise run test:cargo` (145 passed)
- [x] New regression test: `HK_STASH_UNTRACKED=false skips untracked scan in large worktree (#860)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `Git::status()` (libgit2 and shell-git paths) and stash detection call `git status`, which can affect which files hk considers (especially untracked files) and therefore which steps run. The behavior is gated behind `HK_STASH_UNTRACKED=false`, but it touches core git/file-detection logic.
> 
> **Overview**
> Honors `HK_STASH_UNTRACKED=false` by **skipping untracked-file enumeration** during status collection (using `--untracked-files=no` for shell git and disabling untracked options for libgit2) to avoid expensive scans when `GIT_WORK_TREE` is very large.
> 
> Updates the stash porcelain parse to likewise avoid untracked scanning when untracked stashing is disabled, documents the new behavior in `docs/environment_variables.md`, and adds a Bats regression test ensuring untracked “junk” in a large worktree doesn’t appear in `hk check --all` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4049f37396f2cead8232c511095af684921b774d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->