### PR TITLE
ci(release): dedupe sponsor section in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,15 +181,16 @@ jobs:
           else
             TAG_NAME="${{ github.ref_name }}"
           fi
-          {
-            gh release view "$TAG_NAME" --json body --jq .body
-            cat <<'EOF'
-
+          gh release view "$TAG_NAME" --json body --jq .body \
+            | perl -0pe 's/\n*^##[^\n]*Sponsor hk\b.*\z//ms' \
+            > /tmp/release-notes.md
+          printf '\n\n' >> /tmp/release-notes.md
+          cat <<'EOF' >> /tmp/release-notes.md
           ## 💚 Sponsor hk
 
           hk is developed by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev) — a small independent studio behind developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Work on hk is funded by sponsorships.
 
           If hk has sped up your pre-commit loop or made linting feel less painful, please consider [sponsoring at en.dev](https://en.dev). Sponsorships are what keep hk moving and the project independent.
           EOF
-          } > /tmp/release-notes.md
+
           gh release edit "$TAG_NAME" --notes-file /tmp/release-notes.md


### PR DESCRIPTION
## Summary

- The `Append en.dev sponsor blurb` step in [.github/workflows/release.yml](.github/workflows/release.yml) was not idempotent. Under communique 1.1.x, the LLM reproduces a `## Sponsor hk` section verbatim from the previous release's body into the new body, and this step would then unconditionally append a second `## 💚 Sponsor hk` block on top — visible in [v1.44.2](https://github.com/jdx/hk/releases/tag/v1.44.2) (already manually fixed via `gh release edit`).
- Strip any existing `## …Sponsor hk` heading (and everything after it) from the live release body before appending the canonical blurb. Mirrors [jdx/communique#123](https://github.com/jdx/communique/pull/123).
- The regex `s/\n*^##[^\n]*Sponsor hk\b.*\z//ms` matches both the no-emoji form (`## Sponsor hk`, which communique generates because of `[defaults] emoji = false` in `communique.toml`) and the canonical `## 💚 Sponsor hk` form, so the step is self-healing on reruns.

## Why this differs slightly from the upstream communique fix

communique uses `s/\n*##\s+💚?\s*Sponsor communique\b.*\z//s`, which only works when the offending duplicate also contains 💚. That happens to be true in their repo because they don't set `emoji = false`. For hk, the LLM-injected duplicate has no emoji, so the byte-mode `💚?` quantifier (which makes only the last byte of the 4-byte UTF-8 sequence optional, not the whole codepoint) fails to match. The simpler `[^\n]*` form is byte-safe and matches both variants.

## Test plan

- [x] `actionlint .github/workflows/release.yml` passes
- [x] `yamllint .github/workflows/release.yml` passes
- [x] Manual dry-run: piping the live v1.44.2 body through the new regex strips both sponsor sections cleanly, leaving `**Full Changelog**: …` as the last meaningful line
- [x] Manual one-shot fix already applied to v1.44.2 release notes (sponsor count: 1)
- [ ] Next tagged release produces a body with exactly one `## 💚 Sponsor hk` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts how GitHub release notes are post-processed; main risk is accidentally stripping trailing content if the regex matches unexpectedly.
> 
> **Overview**
> Makes the `Append en.dev sponsor blurb` step in `.github/workflows/release.yml` idempotent by first fetching the current GitHub release body and stripping any existing `## …Sponsor hk` section (and everything after it) before appending the canonical sponsor blurb.
> 
> This prevents reruns/LLM-generated notes from producing duplicate sponsor sections in published release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9bed07948b41f960c74cebabd30f08984674005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->