### PR TITLE
fix(config): include main pkl path in cache fresh files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -162,10 +162,12 @@ impl Config {
             // Always include the main config file. The pklr backend's
             // analyze_imports does not include the source file in its
             // output, so without this edits to hk.pkl wouldn't invalidate
-            // the cache when HK_PKL_BACKEND=pklr.
-            let mut files: Vec<PathBuf> = imports.into_iter().collect();
-            files.push(path.clone());
-            files
+            // the cache when HK_PKL_BACKEND=pklr. Using IndexSet avoids
+            // double-listing the path on the pkl CLI backend, whose
+            // resolvedImports already contains it.
+            let mut files: IndexSet<PathBuf> = imports;
+            files.insert(path.clone());
+            files.into_iter().collect()
         } else {
             vec![path.clone()]
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,7 +159,13 @@ impl Config {
                 .get_or_try_init(|| Self::analyze_imports(&path))?
                 .clone();
 
-            imports.into_iter().collect()
+            // Always include the main config file. The pklr backend's
+            // analyze_imports does not include the source file in its
+            // output, so without this edits to hk.pkl wouldn't invalidate
+            // the cache when HK_PKL_BACKEND=pklr.
+            let mut files: Vec<PathBuf> = imports.into_iter().collect();
+            files.push(path.clone());
+            files
         } else {
             vec![path.clone()]
         };


### PR DESCRIPTION
## Summary

- Closes [discussion #877](https://github.com/jdx/hk/discussions/877).
- When `HK_PKL_BACKEND=pklr` was set, edits to `hk.pkl` weren't picked up until `hk cache clear` was run. The default `pkl` CLI didn't have this issue.
- Always append the main config `path` to the config cache's `fresh_files` so changes to `hk.pkl` invalidate the cache regardless of which backend's `analyze_imports` is used.

## Root cause

`Config::load_config_cached` built `fresh_files` from `analyze_imports`'s output. The two backends return different things:

- The **`pkl` CLI** path reads `pkl analyze imports`'s `resolvedImports` map. Its keys include the main file itself plus its transitive imports, so `hk.pkl` ended up in `fresh_files` by accident.
- **`pklr::analyze_imports`** parses the source and returns only the direct/transitive `import` URIs — it never includes the source file in its output.

With `pklr`, `fresh_files` therefore did not contain `hk.pkl`. Editing `hk.pkl` updated its mtime but no file in `fresh_files` was newer than the cache, so `is_fresh()` returned true and the stale `Config` was reused.

The pre-existing comment ``// Build the config cache with all fresh files (imports + main config)`` shows the intent already was *"imports + main config"* — this was a missed step in implementation, not a design decision.

## Test plan

- [x] Build with `mise run build`.
- [x] Reproduce against `main`: with `HK_PKL_BACKEND=pklr` and a scratch `hk.pkl`, run `hk check --why`, then rename a step name in `hk.pkl`. Confirmed `hk check --why` still reports the old name without the fix; reports the new name with the fix.
- [x] Repeat without `HK_PKL_BACKEND` (default backend): edits picked up correctly — no regression.
- [x] `mise run test:cargo` — 145 passed.
- [x] `test/config_pkl_imports.bats` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to cache invalidation inputs for `.pkl` configs, with minimal chance of side effects beyond slightly more frequent cache refreshes.
> 
> **Overview**
> Ensures `.pkl` config cache invalidation always considers the main config file by inserting `path` into the `fresh_files` set built from `analyze_imports`.
> 
> This fixes stale `Config` reuse when `HK_PKL_BACKEND=pklr`, where `analyze_imports` doesn’t include the source file (while avoiding duplicates for the `pkl` CLI backend via `IndexSet`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec979b05e946f7103db39eeffefdad4584c2922f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->