### PR TITLE
chore(docs): remove shrill.en.dev analytics script

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -104,15 +104,6 @@ export default defineConfig({
     }]
   },
   head: [
-    [
-      "script",
-      {
-        defer: "",
-        "data-domain": "hk.jdx.dev",
-        "data-api": "https://shrill.en.dev/f5f1/event",
-        src: "https://shrill.en.dev/shrill/script.js",
-      },
-    ],
     // OpenGraph
     ["meta", { property: "og:site_name", content: "hk" }],
     ["meta", { property: "og:type", content: "website" }],


### PR DESCRIPTION
Removes the proxied shrill.en.dev analytics snippet from the VitePress docs config — the endpoint is going away.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only removes a client-side analytics snippet from docs; no functional or data-path logic changes beyond tracking.
> 
> **Overview**
> Removes the `shrill.en.dev` analytics `<script>` entry from `docs/.vitepress/config.mts` `head`, so the docs site no longer loads the proxied tracking script.
> 
> No other docs configuration or rendering behavior is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a00e544b1f984c697201d4895bea5ef6c6c2786. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->