### PR TITLE
ci: remove rust-cache from release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,14 +55,6 @@ jobs:
             build-tool: cargo
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - if: matrix.os != 'windows-latest'
-        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
-        with:
-          cache: rust
-      - if: matrix.os == 'windows-latest'
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: rust-${{ matrix.target }}
       - if: matrix.os == 'macos-latest'
         uses: apple-actions/import-codesign-certs@fe74d46e82474f87e1ba79832ad28a4013d0e33a # v6
         with:
@@ -160,9 +152,6 @@ jobs:
     runs-on: namespace-profile-endev-linux-amd64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
-        with:
-          cache: rust
       - uses: jdx/mise-action@b287efda3dc5f4f3c328507653b6617da783ff84 # v4
       - run: cargo publish
         env:


### PR DESCRIPTION
## Summary

- Drops `namespacelabs/nscloud-cache-action` (Linux/macOS) and `Swatinem/rust-cache` (Windows) from the `build-binaries` job in `.github/workflows/release.yml`
- Drops `nscloud-cache-action` from the `publish-crate` job

## Why

Release builds run once per tag against a clean checkout — incremental Rust caching doesn't save meaningful time and just adds restore/save overhead and storage.

## Test plan

- [ ] CI on the branch passes
- [ ] Next tagged release builds all binary targets and publishes the crate without the cache steps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that removes Rust caching from release jobs; main impact is potentially longer build times, not runtime behavior.
> 
> **Overview**
> Release workflow no longer restores/saves Rust build caches during `build-binaries` (dropping both `nscloud-cache-action` and `Swatinem/rust-cache`) and removes `nscloud-cache-action` from `publish-crate`.
> 
> This simplifies release CI by always building from a clean checkout without cache-related overhead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e1b3f5735fca91adebf1c3e1beb7cda5dc3bb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->