### PR TITLE
chore: switch analytics from gtm/goatcounter to plausible

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -107,24 +107,10 @@ export default defineConfig({
     [
       "script",
       {
-        async: "",
-        src: "https://www.googletagmanager.com/gtag/js?id=G-M7TEP8PKSE",
-      },
-    ],
-    [
-      "script",
-      {},
-      `window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-M7TEP8PKSE');`,
-    ],
-    [
-      "script",
-      {
-        "data-goatcounter": "https://jdx-hk.goatcounter.com/count",
-        async: "",
-        src: "//gc.zgo.at/count.js",
+        defer: "",
+        "data-domain": "pa-9rbZ17iM0rSRarywoulSW",
+        "data-api": "https://shrill.en.dev/f5f1/event",
+        src: "https://shrill.en.dev/shrill/script.js",
       },
     ],
     // OpenGraph


### PR DESCRIPTION
## Summary

- Drops Google Tag Manager and goatcounter from the docs site
- Adds Plausible Analytics via the shrill.en.dev Cloudflare worker proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the docs site analytics script injection in VitePress `head`. Main risk is misconfigured tracking due to changed script URL/attributes.
> 
> **Overview**
> Switches docs-site analytics from Google Tag Manager + GoatCounter to a single Plausible script loaded via the `shrill.en.dev` proxy, updating the `head` script tag to use `defer` and Plausible `data-domain`/`data-api` attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1fcf497c402028de6f7c75294c4099c0e89eff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->