### PR TITLE
fix(git): fall back to shell git when libgit2 rejects relativeworktrees

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -170,7 +170,10 @@ impl Git {
                 // relativeworktrees". Fall back to shell git for these — the
                 // rest of this module already supports a `None` repo. Remove
                 // this branch once vendored libgit2 ships native support.
-                Err(e) if e.message().contains("unsupported extension") => {
+                Err(e)
+                    if e.message().contains("unsupported extension")
+                        && e.message().contains("relativeworktrees") =>
+                {
                     warn!(
                         "libgit2 cannot open this repository ({}); falling back to shell git",
                         e.message()

--- a/src/git.rs
+++ b/src/git.rs
@@ -140,26 +140,46 @@ impl Git {
         std::env::set_current_dir(&root)?;
         let repo = if *env::HK_LIBGIT2 {
             debug!("libgit2: true");
-            let repo = if has_git_env {
-                Repository::open_from_env().wrap_err("failed to open repository")?
+            let opened = if has_git_env {
+                Repository::open_from_env()
             } else {
-                Repository::open(".").wrap_err("failed to open repository")?
+                Repository::open(".")
             };
-            // libgit2 status/diff APIs refuse to operate on a bare repository.
-            // For bare-repo dotfile managers (YADM, etc.) the work tree is
-            // provided via GIT_WORK_TREE but libgit2 still flags the repo as
-            // bare — fall back to the shell-git path so those operations work.
-            if repo.is_bare() {
-                debug!("libgit2: bare repo detected, falling back to shell git");
-                None
-            } else {
-                if let Some(index_file) = &*env::GIT_INDEX_FILE {
-                    // sets index to .git/index.lock which is used in the case of `git commit -a`
-                    let mut index =
-                        git2::Index::open(index_file).wrap_err("failed to get index")?;
-                    repo.set_index(&mut index)?;
+            match opened {
+                // libgit2 status/diff APIs refuse to operate on a bare repository.
+                // For bare-repo dotfile managers (YADM, etc.) the work tree is
+                // provided via GIT_WORK_TREE but libgit2 still flags the repo as
+                // bare — fall back to the shell-git path so those operations work.
+                Ok(repo) if repo.is_bare() => {
+                    debug!("libgit2: bare repo detected, falling back to shell git");
+                    None
                 }
-                Some(repo)
+                Ok(repo) => {
+                    if let Some(index_file) = &*env::GIT_INDEX_FILE {
+                        // sets index to .git/index.lock which is used in the case of `git commit -a`
+                        let mut index =
+                            git2::Index::open(index_file).wrap_err("failed to get index")?;
+                        repo.set_index(&mut index)?;
+                    }
+                    Some(repo)
+                }
+                // The bundled libgit2 doesn't recognize the `relativeworktrees`
+                // extension (set when a worktree is created with
+                // `git worktree add --relative-paths`, Git ≥ 2.48), so it refuses
+                // to open such repos with "unsupported extension
+                // relativeworktrees". Fall back to shell git for these — the
+                // rest of this module already supports a `None` repo. Remove
+                // this branch once vendored libgit2 ships native support.
+                Err(e) if e.message().contains("unsupported extension") => {
+                    warn!(
+                        "libgit2 cannot open this repository ({}); falling back to shell git",
+                        e.message()
+                    );
+                    None
+                }
+                Err(e) => {
+                    return Err(eyre::Report::new(e).wrap_err("failed to open repository"));
+                }
             }
         } else {
             debug!("libgit2: false");


### PR DESCRIPTION
## Summary

Running `hk` inside a worktree created with `git worktree add --relative-paths` (Git ≥ 2.48) currently fails immediately with:

```
unsupported extension name extensions.relativeworktrees
```

The error originates in the bundled libgit2, which doesn't yet recognize the `relativeworktrees` repository extension. Because `Git::new()` propagated the libgit2 open error verbatim, the whole CLI was unusable in such worktrees — including for users who didn't opt in to `--relative-paths` themselves but inherited the layout from tooling that does.

## Fix

`src/git.rs` already supports a `repo: Option<Repository>` shape with a complete shell-git fallback path (used for `HK_LIBGIT2=false` and bare repos). This change extends the same fallback to the relativeworktrees case:

- If `Repository::open` / `Repository::open_from_env` returns an error whose message contains `"unsupported extension"`, set `repo = None`, log a warning, and continue. Every downstream `if let Some(repo) = &self.repo { ... } else { /* shell git */ }` site then transparently uses the shell-git path.
- Any other libgit2 open error continues to propagate as before, so genuine repo-corruption issues still surface loudly.
- The fallback branch is documented as removable once vendored libgit2 ships native support for the extension.

## Test plan

Manually verified against a freshly built release binary on macOS (Git 2.52, libgit2 from `git2 = "0.20"` with `vendored-libgit2`):

- [x] In a worktree created with `git worktree add --relative-paths …`, `HK_LIBGIT2=true hk check` previously errored out at `Git::new()`; with this change it logs `hk WARN libgit2 cannot open this repository (unsupported extension name extensions.relativeworktrees); falling back to shell git` and runs the hook to completion (exit 0).
- [x] In a standard (absolute-path) worktree, `HK_LIBGIT2=true hk check` still uses libgit2 — no warning emitted, no behavior change.
- [x] `HK_LIBGIT2=false hk check` is unaffected (libgit2 branch not entered).
- [x] `cargo check`, `cargo clippy --no-deps`, and `cargo fmt --check` are clean.

*This PR was prepared with the help of Claude Code.*