### PR TITLE
feat(builtins): add oxfmt config to hk builtin config

### DIFF
--- a/pkl/builtins/oxfmt.pkl
+++ b/pkl/builtins/oxfmt.pkl
@@ -1,0 +1,73 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+import "./test/helpers.pkl"
+
+@Builtins.meta {
+  category = "JavaScript/TypeScript"
+  description = "Fast Rust-powered code formatter (Prettier compatible)"
+  project_indicators {
+    new { file = "package.json"; contains = "\"oxfmt\"" }
+    // https://oxc.rs/docs/guide/usage/formatter/config.html#create-a-config-file
+    new { file = ".oxfmtrc.json" }
+    new { file = ".oxfmtrc.jsonc" }
+    new { file = "oxfmt.config.ts" }
+  }
+}
+oxfmt = new Config.Step {
+  // Supported file types:
+  //   https://oxc.rs/docs/guide/usage/formatter.html
+  //   https://github.com/oxc-project/oxc/blob/apps_v1.56.0/apps/oxfmt/src/core/support.rs#L147
+  glob =
+    List(
+      // JS/TS
+      "**/*.js",
+      "**/*.mjs",
+      "**/*.cjs",
+      "**/*.ts",
+      "**/*.mts",
+      "**/*.cts",
+      // React
+      "**/*.jsx",
+      "**/*.tsx",
+      "**/*.mdx",
+      // Frontend Frameworks
+      "**/*.vue",
+      // JSON
+      "**/*.json",
+      "**/*.jsonc",
+      "**/*.json5",
+      // YAML
+      "**/*.yaml",
+      "**/*.yml",
+      // TOML
+      "**/*.toml",
+      // Markdown
+      "**/*.md",
+      // HTML
+      "**/*.html",
+      "**/*.htm",
+      // CSS
+      "**/*.css",
+      "**/*.scss",
+      "**/*.less",
+      // GraphQL
+      "**/*.graphql",
+      "**/*.gql",
+      // Handlebars
+      "**/*.handlebars",
+      "**/*.hbs",
+    )
+  check = "oxfmt --check {{ files }}"
+  check_list_files = "oxfmt --list-different {{ files }}"
+  fix = "oxfmt --write {{ files }}"
+  tests {
+    local const testMaker = new helpers.TestMaker { filename = "foo.ts" }
+    // Source: https://github.com/oxc-project/oxc/blob/apps_v1.63.0/apps/oxfmt/test/api/basic.test.ts
+    local const bad = "const x:number=42"
+    local const good = "const x: number = 42;\n"
+    ["check bad file"] = testMaker.checkFail(bad, 1)
+    ["check good file"] = testMaker.checkPass(good)
+    ["fix bad file"] = testMaker.fixPass(bad, good)
+    ["fix good file"] = testMaker.fixPass(good, good)
+  }
+}

--- a/pkl/builtins/oxfmt.pkl
+++ b/pkl/builtins/oxfmt.pkl
@@ -43,6 +43,7 @@ oxfmt = new Config.Step {
       "**/*.toml",
       // Markdown
       "**/*.md",
+      "**/*.markdown",
       // HTML
       "**/*.html",
       "**/*.htm",

--- a/test/builtin_tool_stubs/oxfmt
+++ b/test/builtin_tool_stubs/oxfmt
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "0.48.0"
+tool = "npm:oxfmt"


### PR DESCRIPTION
Add [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) as a new builtin formatter for JavaScript/TypeScript and JSON, YAML and TOML.

#744 could not be reopened, so I recreated it.