### PR TITLE
fix: use site domain for plausible data-domain

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -108,7 +108,7 @@ export default defineConfig({
       "script",
       {
         defer: "",
-        "data-domain": "pa-9rbZ17iM0rSRarywoulSW",
+        "data-domain": "hk.jdx.dev",
         "data-api": "https://shrill.en.dev/f5f1/event",
         src: "https://shrill.en.dev/shrill/script.js",
       },


### PR DESCRIPTION
Follow-up to #885. The Plausible `data-domain` attribute was set to a Cloudflare Pages identifier (`pa-9rbZ...`) instead of the actual site domain. Plausible matches events by the `data-domain` value, so analytics arent being recorded.

Sets it to `hk.jdx.dev` to match how the merged mise PR (#9430) does it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line docs-site config tweak that only affects analytics attribution and should not impact runtime behavior beyond tracking.
> 
> **Overview**
> Updates the VitePress docs analytics script configuration to use the actual site domain (`hk.jdx.dev`) for the Plausible `data-domain` attribute instead of the Cloudflare Pages identifier, so pageview events are attributed correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e76643c2a0881f0dd1a61def89fdb13abe4d5c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->