### PR TITLE
fix(hook): do not stage fixes when fail_on_fix=true

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -826,6 +826,8 @@ impl Hook {
             return Ok(());
         }
         let run_type = self.run_type(&opts);
+        // fail_on_fix exists to surface fixes for review; staging would defeat that.
+        let should_stage = should_stage && !(self.fail_on_fix && matches!(run_type, RunType::Fix));
         let repo = Arc::new(Mutex::new(Git::new()?));
         let groups = self.get_step_groups(&opts);
         let stash_method = if let Some(stash_str) = &opts.stash {

--- a/test/fail_on_fix.bats
+++ b/test/fail_on_fix.bats
@@ -117,3 +117,53 @@ EOF
 
     hk run fix
 }
+
+@test "fail_on_fix=true preserves staged changes and surfaces fix as unstaged (#888)" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        fix = true
+        fail_on_fix = true
+        steps {
+            ["normalize"] {
+                glob = "*.json"
+                fix = #"for f in {{ files }}; do tr -d ' ' < "\$f" > "\$f.tmp" && mv "\$f.tmp" "\$f"; done"#
+            }
+        }
+    }
+}
+EOF
+    # Initial committed state has spaces that the fixer will strip.
+    echo '{"a": 1}' > a.json
+    echo "original" > b.md
+    git add hk.pkl a.json b.md
+    git commit -m "initial commit"
+    hk install
+
+    # User makes intentional changes to both files, but only stages a.json.
+    echo '{"a": 2}' > a.json
+    echo "modified" > b.md
+    git add a.json
+
+    # Pre-commit must fail with fail_on_fix.
+    run git commit -m "update"
+    assert_failure
+
+    # The user's staged change to a.json must survive: index still differs from HEAD
+    # in the test value, NOT in the formatting (which is the fixer's contribution).
+    run git diff --cached --name-only
+    assert_output "a.json"
+    run git diff --cached a.json
+    assert_output --partial '"a": 2'
+    refute_output --partial '{"a":2}'
+
+    # The fix should now be visible as an unstaged change on a.json (whitespace removed).
+    run git diff --name-only
+    assert_line "a.json"
+    assert_line "b.md"
+
+    # b.md unstaged change must be preserved.
+    run cat b.md
+    assert_output "modified"
+}


### PR DESCRIPTION
## Summary

When a hook has `fail_on_fix=true`, the step's auto-staging would silently re-stage the fixer's output over the user's explicit `git add` choices. After the failed commit:

- The user's staged changes were merged with / overwritten by the fix
- The fix was no longer visible as an unstaged change for review
- A re-commit would silently succeed with the fix baked in — defeating the entire point of `fail_on_fix`

This is the bug reported in [#888](https://github.com/jdx/hk/discussions/888).

## Fix

Force `should_stage = false` during fix runs when `fail_on_fix = true` ([src/hook.rs:828](https://github.com/jdx/hk/blob/claude/reverent-shaw-9d6102/src/hook.rs#L828)). The fixer's output stays in the worktree as an unstaged change, the user's staged changes are preserved, and a re-commit will fail again until the user explicitly accepts the fix.

After the fix, the user's reproduction scenario yields exactly what they expected:

```
=== git status AFTER failed commit ===
Changes to be committed:
        modified:   a.json        # user's original staged change preserved
Changes not staged for commit:
        modified:   a.json        # fixer's reformatting now visible for review
        modified:   b.md          # untouched
```

## Test plan

- [x] New regression test in `test/fail_on_fix.bats` reproducing the discussion scenario
- [x] All 5 `fail_on_fix.bats` tests pass in both `libgit2` and `nolibgit2` modes
- [x] All other stage / stash bats tests still pass
- [x] `cargo test` (145 tests) passes
- [x] Manual reproduction matches expected behavior

Closes #888

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `pre-commit`/hook execution behavior around git staging during fix runs, which can affect users’ commit contents. Scope is small and covered by a new regression test, but it touches git index/worktree semantics.
> 
> **Overview**
> Ensures `fail_on_fix=true` runs **do not auto-stage** fixer modifications by forcing `should_stage` off for `RunType::Fix`, so a failed hook leaves fixer edits as *unstaged* changes for review and does not overwrite the user’s staged selection.
> 
> Adds a Bats regression test reproducing #888 to verify a failed `pre-commit` preserves the original staged diff while exposing the fixer’s reformatting in the working tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a2b2022cd34785ac603e4101271684f3106d9f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->