### PR TITLE
fix(docs): stack banner message and link on mobile

### DIFF
--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -39,7 +39,14 @@
 }
 @media (max-width: 640px) {
   .jdx-banner {
-    font-size: 0.85rem;
-    padding: 0.4rem 2.5rem;
+    flex-direction: column;
+    gap: 0.125rem;
+    font-size: 0.8rem;
+    padding: 0.5rem 2.25rem;
+    line-height: 1.3;
+    text-wrap: balance;
+  }
+  .jdx-banner button {
+    right: 0.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- On narrow viewports the site banner rendered cramped: `flex-wrap: nowrap` forced the message onto two squeezed lines while the "Read more" link sat jammed against the text.
- At `<=640px`, switch the banner to `flex-direction: column` so the message and link stack cleanly. Also shrink the font slightly, tighten line-height, add `text-wrap: balance` for even two-line breaks, and nudge the close button flush to the corner.

Matches the identical fix going out to the mise and aube docs.

## Test plan
- [ ] Visit hk.jdx.dev on a mobile device (or DevTools <=640px) after deploy and confirm the banner stacks cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change limited to the banner’s `@media (max-width: 640px)` styling.
> 
> **Overview**
> Adjusts `docs/.vitepress/theme/banner.css` to improve the banner on narrow viewports by switching to `flex-direction: column` with tighter mobile spacing and typography (`gap`, `font-size`, `line-height`, `text-wrap: balance`).
> 
> Also nudges the close button position (`right`) on mobile to better align with the updated layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cce073c7ee10c79cbb91e7dd30cd1e01eea6570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->