### PR TITLE
chore: release v1.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,50 @@
 # Changelog
 
-## [1.45.0](https://github.com/jdx/hk/compare/v1.44.3..v1.45.0) - 2026-05-04
+## [1.46.0](https://github.com/jdx/hk/compare/v1.45.0..v1.46.0) - 2026-05-27
+
+### 🚀 Features
+
+- **(builtins)** add oxfmt config to hk builtin config by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#914](https://github.com/jdx/hk/pull/914)
+- **(builtins)** add vite-plus builtin configs to hk by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#913](https://github.com/jdx/hk/pull/913)
+- **(install)** skip local install when hk is configured globally by [@jdx](https://github.com/jdx) in [#934](https://github.com/jdx/hk/pull/934)
+- **(run)** add staged-only hook scope by [@jdx](https://github.com/jdx) in [#950](https://github.com/jdx/hk/pull/950)
+- update oxlint hook by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#911](https://github.com/jdx/hk/pull/911)
+
+### 🐛 Bug Fixes
+
+- **(check)** parse check_diff output for fix suggestions by [@jdx](https://github.com/jdx) in [#949](https://github.com/jdx/hk/pull/949)
+- **(install)** use absolute commands for global hooks by [@jdx](https://github.com/jdx) in [#939](https://github.com/jdx/hk/pull/939)
+- **(pre-push)** correct inverted ref filter and handle new-branch pushes by [@jdx](https://github.com/jdx) in [#932](https://github.com/jdx/hk/pull/932)
+- **(run)** expose post-checkout hook variables by [@jdx](https://github.com/jdx) in [#951](https://github.com/jdx/hk/pull/951)
+- **(stash)** preserve fail_on_fix output with git stash by [@jdx](https://github.com/jdx) in [#909](https://github.com/jdx/hk/pull/909)
+- **(stash)** preserve staged deletions across pop_stash by [@jdx](https://github.com/jdx) in [#927](https://github.com/jdx/hk/pull/927)
+- **(stash)** preserve fixer tail-line deletions in three-way merge by [@jdx](https://github.com/jdx) in [#931](https://github.com/jdx/hk/pull/931)
+
+### 🛡️ Security
+
+- **(ci)** add zizmor workflow for github actions security analysis by [@jdx](https://github.com/jdx) in [#925](https://github.com/jdx/hk/pull/925)
+
+### 🔍 Other Changes
+
+- **(ci)** remove autofix.ci workflow by [@jdx](https://github.com/jdx) in [#923](https://github.com/jdx/hk/pull/923)
+- **(ci)** assert mise run render produces no diff by [@jdx](https://github.com/jdx) in [#924](https://github.com/jdx/hk/pull/924)
+- **(ci)** close failing or conflicted PRs sooner by [@jdx](https://github.com/jdx) in [#936](https://github.com/jdx/hk/pull/936)
+- remove pull_request_target workflow by [@jdx](https://github.com/jdx) in [#921](https://github.com/jdx/hk/pull/921)
+- remove caching from publishing workflows by [@jdx](https://github.com/jdx) in [#922](https://github.com/jdx/hk/pull/922)
+
+### 📦️ Dependency Updates
+
+- update anthropics/claude-code-action digest to 939ae9c by [@renovate[bot]](https://github.com/renovate[bot]) in [#912](https://github.com/jdx/hk/pull/912)
+- update anthropics/claude-code-action digest to 034cbdb by [@renovate[bot]](https://github.com/renovate[bot]) in [#916](https://github.com/jdx/hk/pull/916)
+- update actions-rust-lang/setup-rust-toolchain digest to 46268bd by [@renovate[bot]](https://github.com/renovate[bot]) in [#915](https://github.com/jdx/hk/pull/915)
+- update anthropics/claude-code-action digest to ad67978 by [@renovate[bot]](https://github.com/renovate[bot]) in [#917](https://github.com/jdx/hk/pull/917)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#918](https://github.com/jdx/hk/pull/918)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#938](https://github.com/jdx/hk/pull/938)
+- update anthropics/claude-code-action action to v1.0.123 by [@renovate[bot]](https://github.com/renovate[bot]) in [#945](https://github.com/jdx/hk/pull/945)
+- update zizmorcore/zizmor-action action to v0.5.4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#946](https://github.com/jdx/hk/pull/946)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#947](https://github.com/jdx/hk/pull/947)
+
+## [1.45.0](https://github.com/jdx/hk/compare/v1.44.3..v1.45.0) - 2026-05-05
 
 ### 🚀 Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1054,7 +1054,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.45.0"
+version = "1.46.0"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -1121,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1178,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1595,9 +1595,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -1651,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -1672,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "miette"
@@ -2327,9 +2327,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -4124,18 +4124,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "hk"
 repository = "https://github.com/jdx/hk"
 rust-version = "1.88.0"
-version = "1.45.0"
+version = "1.46.0"
 
 [[bin]]
 name = "generate-docs"

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 90+ pre-configured linters and formatters through the `Builtins` mod
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -4929,7 +4929,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.45.0",
+  "version": "1.46.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.45.0
+**Version**: 1.46.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // linters can be manually defined
@@ -208,8 +208,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -242,7 +242,7 @@ Add steps to your hkrc. hk merges them into every project's hooks — steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -335,7 +335,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,8 +105,8 @@ Separately from global *hooks*, you can also create a global *config* file that 
 This will generate a `hk.pkl` file in the root of the repository, here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // linters can be manually defined

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -43,7 +43,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
 
 `pre-commit` {
     ["prelint"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,8 +3,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,8 +3,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,8 +3,8 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,8 +4,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -7,8 +7,8 @@
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
 
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -7,8 +7,8 @@
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
 
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -7,8 +7,8 @@
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -8,8 +8,8 @@
 /// * Sorts imports with isort
 /// * Validates with flake8
 
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.46.0/hk@1.46.0#/Config.pkl"
 amends "pkl/Config.pkl"
 import "pkl/Builtins.pkl"
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.45.0"
+version "1.46.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)" hide=#true global=#true {


### PR DESCRIPTION
### 🚀 Features

- **(builtins)** add oxfmt config to hk builtin config by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#914](https://github.com/jdx/hk/pull/914)
- **(builtins)** add vite-plus builtin configs to hk by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#913](https://github.com/jdx/hk/pull/913)
- **(install)** skip local install when hk is configured globally by [@jdx](https://github.com/jdx) in [#934](https://github.com/jdx/hk/pull/934)
- **(run)** add staged-only hook scope by [@jdx](https://github.com/jdx) in [#950](https://github.com/jdx/hk/pull/950)
- update oxlint hook by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#911](https://github.com/jdx/hk/pull/911)

### 🐛 Bug Fixes

- **(check)** parse check_diff output for fix suggestions by [@jdx](https://github.com/jdx) in [#949](https://github.com/jdx/hk/pull/949)
- **(install)** use absolute commands for global hooks by [@jdx](https://github.com/jdx) in [#939](https://github.com/jdx/hk/pull/939)
- **(pre-push)** correct inverted ref filter and handle new-branch pushes by [@jdx](https://github.com/jdx) in [#932](https://github.com/jdx/hk/pull/932)
- **(run)** expose post-checkout hook variables by [@jdx](https://github.com/jdx) in [#951](https://github.com/jdx/hk/pull/951)
- **(stash)** preserve fail_on_fix output with git stash by [@jdx](https://github.com/jdx) in [#909](https://github.com/jdx/hk/pull/909)
- **(stash)** preserve staged deletions across pop_stash by [@jdx](https://github.com/jdx) in [#927](https://github.com/jdx/hk/pull/927)
- **(stash)** preserve fixer tail-line deletions in three-way merge by [@jdx](https://github.com/jdx) in [#931](https://github.com/jdx/hk/pull/931)

### 🛡️ Security

- **(ci)** add zizmor workflow for github actions security analysis by [@jdx](https://github.com/jdx) in [#925](https://github.com/jdx/hk/pull/925)

### 🔍 Other Changes

- **(ci)** remove autofix.ci workflow by [@jdx](https://github.com/jdx) in [#923](https://github.com/jdx/hk/pull/923)
- **(ci)** assert mise run render produces no diff by [@jdx](https://github.com/jdx) in [#924](https://github.com/jdx/hk/pull/924)
- **(ci)** close failing or conflicted PRs sooner by [@jdx](https://github.com/jdx) in [#936](https://github.com/jdx/hk/pull/936)
- remove pull_request_target workflow by [@jdx](https://github.com/jdx) in [#921](https://github.com/jdx/hk/pull/921)
- remove caching from publishing workflows by [@jdx](https://github.com/jdx) in [#922](https://github.com/jdx/hk/pull/922)

### 📦️ Dependency Updates

- update anthropics/claude-code-action digest to 939ae9c by [@renovate[bot]](https://github.com/renovate[bot]) in [#912](https://github.com/jdx/hk/pull/912)
- update anthropics/claude-code-action digest to 034cbdb by [@renovate[bot]](https://github.com/renovate[bot]) in [#916](https://github.com/jdx/hk/pull/916)
- update actions-rust-lang/setup-rust-toolchain digest to 46268bd by [@renovate[bot]](https://github.com/renovate[bot]) in [#915](https://github.com/jdx/hk/pull/915)
- update anthropics/claude-code-action digest to ad67978 by [@renovate[bot]](https://github.com/renovate[bot]) in [#917](https://github.com/jdx/hk/pull/917)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#918](https://github.com/jdx/hk/pull/918)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#938](https://github.com/jdx/hk/pull/938)
- update anthropics/claude-code-action action to v1.0.123 by [@renovate[bot]](https://github.com/renovate[bot]) in [#945](https://github.com/jdx/hk/pull/945)
- update zizmorcore/zizmor-action action to v0.5.4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#946](https://github.com/jdx/hk/pull/946)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#947](https://github.com/jdx/hk/pull/947)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical release bump and regenerated docs/lockfile; behavioral changes are already merged and only summarized in the changelog.
> 
> **Overview**
> This PR **bumps the project to v1.46.0** and records what shipped since v1.45.0. It updates **`Cargo.toml`**, **`Cargo.lock`** (including minor transitive crate bumps), **`hk.usage.kdl`**, generated CLI docs, and every **`package://…/v1.46.0`** reference in docs and example `hk.pkl` files.
> 
> The new **`CHANGELOG.md`** entry documents the release: **staged-only** hook scope, **oxfmt** / **vite-plus** builtins, global-install behavior, **check_diff** fix suggestions, **pre-push** ref handling, **post-checkout** env vars, several **stash** / **fail_on_fix** fixes, CI workflow changes (e.g. **zizmor**), and Renovate dependency updates. No application logic changes appear in this diff—only versioning, lockfile, and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01ddb649c565626fb6b1fd935f7137ef2cddf0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->