### PR TITLE
fix: make text-mode progress output usable in CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,8 +390,7 @@ dependencies = [
 [[package]]
 name = "clx"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5a001156058931723b899569201add22c273d019c4f61642698fdcbcecb8e"
+source = "git+https://github.com/jdx/clx.git?branch=fix-text-mode-rendering#cb04fcd82776597ab1956a0225db2e1705cc2dd2"
 dependencies = [
  "console",
  "nix 0.31.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,8 +389,9 @@ dependencies = [
 
 [[package]]
 name = "clx"
-version = "2.0.0"
-source = "git+https://github.com/jdx/clx.git?branch=fix-text-mode-rendering#cb04fcd82776597ab1956a0225db2e1705cc2dd2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feaec225d4c0d5a2a738686605f0e6e8ccceb6691f80c567f22849636983ca8d"
 dependencies = [
  "console",
  "nix 0.31.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,10 @@ clap-sort = "1"
 inherits = "release"
 lto      = true
 
+# TODO: drop once clx 2.x ships with the text-mode rendering fix.
+[patch.crates-io]
+clx = { git = "https://github.com/jdx/clx.git", branch = "fix-text-mode-rendering" }
+
 [package.metadata.release]
 pre-release-hook = ["mise", "run", "pre-release", "--version", "{{version}}"]
 pre-release-replacements = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ arc-swap           = "1"
 chrono             = "0.4"
 clap               = { version = "4", features = ["derive"] }
 clap_usage         = "2"
-clx                = "2.0"
+clx                = "2.0.1"
 color-eyre         = "0.6"
 console            = "0.16"
 dashmap            = "6.1.0"
@@ -87,10 +87,6 @@ clap-sort = "1"
 [profile.serious]
 inherits = "release"
 lto      = true
-
-# TODO: drop once clx 2.x ships with the text-mode rendering fix.
-[patch.crates-io]
-clx = { git = "https://github.com/jdx/clx.git", branch = "fix-text-mode-rendering" }
 
 [package.metadata.release]
 pre-release-hook = ["mise", "run", "pre-release", "--version", "{{version}}"]

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -239,7 +239,7 @@ Example output shape:
 Type: `bool`
 Default: `false`
 
-Controls whether per-step output summaries are printed in plain text mode. By default, summaries are only shown when hk is rendering progress bars (non-text mode). Set this to `true` to force summaries to appear in text mode.
+Controls whether per-step output summaries are printed in plain text mode. In text mode, hk only emits summaries for **failed** steps by default (so CI logs always include the full diagnostic for a failure). Successful steps stream their output during execution, so a trailing summary would just duplicate it. Set this to `true` to force summaries to appear for every step in text mode.
 
 Example:
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -24,18 +24,6 @@ local linters = new Mapping<String, Step | Group> {
     glob = "**/*.rs"
     check = "! rg -e 'dbg!' {{files}}"
   }
-  // TEMP: deliberately failing step to capture the ugly clx failure output in CI.
-  // Remove once we've fixed the formatting in a follow-up.
-  ["demo-fail"] = new Step {
-    glob = "**/*.rs"
-    check =
-      #"""
-      echo "this step is intentionally failing so we can see what the output looks like"
-      echo "line two of stderr" 1>&2
-      echo "line three of stdout"
-      exit 1
-      """#
-  }
   ["eslint"] = (Builtins.eslint) {
     dir = "docs"
     prefix = "aube run"

--- a/hk.pkl
+++ b/hk.pkl
@@ -24,6 +24,18 @@ local linters = new Mapping<String, Step | Group> {
     glob = "**/*.rs"
     check = "! rg -e 'dbg!' {{files}}"
   }
+  // TEMP: deliberately failing step to capture the ugly clx failure output in CI.
+  // Remove once we've fixed the formatting in a follow-up.
+  ["demo-fail"] = new Step {
+    glob = "**/*.rs"
+    check =
+      #"""
+      echo "this step is intentionally failing so we can see what the output looks like"
+      echo "line two of stderr" 1>&2
+      echo "line three of stdout"
+      exit 1
+      """#
+  }
   ["eslint"] = (Builtins.eslint) {
     dir = "docs"
     prefix = "aube run"

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -153,6 +153,10 @@ pub struct HookContext {
     skipped_steps: std::sync::Mutex<IndexMap<String, SkipReason>>,
     /// Aggregated output per step name (in insertion order)
     pub output_by_step: std::sync::Mutex<IndexMap<String, (OutputSummary, String)>>,
+    /// Names of steps that failed during this run. Tracked here because
+    /// `step_contexts` are shift_remove'd as soon as each step finishes, so
+    /// status info is not available to the end-of-run summary.
+    pub failed_steps: std::sync::Mutex<HashSet<String>>,
     /// Collected fix suggestions to display at end of run
     pub fix_suggestions: std::sync::Mutex<Vec<String>>,
     pub should_stage: bool,
@@ -203,6 +207,7 @@ impl HookContext {
             skip_steps,
             skipped_steps: StdMutex::new(IndexMap::new()),
             output_by_step: StdMutex::new(IndexMap::new()),
+            failed_steps: StdMutex::new(HashSet::new()),
             fix_suggestions: StdMutex::new(Vec::new()),
             should_stage,
             initial_untracked,
@@ -290,6 +295,13 @@ impl HookContext {
         map.entry(step_name.to_string())
             .and_modify(|(_, s)| s.push_str(text))
             .or_insert_with(|| (mode, text.to_string()));
+    }
+
+    pub fn mark_step_failed(&self, step_name: &str) {
+        self.failed_steps
+            .lock()
+            .unwrap()
+            .insert(step_name.to_string());
     }
 
     pub fn add_fix_suggestion(&self, suggestion: String) {
@@ -1015,10 +1027,24 @@ impl Hook {
         // Clear progress bars before displaying summary
         clx::progress::stop();
 
-        // Display aggregated output from steps, once per step
-        if clx::progress::output() != ProgressOutput::Text || *env::HK_SUMMARY_TEXT {
+        // Display aggregated output from steps, once per step.
+        //
+        // In UI mode we always emit summaries because the progress display
+        // hides streamed output behind the spinner. In Text mode, successful
+        // steps already streamed their full output, so we suppress those
+        // summaries by default — but failed steps still get a summary so the
+        // user can see the diagnostic in full (text-mode streaming truncates
+        // each line via the `message` prop). `HK_SUMMARY_TEXT=1` forces all
+        // summaries to print in text mode.
+        let in_text_mode = clx::progress::output() == ProgressOutput::Text;
+        let force_summary = *env::HK_SUMMARY_TEXT;
+        let failed_steps = hook_ctx.failed_steps.lock().unwrap().clone();
+        if !in_text_mode || force_summary || !failed_steps.is_empty() {
             let outputs = hook_ctx.output_by_step.lock().unwrap().clone();
             for (step_name, (mode, output)) in outputs.into_iter() {
+                if in_text_mode && !force_summary && !failed_steps.contains(&step_name) {
+                    continue;
+                }
                 let trimmed = output.trim_end();
                 if trimmed.is_empty() {
                     continue;

--- a/src/step/output.rs
+++ b/src/step/output.rs
@@ -46,6 +46,10 @@ impl Step {
             return;
         }
 
+        if is_failure {
+            ctx.hook_ctx.mark_step_failed(&self.name);
+        }
+
         // On failure, use combined output so diagnostic messages are never
         // lost regardless of which stream the tool writes to — but keep
         // the configured label so tests/users see the expected header.

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -27,6 +27,24 @@ use super::shell::ShellType;
 use super::types::{Pattern, RunType, Script, Step};
 use crate::error::Error;
 
+/// Cap on the per-job progress message in printable characters. The
+/// rendered run command can be a multi-line shell script or contain
+/// inline-generated args; text mode prints every prop update verbatim,
+/// so an unbounded message floods CI logs. 2048 is generous for any
+/// realistic diagnostic and bounds the pathological case.
+const MAX_PROGRESS_MESSAGE_CHARS: usize = 2048;
+
+/// Truncate a progress message to `max_chars` printable characters with
+/// a trailing `…`. ANSI-aware via `console::truncate_str` so escape
+/// sequences don't get split mid-cluster or counted toward the budget.
+/// Returns the input unchanged if it fits.
+fn truncate_progress_message(s: &str, max_chars: usize) -> String {
+    if console::measure_text_width(s) <= max_chars {
+        return s.to_string();
+    }
+    console::truncate_str(s, max_chars, "…").into_owned()
+}
+
 impl Step {
     /// Execute a single job.
     ///
@@ -143,15 +161,19 @@ impl Step {
             Some(Pattern::Regex { pattern, .. }) => format!("regex: {}", pattern),
             None => String::new(),
         };
-        job.progress.as_ref().unwrap().prop(
-            "message",
-            &format!(
-                "{} – {} – {}",
-                file_msg(&job.files),
-                pattern_display,
-                run_for_display
-            ),
+        // Cap the full progress message: a `check =` value can be a
+        // multi-line shell script or an inline-generated command, and
+        // text mode prints every render verbatim. 2KB is generous for
+        // any realistic diagnostic and bounds the pathological case
+        // (e.g. a 200-line embedded script dumped on every prop update).
+        let raw_message = format!(
+            "{} – {} – {}",
+            file_msg(&job.files),
+            pattern_display,
+            run_for_display
         );
+        let message = truncate_progress_message(&raw_message, MAX_PROGRESS_MESSAGE_CHARS);
+        job.progress.as_ref().unwrap().prop("message", &message);
         job.progress.as_ref().unwrap().update();
         if log::log_enabled!(log::Level::Trace) {
             for file in &job.files {
@@ -415,6 +437,34 @@ impl Step {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncate_progress_message_passes_short_input() {
+        assert_eq!(truncate_progress_message("hello", 100), "hello");
+    }
+
+    #[test]
+    fn truncate_progress_message_caps_long_input() {
+        let s = "a".repeat(5000);
+        let out = truncate_progress_message(&s, 2048);
+        assert_eq!(console::measure_text_width(&out), 2048);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_progress_message_preserves_ansi_escapes() {
+        // Color escape + long plain run; truncation must be width-aware
+        // so the ANSI bytes don't count toward the budget.
+        let s = format!("\x1b[31m{}\x1b[0m", "a".repeat(100));
+        let out = truncate_progress_message(&s, 50);
+        assert_eq!(console::measure_text_width(&out), 50);
+    }
+
+    #[test]
+    fn truncate_progress_message_at_exact_length_unchanged() {
+        let s = "x".repeat(2048);
+        assert_eq!(truncate_progress_message(&s, 2048), s);
+    }
 
     #[test]
     fn test_has_command_for_empty_command() {

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -128,12 +128,14 @@ impl Step {
         if let Some(prefix) = &self.prefix {
             run = format!("{prefix} {run}");
         }
-        // Display message uses the un-rendered template — expanding `{{files}}`
-        // here would dump every matched path into the progress message, which
-        // in text mode (CI logs, piped stderr) is unbounded line-noise for
-        // steps that match hundreds of files. The pattern and file count
-        // shown next to it already tell the reader what's being processed.
-        let run_for_display = run.clone();
+        // Render twice: once with the full file list for execution, and
+        // once with the display context — which truncates `files` /
+        // `workspace_files` to `first_file …` when there are multiple
+        // files. A 98-file step would otherwise emit ~4KB of paths in the
+        // progress message; this keeps the command shape and one
+        // concrete example path visible without unbounded expansion.
+        let run_for_display =
+            tera::render(&run, &tctx.for_display()).unwrap_or_else(|_| run.clone());
         let run = tera::render(&run, &tctx)
             .wrap_err_with(|| format!("{self}: failed to render command template"))?;
         let pattern_display = match &self.glob {

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -128,6 +128,12 @@ impl Step {
         if let Some(prefix) = &self.prefix {
             run = format!("{prefix} {run}");
         }
+        // Display message uses the un-rendered template — expanding `{{files}}`
+        // here would dump every matched path into the progress message, which
+        // in text mode (CI logs, piped stderr) is unbounded line-noise for
+        // steps that match hundreds of files. The pattern and file count
+        // shown next to it already tell the reader what's being processed.
+        let run_for_display = run.clone();
         let run = tera::render(&run, &tctx)
             .wrap_err_with(|| format!("{self}: failed to render command template"))?;
         let pattern_display = match &self.glob {
@@ -137,7 +143,12 @@ impl Step {
         };
         job.progress.as_ref().unwrap().prop(
             "message",
-            &format!("{} – {} – {}", file_msg(&job.files), pattern_display, run),
+            &format!(
+                "{} – {} – {}",
+                file_msg(&job.files),
+                pattern_display,
+                run_for_display
+            ),
         );
         job.progress.as_ref().unwrap().update();
         if log::log_enabled!(log::Level::Trace) {

--- a/src/step_job.rs
+++ b/src/step_job.rs
@@ -94,8 +94,13 @@ impl StepJob {
             .body(
                 "{{spinner()}} {% if ensembler_cmd %}{{ensembler_cmd | flex}}{% if ensembler_stdout %}\n{{ensembler_stdout | flex}}{% endif %}{% else %}{{message | flex}}{% endif %}"
             )
+            // Text mode (CI / piped stderr) keeps the full message — the
+            // log viewer handles wrapping, and a 60-char truncate just hides
+            // the diagnostic detail callers actually need to debug a
+            // failure. The UI-mode `body` above still uses `flex` because
+            // the in-place renderer needs bounded line widths.
             .body_text(Some(
-                "{% if ensembler_stdout %}  {{name}} – {{ensembler_stdout | truncate_text}}{% elif message %}{{spinner()}} {{name}} – {{message | truncate_text}}{% endif %}".to_string(),
+                "{% if ensembler_stdout %}  {{name}} – {{ensembler_stdout}}{% elif message %}{{spinner()}} {{name}} – {{message}}{% endif %}".to_string(),
             ))
             .status(ProgressStatus::Hide)
             .on_done(ProgressJobDoneBehavior::Hide)

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -116,9 +116,7 @@ fn truncate_quoted_list(value: Option<&tera::Value>) -> Option<String> {
     let s = value.and_then(|v| v.as_str())?;
     let mut tokens = split_quoted_tokens(s);
     let first = tokens.next()?;
-    if tokens.next().is_none() {
-        return None;
-    }
+    tokens.next()?;
     Some(format!("{first} …"))
 }
 

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -91,4 +91,140 @@ impl Context {
         self.insert("workspace_files", &files);
         self
     }
+
+    /// Returns a clone of this context where `files` and `workspace_files`
+    /// are truncated to "first_file …" when there is more than one file.
+    /// Used to render the human-readable progress message — keeps the
+    /// rendered command compact for steps matching hundreds of files
+    /// while still showing one concrete path.
+    pub fn for_display(&self) -> Self {
+        let mut ctx = self.clone();
+        if let Some(truncated) = truncate_quoted_list(self.ctx.get("files")) {
+            ctx.insert("files", &truncated);
+        }
+        if let Some(truncated) = truncate_quoted_list(self.ctx.get("workspace_files")) {
+            ctx.insert("workspace_files", &truncated);
+        }
+        ctx
+    }
+}
+
+/// Truncate a space-separated quoted-token list to "first …" when it
+/// contains more than one token. Returns `None` if the value is missing,
+/// not a string, or has 0–1 tokens (no truncation needed).
+fn truncate_quoted_list(value: Option<&tera::Value>) -> Option<String> {
+    let s = value.and_then(|v| v.as_str())?;
+    let mut tokens = split_quoted_tokens(s);
+    let first = tokens.next()?;
+    if tokens.next().is_none() {
+        return None;
+    }
+    Some(format!("{first} …"))
+}
+
+/// Split a `with_files`-style joined string back into its quoted tokens.
+/// Tokens are space-separated; quoted tokens preserve embedded spaces.
+/// Honors `\\` escapes inside quoted runs because that's what `ShellType::quote`
+/// emits on Unix shells.
+fn split_quoted_tokens(s: &str) -> impl Iterator<Item = &str> {
+    let bytes = s.as_bytes();
+    let mut start = 0usize;
+    std::iter::from_fn(move || {
+        while start < bytes.len() && bytes[start] == b' ' {
+            start += 1;
+        }
+        if start >= bytes.len() {
+            return None;
+        }
+        let token_start = start;
+        let mut quote: Option<u8> = None;
+        let mut i = start;
+        while i < bytes.len() {
+            let b = bytes[i];
+            match quote {
+                Some(q) => {
+                    if b == b'\\' && i + 1 < bytes.len() {
+                        i += 2;
+                        continue;
+                    }
+                    if b == q {
+                        quote = None;
+                    }
+                }
+                None => {
+                    if b == b' ' {
+                        break;
+                    }
+                    if b == b'\'' || b == b'"' {
+                        quote = Some(b);
+                    }
+                }
+            }
+            i += 1;
+        }
+        let token = &s[token_start..i];
+        start = i;
+        Some(token)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn split(s: &str) -> Vec<&str> {
+        split_quoted_tokens(s).collect()
+    }
+
+    #[test]
+    fn split_quoted_tokens_handles_unquoted() {
+        assert_eq!(split("a b c"), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn split_quoted_tokens_preserves_single_quoted_spaces() {
+        assert_eq!(
+            split("'has space.txt' other.txt"),
+            vec!["'has space.txt'", "other.txt"]
+        );
+    }
+
+    #[test]
+    fn split_quoted_tokens_handles_escaped_quote_in_double() {
+        assert_eq!(split(r#""a\"b" c"#), vec![r#""a\"b""#, "c"]);
+    }
+
+    #[test]
+    fn truncate_quoted_list_returns_none_for_single_token() {
+        let v = json!("only.txt");
+        assert_eq!(truncate_quoted_list(Some(&v)), None);
+    }
+
+    #[test]
+    fn truncate_quoted_list_truncates_multiple_tokens() {
+        let v = json!("first.txt second.txt third.txt");
+        assert_eq!(
+            truncate_quoted_list(Some(&v)),
+            Some("first.txt …".to_string())
+        );
+    }
+
+    #[test]
+    fn truncate_quoted_list_preserves_quoted_first_token() {
+        let v = json!("'a b.txt' other.txt");
+        assert_eq!(
+            truncate_quoted_list(Some(&v)),
+            Some("'a b.txt' …".to_string())
+        );
+    }
+
+    #[test]
+    fn truncate_quoted_list_returns_none_for_empty_or_missing() {
+        assert_eq!(truncate_quoted_list(None), None);
+        let v = json!("");
+        assert_eq!(truncate_quoted_list(Some(&v)), None);
+        let v = json!("   ");
+        assert_eq!(truncate_quoted_list(Some(&v)), None);
+    }
 }

--- a/test/git.bats
+++ b/test/git.bats
@@ -104,27 +104,27 @@ hooks {
 }
 EOF
 
-    # The progress message keeps the un-rendered command template so steps
-    # matching hundreds of files don't blow up CI log lines (the file count
-    # next to it tells you how many were matched). The actual file list
-    # surfaces via the streamed `echo` stdout, which we assert separately.
+    # The progress message renders the command with `files` truncated to
+    # "first_file …" when there's more than one file — keeps CI log lines
+    # bounded for steps matching hundreds of files while still showing one
+    # concrete example. The full list still surfaces via streamed stdout.
 
     # Test files between base and feature
     run hk fix -v --from-ref=$BASE_COMMIT --to-ref=$FEATURE_COMMIT
     assert_success
-    assert_output --partial "print-files – 1 file –  – echo '{{files}}'"
+    assert_output --partial "print-files – 1 file –  – echo 'feature.txt'"
     assert_output --partial "print-files – feature.txt"
 
     # Test files between base and merge commit
     run hk fix --from-ref=$BASE_COMMIT --to-ref=$MERGE_COMMIT
     assert_success
-    assert_output --partial "print-files – 2 files –  – echo '{{files}}'"
+    assert_output --partial "print-files – 2 files –  – echo 'feature.txt …'"
     assert_output --partial "print-files – feature.txt main.txt"
 
     # Test files between feature and merge commit
     run hk fix --from-ref=$FEATURE_COMMIT --to-ref=$MERGE_COMMIT
     assert_success
-    assert_output --partial "print-files – 1 file –  – echo '{{files}}'"
+    assert_output --partial "print-files – 1 file –  – echo 'main.txt'"
     assert_output --partial "print-files – main.txt"
 }
 

--- a/test/git.bats
+++ b/test/git.bats
@@ -104,22 +104,27 @@ hooks {
 }
 EOF
 
+    # The progress message keeps the un-rendered command template so steps
+    # matching hundreds of files don't blow up CI log lines (the file count
+    # next to it tells you how many were matched). The actual file list
+    # surfaces via the streamed `echo` stdout, which we assert separately.
+
     # Test files between base and feature
     run hk fix -v --from-ref=$BASE_COMMIT --to-ref=$FEATURE_COMMIT
     assert_success
-    assert_output --partial "print-files – 1 file –  – echo 'feature.txt'"
+    assert_output --partial "print-files – 1 file –  – echo '{{files}}'"
     assert_output --partial "print-files – feature.txt"
 
     # Test files between base and merge commit
     run hk fix --from-ref=$BASE_COMMIT --to-ref=$MERGE_COMMIT
     assert_success
-    assert_output --partial "print-files – 2 files –  – echo 'feature.txt main.txt'"
+    assert_output --partial "print-files – 2 files –  – echo '{{files}}'"
     assert_output --partial "print-files – feature.txt main.txt"
 
     # Test files between feature and merge commit
     run hk fix --from-ref=$FEATURE_COMMIT --to-ref=$MERGE_COMMIT
     assert_success
-    assert_output --partial "print-files – 1 file –  – echo 'main.txt'"
+    assert_output --partial "print-files – 1 file –  – echo '{{files}}'"
     assert_output --partial "print-files – main.txt"
 }
 


### PR DESCRIPTION
## Summary

Cleans up hk's text-mode (CI / piped stderr) progress output. The previous behavior was unreadable in GitHub Actions logs: raw `[9A[80D[0J` cursor-control escapes leaked into the log, every status change duplicated, failure stderr was suppressed, and a step matching hundreds of files dumped ~4KB of paths into every progress line. After this PR a 14-step pre-commit run reads as a clean append-only stream with one full diagnostic block per failure.

## What changed

**Bumped clx 2.0 → 2.0.1** ([clx#86](https://github.com/jdx/clx/pull/86))
- `refresh_once()` is now a no-op in `ProgressOutput::Text` so terminal-state transitions and `stop()` don't leak UI escape codes
- `render_text_mode()` dedupes consecutive identical job lines per job (multiple props updated in quick succession no longer print the same line N times)
- `next_operation()` resets the dedup cache so multi-operation transitions are never silently swallowed

**Failure summaries shown in text mode** ([src/hook.rs](src/hook.rs))
- `HookContext.failed_steps: Mutex<HashSet<String>>` tracks failures so the end-of-run summary survives the `step_contexts.shift_remove` that fires when each step finishes
- In text mode, the per-step output summary block is now emitted for failed steps by default — successful steps stay quiet (their output already streamed). `HK_SUMMARY_TEXT=1` still forces every step's summary to print
- Docs updated for `HK_SUMMARY_TEXT` to reflect the new default behavior

**Bounded progress message rendering** ([src/step/runner.rs](src/step/runner.rs), [src/tera.rs](src/tera.rs), [src/step_job.rs](src/step_job.rs))
- New `Context::for_display()` returns a tera context where `files` / `workspace_files` are rewritten to `first_token …` when more than one file matches. The runner renders twice — display version for the progress message, full version for execution
- `truncate_progress_message()` caps the formatted progress message at 2048 printable chars with a trailing `…`, ANSI-aware so escape sequences don't get split mid-cluster
- Dropped the `truncate_text` filter from `step_job.rs` body_text — clx's filter clamped to (`term_width - 20`) which is `60` chars in non-TTY environments, cutting exactly the diagnostic detail you need to debug a CI failure

**Examples — `dbg` step matching 98 .rs files in CI:**
```
# before:
  dbg – 98 files – **/*.rs – ! rg -e 'dbg!' bin/generate_docs.rs build/generate_builtins.rs ... [continues for 98 paths] ...

# after:
  dbg – 98 files – **/*.rs – ! rg -e 'dbg!' bin/generate_docs.rs …
```

**Failed step in CI:**
```
# before (excerpt — full block was ~85 lines of escape-code-littered duplication):
[9A[80D[0J✔ files - Fetching all files in repo (671 files)
✗ demo-fail
✗ demo-fail
✗ demo-fail
✗ demo-fail – ERROR
[9A[80D[0J✔ files - Fetching all files in repo (671 files)
... (escape-code redraws repeat for every aborted sibling step)

# after:
  demo-fail – 98 files – **/*.rs – echo "..." (multi-line script)
  demo-fail – this step is intentionally failing so we can see what the output looks like
  demo-fail – line two of stderr
  demo-fail – line three of stdout
✗ demo-fail
✗ demo-fail – ERROR

demo-fail stderr:
this step is intentionally failing so we can see what the output looks like
line two of stderr
line three of stdout
```

## Test plan
- [x] `cargo test` — 149 pass (11 new across `src/tera.rs::tests` and `src/step::runner::tests`)
- [x] `mise run test:bats test/git.bats` — 4 pass under both libgit2 and nolibgit2 (assertions updated for `first_file …` display)
- [x] `mise run test:bats test/output_summary.bats test/output_summary_no_duplicate.bats test/output_summary_check_first.bats` — 11 pass
- [x] Verified end-to-end in CI via the (now-removed) `demo-fail` scaffolding step — see runs [25166877825](https://github.com/jdx/hk/actions/runs/25166877825) (before) and [25168039915](https://github.com/jdx/hk/actions/runs/25168039915) (after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)