### PR TITLE
chore: add pr-closer workflow

### DIFF
--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -16,12 +16,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
-          gh pr list -R "$REPO" --state open --json number,author,labels,updatedAt,statusCheckRollup --limit 500 | \
-          jq -r '.[] | select(
-            (.updatedAt | fromdateiso8601) < (now - 30*24*60*60) and
-            .author.login != "jdx" and
-            ([.labels[].name] | index("keep-open") | not)
-          ) | [.number, (if (.statusCheckRollup | length > 0) and ([.statusCheckRollup[].conclusion] | index("FAILURE") or index("failure")) then "failing" else "passing" end)] | @tsv' | \
+          CUTOFF=$(date -u -d '30 days ago' +%Y-%m-%d)
+          gh pr list -R "$REPO" --state open --search "updated:<$CUTOFF -author:jdx -label:keep-open sort:updated-asc" --json number,statusCheckRollup --limit 500 | \
+          jq -r '.[] | [.number, (if (.statusCheckRollup | length > 0) and ([.statusCheckRollup[].conclusion] | index("FAILURE") or index("failure")) then "failing" else "passing" end)] | @tsv' | \
           while read -r pr status; do
             echo "Closing PR #$pr (checks: $status)"
             if [ "$status" = "failing" ]; then

--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -8,12 +8,15 @@ on:
 jobs:
   close-stale-prs:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Close stale PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          gh pr list -R jdx/hk --state open --json number,author,labels,updatedAt,statusCheckRollup --limit 100 | \
+          gh pr list -R "$REPO" --state open --json number,author,labels,updatedAt,statusCheckRollup --limit 500 | \
           jq -r '.[] | select(
             (.updatedAt | fromdateiso8601) < (now - 30*24*60*60) and
             .author.login != "jdx" and
@@ -22,8 +25,8 @@ jobs:
           while read -r pr status; do
             echo "Closing PR #$pr (checks: $status)"
             if [ "$status" = "failing" ]; then
-              gh pr close "$pr" -R jdx/hk -c "This PR has been open for more than 30 days without activity. Note: CI checks were failing, which may be why it wasn't reviewed. Feel free to reopen or create a new PR if you'd like to continue working on this."
+              gh pr close "$pr" -R "$REPO" -c "This PR has been open for more than 30 days without activity. Note: CI checks were failing, which may be why it wasn't reviewed. Feel free to reopen or create a new PR if you'd like to continue working on this."
             else
-              gh pr close "$pr" -R jdx/hk -c "This PR has been open for more than 30 days without activity. Feel free to reopen or create a new PR if you'd like to continue working on this."
+              gh pr close "$pr" -R "$REPO" -c "This PR has been open for more than 30 days without activity. Feel free to reopen or create a new PR if you'd like to continue working on this."
             fi
           done

--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -1,0 +1,29 @@
+name: pr-closer
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # daily at midnight
+  workflow_dispatch:
+
+jobs:
+  close-stale-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr list -R jdx/hk --state open --json number,author,labels,updatedAt,statusCheckRollup --limit 100 | \
+          jq -r '.[] | select(
+            (.updatedAt | fromdateiso8601) < (now - 30*24*60*60) and
+            .author.login != "jdx" and
+            ([.labels[].name] | index("keep-open") | not)
+          ) | [.number, (if (.statusCheckRollup | length > 0) and ([.statusCheckRollup[].conclusion] | index("FAILURE") or index("failure")) then "failing" else "passing" end)] | @tsv' | \
+          while read -r pr status; do
+            echo "Closing PR #$pr (checks: $status)"
+            if [ "$status" = "failing" ]; then
+              gh pr close "$pr" -R jdx/hk -c "This PR has been open for more than 30 days without activity. Note: CI checks were failing, which may be why it wasn't reviewed. Feel free to reopen or create a new PR if you'd like to continue working on this."
+            else
+              gh pr close "$pr" -R jdx/hk -c "This PR has been open for more than 30 days without activity. Feel free to reopen or create a new PR if you'd like to continue working on this."
+            fi
+          done


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-closer.yml`, ported from `jdx/mise`
- Runs daily and closes non-jdx PRs idle for 30+ days; uses a different message when CI was failing
- Skips PRs labeled `keep-open`

## Test plan
- [ ] Trigger via `workflow_dispatch` once merged to confirm it runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an automated GitHub Actions job that closes pull requests, which can unintentionally close active work if the search criteria or labels are misapplied. Otherwise isolated to repo maintenance and uses standard `GITHUB_TOKEN` permissions.
> 
> **Overview**
> Adds a new GitHub Actions workflow, `pr-closer`, that runs daily (and via manual dispatch) to close open PRs not updated in 30+ days.
> 
> The job excludes PRs authored by `jdx` and PRs labeled `keep-open`, and posts a different close comment when CI checks are detected as failing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfeef5d75a614c2fa59d7096c5f67bff79d5677d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->