### PR TITLE
fix(ci): suppress progress noise in non-interactive logs

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -100,7 +100,7 @@ pub async fn run() -> Result<()> {
     });
 
     if is_ci::cached() || !console::user_attended_stderr() || args.no_progress {
-        clx::progress::set_output(ProgressOutput::Text);
+        clx::progress::set_output(ProgressOutput::Quiet);
     }
     if args.verbose > 1 {
         clx::progress::set_output(ProgressOutput::Text);

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1014,7 +1014,10 @@ impl Hook {
         clx::progress::stop();
 
         // Display aggregated output from steps, once per step
-        if clx::progress::output() != ProgressOutput::Text || *env::HK_SUMMARY_TEXT {
+        if clx::progress::output() != ProgressOutput::Text
+            || clx::progress::output() == ProgressOutput::Quiet
+            || *env::HK_SUMMARY_TEXT
+        {
             let outputs = hook_ctx.output_by_step.lock().unwrap().clone();
             for (step_name, (mode, output)) in outputs.into_iter() {
                 let trimmed = output.trim_end();


### PR DESCRIPTION
## Summary

- make hk use clx's `ProgressOutput::Quiet` mode during CI, non-interactive stderr, and `--no-progress` runs instead of emitting every text-mode progress update
- still print aggregated step output summaries in quiet progress mode, so CI failures include useful command output without repeated progress redraws

## Validation

- `cargo fmt --all -- --check`
- `cargo check --all-features`

_This PR was generated by Codex._