### PR TITLE
fix(stash): preserve fail_on_fix output with git stash

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -86,6 +86,7 @@ pub struct Git {
     stash: Option<StashType>,
     // Commit id of the stash entry we created (top-of-stack at creation time)
     stash_commit: Option<String>,
+    stashed_paths: Option<BTreeSet<PathBuf>>,
     saved_index: Option<Vec<(u32, String, PathBuf)>>,
     saved_worktree: Option<std::collections::HashMap<PathBuf, String>>,
 }
@@ -168,6 +169,7 @@ impl Git {
             repo,
             stash: None,
             stash_commit: None,
+            stashed_paths: None,
             saved_index: None,
             saved_worktree: None,
         })
@@ -741,8 +743,10 @@ impl Git {
         } else {
             Some(&subset_vec[..])
         };
+        self.stashed_paths = Some(files_to_stash);
         self.stash = self.push_stash(subset_opt, status)?;
         if self.stash.is_none() {
+            self.stashed_paths = None;
             job.prop("message", "No unstaged files to stash");
             job.set_status(ProgressStatus::Done);
             return Ok(());
@@ -948,6 +952,11 @@ impl Git {
                     .split('\0')
                     .filter(|s| !s.is_empty())
                     .map(PathBuf::from)
+                    .filter(|p| {
+                        self.stashed_paths
+                            .as_ref()
+                            .is_none_or(|stashed_paths| stashed_paths.contains(p))
+                    })
                     .collect();
 
                 // Build a map of CURRENT index (post-step) entries to re-stage Fixer blobs.
@@ -1350,6 +1359,7 @@ impl Git {
         // Clear saved snapshots now that we've restored
         self.saved_worktree = None;
         self.stash_commit = None;
+        self.stashed_paths = None;
         Ok(())
     }
 

--- a/test/fail_on_fix.bats
+++ b/test/fail_on_fix.bats
@@ -124,6 +124,7 @@ amends "$PKL_PATH/Config.pkl"
 hooks {
     ["pre-commit"] {
         fix = true
+        stash = "git"
         fail_on_fix = true
         steps {
             ["normalize"] {


### PR DESCRIPTION
## Summary
- track the exact paths selected for unstaged stashing
- filter manual stash restore to those paths so staged-only files are not rewritten from stash metadata
- exercise the #888 regression with `stash = "git"`

## Root Cause
`git stash show --name-only` can include staged files stored in the stash commit, even when those files were not part of the unstaged path set being restored. With `fail_on_fix=true` and `stash = "git"`, manual unstash could then rewrite a staged-only file and discard the fixer output that should remain visible as an unstaged diff.

## Validation
- `mise run test:bats test/fail_on_fix.bats`
- exact `jq` reproduction leaves `MM a.json` and ` M b.md`
- `cargo fmt --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches manual `git stash` restore logic used during hooks/commit flows; a bad filter or state reset could drop or misapply user changes, though scope is limited and covered by a regression test.
> 
> **Overview**
> Fixes a `stash = "git"` edge case where manual stash restoration could rewrite *staged-only* files and hide `fail_on_fix` fixer output.
> 
> The stash flow now records the exact path set selected for unstaged stashing (`stashed_paths`) and filters `git stash show --name-only` restoration to that set, clearing the tracking state when no stash is created and after restore.
> 
> Adds a Bats regression test for #888 that asserts staged changes remain staged while fixer output appears as an unstaged diff when `fail_on_fix=true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29f98cb7e2b804dbbaeb8f843b882ece1ac85ee2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->