### PR TITLE
docs: prefix GitHub star count with ★ glyph

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -27,7 +27,7 @@ export default {
           if (!githubLink.querySelector('.star-count')) {
             const starBadge = document.createElement('span')
             starBadge.className = 'star-count'
-            starBadge.textContent = starsData.stars
+            starBadge.textContent = `★ ${starsData.stars}`
             starBadge.title = 'GitHub Stars'
             githubLink.appendChild(starBadge)
           }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -27,8 +27,12 @@ export default {
           if (!githubLink.querySelector('.star-count')) {
             const starBadge = document.createElement('span')
             starBadge.className = 'star-count'
-            starBadge.textContent = `★ ${starsData.stars}`
             starBadge.title = 'GitHub Stars'
+            const glyph = document.createElement('span')
+            glyph.className = 'star-glyph'
+            glyph.textContent = '★'
+            glyph.setAttribute('aria-hidden', 'true')
+            starBadge.append(glyph, starsData.stars)
             githubLink.appendChild(starBadge)
           }
         })

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -399,6 +399,12 @@ h1, .vp-doc h1 {
   line-height: 1;
 }
 
+.VPSocialLinks .star-count .star-glyph {
+  font-family: -apple-system, "Segoe UI Symbol", sans-serif;
+  line-height: 1;
+  margin-right: 0.2em;
+}
+
 .VPSocialLinks a[href*="github.com/jdx/hk"]:hover .star-count {
   color: var(--vp-c-brand-1);
 }


### PR DESCRIPTION
Adds a small ★ (U+2605) before the GitHub stargazer count in the top-nav social link, so it reads "★ 784" instead of just "784".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change limited to VitePress docs theme DOM injection and CSS styling, with no data, auth, or behavioral impact beyond presentation.
> 
> **Overview**
> Updates the VitePress docs theme to render the GitHub star badge as `★ <count>` by inserting a new `.star-glyph` element before the existing star count text.
> 
> Adds small CSS rules to style the glyph (font fallback, spacing) while keeping existing hover and responsive behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f68fa47ec2da03ac11756ecfd931ce6767d80e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->