### PR TITLE
chore: release v1.44.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [1.44.2](https://github.com/jdx/hk/compare/v1.44.1..v1.44.2) - 2026-04-26
+
+### 🐛 Bug Fixes
+
+- **(builtins)** silence pklr deprecation warnings on Builtins.pkl load by [@jdx](https://github.com/jdx) in [#880](https://github.com/jdx/hk/pull/880)
+- **(ci)** serialize docs lint step by [@jdx](https://github.com/jdx) in [#874](https://github.com/jdx/hk/pull/874)
+- **(config)** include main pkl path in cache fresh files by [@jdx](https://github.com/jdx) in [#879](https://github.com/jdx/hk/pull/879)
+- **(docs)** stack banner message and link on mobile by [@jdx](https://github.com/jdx) in [#865](https://github.com/jdx/hk/pull/865)
+- **(docs)** pin banner close button to top-right corner on mobile by [@jdx](https://github.com/jdx) in [#867](https://github.com/jdx/hk/pull/867)
+
+### 📚 Documentation
+
+- **(site)** show release version and github stars by [@jdx](https://github.com/jdx) in [#872](https://github.com/jdx/hk/pull/872)
+
+### 🔍 Other Changes
+
+- add pr-closer workflow by [@jdx](https://github.com/jdx) in [#876](https://github.com/jdx/hk/pull/876)
+
+### 📦️ Dependency Updates
+
+- bump communique 1.0.3 → 1.0.4 by [@jdx](https://github.com/jdx) in [#868](https://github.com/jdx/hk/pull/868)
+- update anthropics/claude-code-action digest to 2da6cfa by [@renovate[bot]](https://github.com/renovate[bot]) in [#869](https://github.com/jdx/hk/pull/869)
+- update anthropics/claude-code-action digest to 567fe95 by [@renovate[bot]](https://github.com/renovate[bot]) in [#870](https://github.com/jdx/hk/pull/870)
+- bump communique to 1.1.2 by [@jdx](https://github.com/jdx) in [#875](https://github.com/jdx/hk/pull/875)
+
 ## [1.44.1](https://github.com/jdx/hk/compare/v1.44.0..v1.44.1) - 2026-04-24
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -242,9 +242,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
@@ -1071,7 +1071,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.44.1"
+version = "1.44.2"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -1186,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -2515,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "hk"
 repository = "https://github.com/jdx/hk"
 rust-version = "1.88.0"
-version = "1.44.1"
+version = "1.44.2"
 
 [[bin]]
 name = "generate-docs"

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 90+ pre-configured linters and formatters through the `Builtins` mod
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -4799,7 +4799,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.44.1",
+  "version": "1.44.2",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.44.1
+**Version**: 1.44.2
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // linters can be manually defined
@@ -208,8 +208,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -242,7 +242,7 @@ Add steps to your hkrc. hk merges them into every project's hooks — steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -335,7 +335,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,8 +105,8 @@ Separately from global *hooks*, you can also create a global *config* file that 
 This will generate a `hk.pkl` file in the root of the repository, here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // linters can be manually defined

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -43,7 +43,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
 
 `pre-commit` {
     ["prelint"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,8 +3,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,8 +3,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,8 +3,8 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,8 +4,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -7,8 +7,8 @@
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
 
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -7,8 +7,8 @@
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
 
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -7,8 +7,8 @@
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -8,8 +8,8 @@
 /// * Sorts imports with isort
 /// * Validates with flake8
 
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.44.1/hk@1.44.1#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.44.2/hk@1.44.2#/Config.pkl"
 amends "pkl/Config.pkl"
 import "pkl/Builtins.pkl"
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.44.1"
+version "1.44.2"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)" hide=#true global=#true {


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(builtins)** silence pklr deprecation warnings on Builtins.pkl load by [@jdx](https://github.com/jdx) in [#880](https://github.com/jdx/hk/pull/880)
- **(ci)** serialize docs lint step by [@jdx](https://github.com/jdx) in [#874](https://github.com/jdx/hk/pull/874)
- **(config)** include main pkl path in cache fresh files by [@jdx](https://github.com/jdx) in [#879](https://github.com/jdx/hk/pull/879)
- **(docs)** stack banner message and link on mobile by [@jdx](https://github.com/jdx) in [#865](https://github.com/jdx/hk/pull/865)
- **(docs)** pin banner close button to top-right corner on mobile by [@jdx](https://github.com/jdx) in [#867](https://github.com/jdx/hk/pull/867)

### 📚 Documentation

- **(site)** show release version and github stars by [@jdx](https://github.com/jdx) in [#872](https://github.com/jdx/hk/pull/872)

### 🔍 Other Changes

- add pr-closer workflow by [@jdx](https://github.com/jdx) in [#876](https://github.com/jdx/hk/pull/876)

### 📦️ Dependency Updates

- bump communique 1.0.3 → 1.0.4 by [@jdx](https://github.com/jdx) in [#868](https://github.com/jdx/hk/pull/868)
- update anthropics/claude-code-action digest to 2da6cfa by [@renovate[bot]](https://github.com/renovate[bot]) in [#869](https://github.com/jdx/hk/pull/869)
- update anthropics/claude-code-action digest to 567fe95 by [@renovate[bot]](https://github.com/renovate[bot]) in [#870](https://github.com/jdx/hk/pull/870)
- bump communique to 1.1.2 by [@jdx](https://github.com/jdx) in [#875](https://github.com/jdx/hk/pull/875)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: version bumps, regenerated CLI/docs artifacts, and minor lockfile dependency updates with no functional code changes shown in this diff.
> 
> **Overview**
> Bumps `hk` from **1.44.1 → 1.44.2** (Cargo + CLI usage metadata) and adds the `1.44.2` section to `CHANGELOG.md`.
> 
> Regenerates/updates documentation and examples to reference the `v1.44.2` Pkl package URLs, and refreshes `Cargo.lock` with small crate patch updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62ff432f2aba57b0f93cbd5d85fb690d40b9c73f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->