### PR TITLE
ci: remove caching from publishing workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -26,9 +26,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.HK_GH_TOKEN }}
-      - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
-        with:
-          cache: rust
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           experimental: true


### PR DESCRIPTION
## Summary
- Strips cache actions (`nscloud-cache-action`, `Swatinem/rust-cache`, `actions/cache`) from release / release-plz / publishing workflows.
- These workflows have elevated permissions (write tokens, signing keys, registry credentials). Even with Namespace's protected-branches setting and GHA's ref-scoped cache enforcement, the simplest defense for the publishing surface is to not depend on any cache at all — builds re-run from clean each time.
- For mise's `release-plz.yml`, also removes the now-pointless sccache install/configure since it had no persistent backing store without the nscloud cache.

## Test plan
- [ ] Releases still build successfully (cold cache; expect slower but functional).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk and limited to CI configuration, but may increase release build times and could surface previously-masked dependency/build issues due to cold builds.
> 
> **Overview**
> Removes `namespacelabs/nscloud-cache-action` from `.github/workflows/release-plz.yml`, so the `release-plz` job no longer restores/persists the Rust cache and instead runs `mise run release-plz` on a clean environment each time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 429496481023f9613ef80e939b2614070bed2f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->