### PR TITLE
fix(ci): serialize docs lint step

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -41,6 +41,7 @@ local linters = new Mapping<String, Step | Group> {
   ["docs"] = new Step {
     glob = "docs/**"
     check = "mise run docs:build"
+    exclusive = true
     output_summary = "hide"
   }
 }


### PR DESCRIPTION
## Summary

- mark the docs lint step as exclusive so `mise run docs:build` does not race Cargo checks during `mise run lint`
- fixes the macOS CI failure where `cargo-check` lost Cargo fingerprint files while docs generation was also compiling/running

## Validation

- `mise run pkl:gen && pkl eval hk.pkl >/dev/null`

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config change that only affects hook/lint step scheduling; main risk is longer lint runtimes or unintended serialization if `exclusive` is misapplied.
> 
> **Overview**
> Marks the `docs` lint step in `hk.pkl` as `exclusive` so `mise run docs:build` runs serialized instead of concurrently with other lint steps.
> 
> This prevents CI races (notably on macOS) where docs generation and Rust `cargo` checks contend for Cargo fingerprint/build artifacts during `mise run lint`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 280228fea2f43ddf907da3f17bce4e9c49ebe613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->