### PR TITLE
chore(ci): add zizmor workflow for github actions security analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,12 @@ env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions: {}
+
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -30,10 +34,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
         with:
           cache: rust
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
       - run: mise run build
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -42,9 +50,15 @@ jobs:
   build-windows:
     runs-on: windows-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
       - name: Build
         run: cargo build --features git2/vendored-libgit2,git2/vendored-openssl
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -53,6 +67,8 @@ jobs:
           path: target/debug/hk.exe
   ci-libgit2:
     needs: build
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +83,11 @@ jobs:
       - run: brew install parallel
         if: ${{ matrix.os == 'macos-latest' }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           toolchain: nightly
@@ -87,6 +107,8 @@ jobs:
           command: mise run test:bats:libgit2
   ci-nolibgit2:
     needs: build
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -101,7 +123,11 @@ jobs:
       - run: brew install parallel
         if: ${{ matrix.os == 'macos-latest' }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           toolchain: nightly
@@ -121,6 +147,8 @@ jobs:
           command: mise run test:bats:nolibgit2
   ci-nogit:
     needs: build
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -136,7 +164,11 @@ jobs:
       - run: brew install parallel
         if: ${{ matrix.os == 'macos-latest' }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
           toolchain: nightly
@@ -155,6 +187,8 @@ jobs:
           max_attempts: 3
           command: mise run test:bats:nogit
   ci-other:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -169,10 +203,14 @@ jobs:
       - run: brew install parallel
         if: ${{ matrix.os == 'macos-latest' }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
         with:
           cache: rust
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
       - run: mise x -- aube install
       - name: mise run test:cargo
         run: mise run test:cargo
@@ -191,21 +229,35 @@ jobs:
   msrv:
     runs-on: namespace-profile-endev-linux-amd64
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
         with:
           cache: rust
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
       - run: mise run msrv
   ci-windows:
     needs: build-windows
     runs-on: windows-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          lookup-only: true
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: hk-windows-latest
@@ -223,6 +275,7 @@ jobs:
           # Regression test for discussion #823 (cmd.exe {{files}} quoting)
           ./e2e-win/run.ps1 -TestName "*{{files}} template*"
   final:
+    permissions: {}
     needs:
       - build
       - build-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          lookup-only: true
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # zizmor: ignore[cache-poisoning] v2
       - name: Build
         run: cargo build --features git2/vendored-libgit2,git2/vendored-openssl
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -252,9 +250,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          lookup-only: true
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # zizmor: ignore[cache-poisoning] v2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           cache: false

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@ad67978e5eb3fc76e3c86855adc19db5673fa818 # v1
+        uses: anthropics/claude-code-action@ad67978e5eb3fc76e3c86855adc19db5673fa818 # v1.0.118
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,11 +16,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -33,11 +29,14 @@ jobs:
   build:
     if: github.repository == 'jdx/hk'
     runs-on: namespace-profile-endev-linux-amd64
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
+          persist-credentials: false
       - uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
         with:
           cache: rust

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: namespace-profile-endev-linux-amd64
     permissions:
       contents: read
+      # actions/configure-pages needs pages permission to enable Pages on the repo.
+      pages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -26,9 +26,11 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.HK_GH_TOKEN }}
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           experimental: true
+          cache: false
       - run: mise trust --all
       - run: mise run release-plz
         env:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,8 +1,6 @@
 name: release-plz
 
-permissions:
-  pull-requests: write
-  contents: write
+permissions: {}
 
 on:
   workflow_dispatch: {}
@@ -21,12 +19,17 @@ jobs:
   release-plz:
     if: github.repository == 'jdx/hk'
     runs-on: namespace-profile-endev-linux-amd64
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # release-plz needs persisted credentials so the mise-tasks/release-plz
+      # script's `git push --tags` / `git push origin release --force` can
+      # authenticate.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # zizmor: ignore[artipacked] v6
         with:
           fetch-depth: 0
           token: ${{ secrets.HK_GH_TOKEN }}
-          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           experimental: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           cache: false
-      - run: cargo publish
+      - run: cargo publish # zizmor: ignore[use-trusted-publishing]
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: release
 
-permissions:
-  contents: write
+permissions: {}
 
 on:
   push:
@@ -21,6 +20,8 @@ env:
 jobs:
   build-binaries:
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -55,6 +56,8 @@ jobs:
             build-tool: cargo
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - if: matrix.os == 'macos-latest'
         uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7
         with:
@@ -83,15 +86,24 @@ jobs:
 
   build-pkl:
     runs-on: namespace-profile-endev-linux-amd64
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
       - name: Package Pkl
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            TAG_NAME="v${{ inputs.version }}"
+          if [[ -n "${INPUTS_VERSION}" ]]; then
+            TAG_NAME="v${INPUTS_VERSION}"
           else
-            TAG_NAME="${{ github.ref_name }}"
+            TAG_NAME="${GITHUB_REF_NAME}"
           fi
           VERSION="${TAG_NAME#v}"
           echo "Building pkl package for version: $VERSION"
@@ -111,11 +123,16 @@ jobs:
   create-release:
     needs: [build-binaries, build-pkl]
     runs-on: namespace-profile-endev-linux-amd64
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
       - name: Extract release notes from CHANGELOG.md
         run: |
           awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md > release-notes.md
@@ -135,11 +152,14 @@ jobs:
           fi
           ls -la release-assets/
       - name: Create release with all assets
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            TAG_NAME="v${{ inputs.version }}"
+          if [[ -n "${INPUTS_VERSION}" ]]; then
+            TAG_NAME="v${INPUTS_VERSION}"
           else
-            TAG_NAME="${{ github.ref_name }}"
+            TAG_NAME="${GITHUB_REF_NAME}"
           fi
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
@@ -150,9 +170,15 @@ jobs:
     needs: [create-release]
     if: github.repository == 'jdx/hk'
     runs-on: namespace-profile-endev-linux-amd64
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
       - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -160,29 +186,38 @@ jobs:
   enhance-release:
     needs: [create-release]
     runs-on: namespace-profile-endev-linux-amd64
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          cache: false
       - name: Enhance release notes with communique
-        run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            TAG_NAME="v${{ inputs.version }}"
-          else
-            TAG_NAME="${{ github.ref_name }}"
-          fi
-          communique generate "$TAG_NAME" --github-release
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          INPUTS_VERSION: ${{ inputs.version }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ -n "${INPUTS_VERSION}" ]]; then
+            TAG_NAME="v${INPUTS_VERSION}"
+          else
+            TAG_NAME="${GITHUB_REF_NAME}"
+          fi
+          communique generate "$TAG_NAME" --github-release
       - name: Append en.dev sponsor blurb
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUTS_VERSION: ${{ inputs.version }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          if [[ -n "${{ inputs.version }}" ]]; then
-            TAG_NAME="v${{ inputs.version }}"
+          if [[ -n "${INPUTS_VERSION}" ]]; then
+            TAG_NAME="v${INPUTS_VERSION}"
           else
-            TAG_NAME="${{ github.ref_name }}"
+            TAG_NAME="${GITHUB_REF_NAME}"
           fi
           gh release view "$TAG_NAME" --json body --jq .body \
             | perl -0pe 's/\n*^##[^\n]*Sponsor hk\b.*\z//ms' \

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,3 +17,5 @@ jobs:
         with:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,19 @@
+name: zizmor
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths: ['.github/workflows/**']
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths: ['.github/workflows/**']
+    paths: [".github/workflows/**"]
 
 permissions: {}
 

--- a/mise-tasks/pkl/gen
+++ b/mise-tasks/pkl/gen
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 #MISE description="Generate pkl/Builtins.pkl from all builtins/*.pkl files"
 set -euo pipefail
+# Windows is handled by the parallel pkl:gen.ps1 task; Python's subprocess
+# can't resolve mise/pkl when invoked from Git Bash on Windows.
+case "${OS:-}${OSTYPE:-}" in
+  *indows*|msys*|cygwin*) exit 0 ;;
+esac
 python3 scripts/gen_builtins.py

--- a/mise.lock
+++ b/mise.lock
@@ -91,6 +91,7 @@ url_api = "https://api.github.com/repos/endevco/aube/releases/assets/399980361"
 checksum = "sha256:dedacf0c40a208ef8a4a76967208e5e33de18873781cbe1c793b1d7058ea7451"
 url = "https://github.com/endevco/aube/releases/download/v1.0.0-beta.5/aube-v1.0.0-beta.5-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/endevco/aube/releases/assets/399980603"
+provenance = "github-attestations"
 
 [tools.aube."platforms.windows-arm64"]
 checksum = "sha256:feab770c233c412969f66803040d886b100d63edd54a706afd0274ec00d36d83"
@@ -261,6 +262,7 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964691
 checksum = "sha256:459993e31a6c4ccbd09882f5679a2bc1ea5d9068701ecefc411a00fb69ce82e6"
 url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964098"
+provenance = "github-attestations"
 
 [tools.communique."platforms.windows-arm64"]
 checksum = "sha256:ad7e174b0da7c1ed4b1ba852ac24152c4ea20f2ac357e87223192834b0502298"
@@ -510,6 +512,7 @@ url = "https://github.com/tamasfe/taplo/releases/download/0.9.3/taplo-linux-x86_
 url = "https://github.com/tamasfe/taplo/releases/download/0.9.3/taplo-linux-x86_64.gz"
 
 [tools.taplo."platforms.macos-arm64"]
+checksum = "blake3:36d2541f27082280c42167bdb6ea0bc16af3e008e92c3b9b0ab1959945897487"
 url = "https://github.com/tamasfe/taplo/releases/download/0.9.3/taplo-darwin-aarch64.gz"
 
 [tools.taplo."platforms.macos-x64"]
@@ -608,6 +611,7 @@ url = "https://github.com/astral-sh/uv/releases/download/0.11.2/uv-x86_64-unknow
 [tools.uv."platforms.macos-arm64"]
 checksum = "sha256:4beaa9550f93ef7f0fc02f7c28c9c48cd61fe30db00f5ac8947e0a425c3fb282"
 url = "https://github.com/astral-sh/uv/releases/download/0.11.2/uv-aarch64-apple-darwin.tar.gz"
+provenance = "github-attestations"
 
 [tools.uv."platforms.macos-x64"]
 checksum = "sha256:a9c3653245031304c50dd60ac0301bf6c112e12c38c32302a71d4fa6a63ba2cb"

--- a/scripts/gen_builtins.py
+++ b/scripts/gen_builtins.py
@@ -83,7 +83,7 @@ def main():
             f.write(f'{alias} = Builtins["builtins/{canonical}.pkl"].{canonical}\n')
 
     # pkl format (exits 11 after formatting, ignore that)
-    subprocess.run(["mise", "x", "--", "pkl", "format", "--write", "pkl/Builtins.pkl"])
+    subprocess.run(["pkl", "format", "--write", "pkl/Builtins.pkl"])
 
     # Generate builtins metadata JSON for build script
     reflect_script = os.path.join(os.getcwd(), "scripts", "reflect.pkl")
@@ -99,7 +99,7 @@ def main():
         # Use pkl reflection to extract metadata
         try:
             result = subprocess.run(
-                ["mise", "x", "--", "pkl", "eval", filepath, "--format", "json", "-x",
+                ["pkl", "eval", filepath, "--format", "json", "-x",
                  f'import("{reflect_uri}").render(module)'],
                 capture_output=True, text=True, timeout=30,
             )

--- a/scripts/gen_builtins.py
+++ b/scripts/gen_builtins.py
@@ -83,7 +83,7 @@ def main():
             f.write(f'{alias} = Builtins["builtins/{canonical}.pkl"].{canonical}\n')
 
     # pkl format (exits 11 after formatting, ignore that)
-    subprocess.run(["pkl", "format", "--write", "pkl/Builtins.pkl"])
+    subprocess.run(["mise", "x", "--", "pkl", "format", "--write", "pkl/Builtins.pkl"])
 
     # Generate builtins metadata JSON for build script
     reflect_script = os.path.join(os.getcwd(), "scripts", "reflect.pkl")
@@ -99,7 +99,7 @@ def main():
         # Use pkl reflection to extract metadata
         try:
             result = subprocess.run(
-                ["pkl", "eval", filepath, "--format", "json", "-x",
+                ["mise", "x", "--", "pkl", "eval", filepath, "--format", "json", "-x",
                  f'import("{reflect_uri}").render(module)'],
                 capture_output=True, text=True, timeout=30,
             )


### PR DESCRIPTION
Adds [zizmor](https://github.com/zizmorcore/zizmor) to audit GitHub Actions workflows for security issues. Runs on push to main and on PRs that change `.github/workflows/**`. Fails CI on any finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple CI/release workflows by tightening `GITHUB_TOKEN` permissions and disabling credential persistence/caching, which could break builds or publishing if any job relied on prior implicit access. Adds a new workflow that can fail PRs based on zizmor findings, impacting developer workflow.
> 
> **Overview**
> Adds a new `zizmor` GitHub Actions workflow to audit `.github/workflows/**` changes (and `main` pushes) and fail CI on findings.
> 
> Hardens existing workflows (`ci.yml`, `docs.yml`, `release.yml`, `release-plz.yml`, `claude.yml`) by setting default `permissions: {}` and granting per-job least-privilege, disabling `actions/checkout` credential persistence, and turning off `mise-action` caching; also annotates specific steps with `zizmor` ignores where intentional.
> 
> Improves cross-platform/release reliability by skipping `mise-tasks/pkl/gen` on Windows (handled elsewhere), making release scripts use explicit env vars for tag/version selection, and updating `mise.lock` entries with provenance/checksum metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f7a36ad0e2e1517603fc9d674923893bf86af08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->