### PR TITLE
chore(ci): use !cancelled() instead of always() for final job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,9 @@ jobs:
       - msrv
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 1
-    if: always()
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
     steps:
       - name: Check CI job results
         run: |


### PR DESCRIPTION
## Summary
- Combined with the workflow's `cancel-in-progress` group, `if: always()` overrides cancellation and runs the `final` aggregator even on superseded commits.
- `!cancelled()` still runs on upstream success or failure but skips when the workflow is cancelled — saves a runner and avoids confusing error annotations on already-superseded shas.
- Caught by Cursor Bugbot on a sibling repo (endevco/pitchfork#413). Same `final`-aggregator pattern + `cancel-in-progress: true` here, so the same fix applies.

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adjusts when the `final` job runs; main impact is potentially skipping failure aggregation on cancelled/superseded runs.
> 
> **Overview**
> Updates the GitHub Actions `final` aggregator in `ci.yml` to use `if: ${{ !cancelled() }}` instead of `always()`, so it still runs after upstream success/failure but **does not run when the workflow is cancelled** (e.g., due to `cancel-in-progress`). This avoids consuming runners and emitting misleading failure annotations on superseded commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b8b543b10be8fbb1d9113eb439e9bb28d14a1e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->