### PR TITLE
chore: set dev profile debug to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,6 @@ pre-release-hook = ["mise", "run", "pre-release", "--version", "{{version}}"]
 pre-release-replacements = [
   { file = "pkl/Config.pkl", search = 'min_hk_version = ".*"', replace = 'min_hk_version = "{{version | truncate(length=1)}}.0.0"' },
 ]
+
+[profile.dev]
+debug = 1


### PR DESCRIPTION
## Summary

Reduces `target/` disk usage by setting `[profile.dev] debug = 1`, while keeping backtrace file:line info intact.

The default `debug = 2` writes full DWARF — including variable/type info that's only needed when stepping through code in a debugger (lldb/gdb). With `debug = 1`, panics, `RUST_BACKTRACE=1`, and error chains still resolve to file:line; only debugger variable inspection is reduced.

In practice this typically shrinks `target/` by a meaningful percentage, which adds up across worktrees.

## Test plan

- [ ] `cargo build` still succeeds
- [ ] CI is green

---
*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: build configuration-only change that reduces debug info in `dev` builds and may only affect stepping/variable inspection in debuggers.
> 
> **Overview**
> Adjusts Rust `dev` build settings by adding `[profile.dev] debug = 1` in `Cargo.toml`, reducing the amount of generated debug symbols (and typically `target/` size) while keeping file/line backtrace information.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f300b3981635c0a878bb5c0217a7cda305bbb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->