### PR TITLE
chore(deps): bump communique to 1.1.2

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -276,6 +276,7 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964430
 checksum = "sha256:3cc0e880ac2168aed3163223627bbd1eee62e07a9901cb85cb507c6c8927bc93"
 url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964430"
+
 [[tools.git-cliff]]
 version = "2.10.0"
 backend = "aqua:orhun/git-cliff"

--- a/mise.lock
+++ b/mise.lock
@@ -223,60 +223,59 @@ version = "0.25.18"
 backend = "cargo:cargo-release"
 
 [[tools.communique]]
-version = "1.0.4"
+version = "1.1.2"
 backend = "github:jdx/communique"
 
 [tools.communique."platforms.linux-arm64"]
-checksum = "sha256:3c3b8bc3ea4f887c3db1d3a9af9875864ecdb4f053c7ad7e05d55b51769359b5"
-url = "https://github.com/jdx/communique/releases/download/v1.0.4/communique-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/404781311"
+checksum = "sha256:7bb0843207fc3d7b5df2a5c0198bb10539cf13a6b247b4adfbf6b302a68f03de"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964161"
 
 [tools.communique."platforms.linux-arm64-musl"]
-checksum = "sha256:3c3b8bc3ea4f887c3db1d3a9af9875864ecdb4f053c7ad7e05d55b51769359b5"
-url = "https://github.com/jdx/communique/releases/download/v1.0.4/communique-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/404781311"
+checksum = "sha256:b663407be77a370c209df40307b82e436f56a6bc23d4e423510d62ac6e1fedf4"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964743"
 
 [tools.communique."platforms.linux-x64"]
-checksum = "sha256:4ea1bc9e59fee38bee3b6e2d377eeb80f1c4c85787db0aed53c70e0b70857897"
-url = "https://github.com/jdx/communique/releases/download/v1.0.4/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/404781142"
+checksum = "sha256:5e74ead7037f42940c7dba4f6aa4ed968920cbb55a047aa0d291b0c675c65676"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405963914"
 provenance = "github-attestations"
 
 [tools.communique."platforms.linux-x64-baseline"]
-checksum = "sha256:4ea1bc9e59fee38bee3b6e2d377eeb80f1c4c85787db0aed53c70e0b70857897"
-url = "https://github.com/jdx/communique/releases/download/v1.0.4/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/404781142"
+checksum = "sha256:5e74ead7037f42940c7dba4f6aa4ed968920cbb55a047aa0d291b0c675c65676"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405963914"
 
 [tools.communique."platforms.linux-x64-musl"]
-checksum = "sha256:4ea1bc9e59fee38bee3b6e2d377eeb80f1c4c85787db0aed53c70e0b70857897"
-url = "https://github.com/jdx/communique/releases/download/v1.0.4/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/404781142"
+checksum = "sha256:01a6a8b49e635a5a209fdaf6c7b2e976374debc2db1c846c033f567fdba0d86c"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964691"
 
 [tools.communique."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:4ea1bc9e59fee38bee3b6e2d377eeb80f1c4c85787db0aed53c70e0b70857897"
-url = "https://github.com/jdx/communique/releases/download/v1.0.4/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/404781142"
+checksum = "sha256:01a6a8b49e635a5a209fdaf6c7b2e976374debc2db1c846c033f567fdba0d86c"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964691"
 
 [tools.communique."platforms.macos-arm64"]
-checksum = "sha256:27eed5b2ebd1492f3a0fcfb5e2799148c7e6d8fdbdadfe3f70e3b721d04c2ca7"
-url = "https://github.com/jdx/communique/releases/download/v1.0.4/communique-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/404782180"
+checksum = "sha256:459993e31a6c4ccbd09882f5679a2bc1ea5d9068701ecefc411a00fb69ce82e6"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964098"
 
 [tools.communique."platforms.windows-arm64"]
-checksum = "sha256:396ee1f8463d762f009743e8c400fa1a5befe19d3738541d89a425946abf2503"
-url = "https://github.com/jdx/communique/releases/download/v1.0.4/communique-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/404781785"
+checksum = "sha256:ad7e174b0da7c1ed4b1ba852ac24152c4ea20f2ac357e87223192834b0502298"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964520"
 
 [tools.communique."platforms.windows-x64"]
-checksum = "sha256:f2efaa4c0b7369b0040127b21e5c00f27ca2c4f2493e9bb534707e67586109d8"
-url = "https://github.com/jdx/communique/releases/download/v1.0.4/communique-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/404781972"
+checksum = "sha256:3cc0e880ac2168aed3163223627bbd1eee62e07a9901cb85cb507c6c8927bc93"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964430"
 
 [tools.communique."platforms.windows-x64-baseline"]
-checksum = "sha256:f2efaa4c0b7369b0040127b21e5c00f27ca2c4f2493e9bb534707e67586109d8"
-url = "https://github.com/jdx/communique/releases/download/v1.0.4/communique-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/404781972"
-
+checksum = "sha256:3cc0e880ac2168aed3163223627bbd1eee62e07a9901cb85cb507c6c8927bc93"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964430"
 [[tools.git-cliff]]
 version = "2.10.0"
 backend = "aqua:orhun/git-cliff"


### PR DESCRIPTION
## Summary
- update the communique mise lock entry to v1.1.2
- refresh release asset URLs and checksums, including musl assets

## Validation
- monitored jdx/communique release workflow 24960017639 to success
- `mise install --locked communique`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only change that updates the pinned `communique` tool binary and its download metadata; main risk is install/CI breakage if any platform URL/checksum is incorrect.
> 
> **Overview**
> Updates `mise.lock` to bump the pinned `communique` tool from `1.0.4` to `1.1.2`.
> 
> Refreshes per-platform release asset URLs, `url_api` IDs, and checksums (including switching to distinct `*-musl` assets where applicable) so `mise install --locked communique` pulls the new binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4be0ba226fe05598f20dcd152235f40c24df5ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->