### PR TITLE
fix(docs): pin banner close button to top-right corner on mobile

### DIFF
--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -47,6 +47,8 @@
     text-wrap: balance;
   }
   .jdx-banner button {
+    top: 0.25rem;
     right: 0.25rem;
+    transform: none;
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #865. With `flex-direction: column` the mobile banner is now taller, and the base rule's `top: 50%; transform: translateY(-50%)` centering floats the × button in the vertical middle of the stacked content instead of in the top-right corner.

Override `top` and `transform` inside the `<=640px` media query so the button pins flush to the corner.

## Test plan
- [ ] Open hk.jdx.dev at a <=640px viewport, clear `localStorage['jdx-banner-dismissed']`, confirm the × button sits in the top-right corner rather than floating in the middle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change scoped to the mobile banner close button positioning with no functional or data-impacting logic changes.
> 
> **Overview**
> Adjusts `docs/.vitepress/theme/banner.css` so that on `<=640px` viewports the banner close button no longer uses `top: 50%` + `translateY(-50%)` centering.
> 
> Within the mobile media query, it explicitly sets `top: 0.25rem` and removes the transform to keep the × button pinned to the top-right corner when the banner stacks vertically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf8067f5161598fab412739740a01086f4ec382. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->