### PR TITLE
chore(ci): assert mise run render produces no diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             echo "::error::'mise run render' produced changes. Run it locally and commit."
             git status
-            git diff
+            git diff HEAD
             exit 1
           fi
       - name: mise run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,16 @@ jobs:
       - run: mise x -- aube install
       - name: mise run test:cargo
         run: mise run test:cargo
+      - name: mise run render
+        run: mise run render
+      - name: assert render produces no diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::'mise run render' produced changes. Run it locally and commit."
+            git status
+            git diff
+            exit 1
+          fi
       - name: mise run lint
         run: mise run lint
   msrv:


### PR DESCRIPTION
Runs `mise run render` and asserts it produces no diff. Follows up the autofix.ci workflow removal in #923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the GitHub Actions workflow to run a render step and fail when it produces uncommitted changes, with no production code impact.
> 
> **Overview**
> Adds a `mise run render` step to the `ci-other` GitHub Actions job and then **fails the workflow if the working tree is dirty** (printing `git status`/`git diff`) to ensure generated/rendered artifacts are committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b4475e1180ae445bfc92284d752026061a8b7df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->