### PR TITLE
fix(builtins): silence pklr deprecation warnings on Builtins.pkl load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,9 +2066,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pklr"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7010962140d2369f8d1d287fa9b8862d4ca9d104621dcf614777efa33fccc545"
+checksum = "46a2a30479b1648d912e1d85b939ccab3813b8fcdd4c3f805f3fb8f2efa95215"
 dependencies = [
  "async-recursion",
  "indexmap 2.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ itertools          = "0.14"
 libc               = "0.2"
 log                = "0.4"
 once_cell          = "1"
-pklr               = "0.4.1"
+pklr               = "0.4.2"
 regex              = "1"
 semver             = "1"
 serde              = { version = "1", features = ["derive"] }

--- a/scripts/gen_builtins.py
+++ b/scripts/gen_builtins.py
@@ -40,14 +40,47 @@ class meta extends Annotation {
 """
 
 
+# Deprecated aliases. These point at a canonical builtin so loading
+# Builtins.pkl never reads a deprecated property — under pklr's lazy
+# @Deprecated handling (>= 0.4.2) the warning then fires only when a
+# user references e.g. `Builtins.check_byte_order_marker`.
+# (alias_name, canonical_name, since, message)
+DEPRECATED_ALIASES = [
+    (
+        "check_byte_order_marker",
+        "byte_order_marker",
+        "1.30.0",
+        "Use `Builtins.byte_order_marker`",
+    ),
+    (
+        "fix_byte_order_marker",
+        "byte_order_marker",
+        "1.30.0",
+        "Use `Builtins.byte_order_marker`",
+    ),
+]
+
+
 def main():
+    skip = {alias for alias, _, _, _ in DEPRECATED_ALIASES}
+
     # Generate pkl/Builtins.pkl
     with open("pkl/Builtins.pkl", "w", newline="\n") as f:
         f.write(HEADER)
         for filepath in sorted(glob.glob("pkl/builtins/*.pkl")):
             filename = os.path.splitext(os.path.basename(filepath))[0]
             identifier = filename.replace("-", "_")
+            if identifier in skip:
+                continue
             f.write(f'{identifier} = Builtins["builtins/{filename}.pkl"].{identifier}\n')
+
+        for alias, canonical, since, message in DEPRECATED_ALIASES:
+            f.write("\n")
+            f.write("@Deprecated {\n")
+            f.write(f'  since = "{since}"\n')
+            f.write(f'  message = "{message}"\n')
+            f.write("}\n")
+            f.write(f'{alias} = Builtins["builtins/{canonical}.pkl"].{canonical}\n')
 
     # pkl format (exits 11 after formatting, ignore that)
     subprocess.run(["pkl", "format", "--write", "pkl/Builtins.pkl"])

--- a/src/cli/migrate/pre_commit.rs
+++ b/src/cli/migrate/pre_commit.rs
@@ -1165,13 +1165,13 @@ impl PreCommit {
             "check_executables_have_shebangs",
         );
         map.insert("check-symlinks", "check_symlinks");
-        map.insert("check-byte-order-marker", "check_byte_order_marker");
+        map.insert("check-byte-order-marker", "byte_order_marker");
         map.insert("check-added-large-files", "check_added_large_files");
         map.insert("check-ast", "python_check_ast");
         map.insert("debug-statements", "python_debug_statements");
         map.insert("detect-private-key", "detect_private_key");
         map.insert("no-commit-to-branch", "no_commit_to_branch");
-        map.insert("fix-byte-order-marker", "fix_byte_order_marker");
+        map.insert("fix-byte-order-marker", "byte_order_marker");
 
         map
     }


### PR DESCRIPTION
## Summary

- Closes [discussion #878](https://github.com/jdx/hk/discussions/878).
- With `HK_PKL_BACKEND=pklr`, every load of `Builtins.pkl` printed `[pklr] WARNING: property 'check_byte_order_marker' is deprecated` and the same for `fix_byte_order_marker`, even when the user's `hk.pkl` did not reference those aliases.
- Combine the upstream pklr fix with a generator change so the warning only fires when a user actually references the deprecated aliases.

## Two coordinated changes

1. **Bump `pklr` 0.4.1 → 0.4.2** ([jdx/pklr#58](https://github.com/jdx/pklr/pull/58), [jdx/pklr#61](https://github.com/jdx/pklr/pull/61)). pklr now treats `@Deprecated` lazily — the warning fires on field access, not on module evaluation.
2. **`scripts/gen_builtins.py`**: special-case the deprecated aliases. Skip them in the auto-loop and emit them as `@Deprecated` bindings that point at the canonical `byte_order_marker` step. With this, `Builtins.pkl`'s own bindings no longer access a deprecated property at load, so even the lazy field-access warning stays silent until the user explicitly references `Builtins.check_byte_order_marker` / `.fix_byte_order_marker`.

The deprecated stub files (`pkl/builtins/check_byte_order_marker.pkl`, `pkl/builtins/fix_byte_order_marker.pkl`) keep their `@Deprecated` annotations untouched — the migration nudge is preserved for direct importers.

## Test plan

- [x] `mise run test:cargo` — 145 passed.
- [x] End-to-end with `HK_PKL_BACKEND=pklr`:
   - import `Builtins.pkl` without using deprecated aliases → **silent** (was 2× warnings per load).
   - access `Builtins.check_byte_order_marker` → warning fires once per evaluation.
- [x] `hk` pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a dependency patch bump and generation/mapping of builtin aliases to reduce deprecation warnings, with no impact on core hook execution logic beyond alias resolution.
> 
> **Overview**
> Stops `Builtins.pkl` from triggering deprecation warnings on load when using the `pklr` backend.
> 
> This bumps `pklr` from `0.4.1` to `0.4.2` and updates `scripts/gen_builtins.py` to *skip* generating deprecated builtin bindings in the main loop, then re-add them as explicit `@Deprecated` aliases pointing to the canonical `byte_order_marker` builtin.
> 
> The pre-commit migration map is updated so `check-byte-order-marker` and `fix-byte-order-marker` now resolve directly to `Builtins.byte_order_marker` instead of the deprecated alias names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 549c070740cce8b5377d574e464f0d17a2c7262f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->