### PR TITLE
fix(stash): preserve fixer tail-line deletions in three-way merge

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -216,6 +216,22 @@ mod tests {
     }
 
     #[test]
+    fn diff_handles_tail_deletion_following_mismatch() {
+        // Regression guard for issue #929: when the only non-LCS region is a
+        // mismatch-then-tail-deletion, the existing `cur_start == Some` branch
+        // already captures the deletion because the loop exits with `i == n`.
+        // (`j` can only reach `m` via match, which resets cur_start to None;
+        // inserts cannot advance `j` from `m-1` to `m`.)
+        let base = "a\nb\nc\nd\n";
+        let other = "a\nX\n";
+        let hunks = diff_hunks(base, other, HunkSource::Fixer);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].start, 1);
+        assert_eq!(hunks[0].end, 4);
+        assert_eq!(hunks[0].lines, vec!["X\n".to_string()]);
+    }
+
+    #[test]
     fn merge_preserves_fixer_tail_deletion_with_middle_worktree_change() {
         // Regression test for issue #929: fixer removes trailing blank lines while
         // the worktree has an unrelated change in the middle. The fixer's tail

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -86,6 +86,15 @@ pub fn diff_hunks(base: &str, other: &str, source: HunkSource) -> Vec<Hunk> {
             lines: b[j..].iter().map(|s| (*s).to_string()).collect(),
             source,
         });
+    } else if i < n {
+        // pure tail deletion: other is shorter than base, loop exited with j == m
+        // after a matching line reset cur_start to None
+        hunks.push(Hunk {
+            start: i,
+            end: n,
+            lines: vec![],
+            source,
+        });
     }
     hunks
 }
@@ -191,5 +200,30 @@ mod tests {
         assert_eq!(hunks.len(), 2);
         assert_eq!(hunks[0].start, 1);
         assert!(hunks[0].lines.join("").contains("B"));
+    }
+
+    #[test]
+    fn diff_emits_pure_tail_deletion_hunk() {
+        // Regression test for issue #929: trailing-line removals were lost when the
+        // LCS walk consumed `other` entirely and exited with cur_start == None.
+        let base = "a\nb\nc\nd\n";
+        let other = "a\nb\n";
+        let hunks = diff_hunks(base, other, HunkSource::Fixer);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].start, 2);
+        assert_eq!(hunks[0].end, 4);
+        assert!(hunks[0].lines.is_empty());
+    }
+
+    #[test]
+    fn merge_preserves_fixer_tail_deletion_with_middle_worktree_change() {
+        // Regression test for issue #929: fixer removes trailing blank lines while
+        // the worktree has an unrelated change in the middle. The fixer's tail
+        // deletion must survive the three-way merge.
+        let base = "name: my-app\nversion: 1.0\ndeps:\n  flask\n\n\n";
+        let fixer = Some("name: my-app\nversion: 1.0\ndeps:\n  flask\n");
+        let work = Some("name: my-app\nversion: 2.0\ndeps:\n  flask\n\n\n");
+        let merged = three_way_merge_hunks(base, fixer, work);
+        assert_eq!(merged, "name: my-app\nversion: 2.0\ndeps:\n  flask\n");
     }
 }

--- a/test/fixer_tail_deletion_with_middle_unstaged.bats
+++ b/test/fixer_tail_deletion_with_middle_unstaged.bats
@@ -77,14 +77,14 @@ EOF
     assert_success
 
     # After the commit: fixer's tail deletion is preserved on disk and the
-    # worktree retains the version=2.0 unstaged change.
+    # worktree retains the version=2.0 unstaged change. Compare with `diff`
+    # (not bash command substitution, which strips trailing newlines and would
+    # silently accept the very tail-blank-lines regression this test guards).
     expected=$'name: my-app\nversion: 2.0\ndeps:\n  flask: 2.0\n  redis: 4.0\n'
-    actual="$(cat config.yml)"$'\n'
-    [ "$actual" = "$expected" ]
+    printf '%s' "$expected" | diff - config.yml
 
     # The committed (HEAD) content is the fixer's output: redis added, no
     # trailing blank lines.
     expected_head=$'name: my-app\nversion: 1.0\ndeps:\n  flask: 2.0\n  redis: 4.0\n'
-    actual_head="$(git show HEAD:config.yml)"$'\n'
-    [ "$actual_head" = "$expected_head" ]
+    git show HEAD:config.yml | diff - <(printf '%s' "$expected_head")
 }

--- a/test/fixer_tail_deletion_with_middle_unstaged.bats
+++ b/test/fixer_tail_deletion_with_middle_unstaged.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+# Regression test for https://github.com/jdx/hk/discussions/929
+#
+# When a fixer removes lines from the end of a file and the user has an
+# unrelated unstaged change in the middle of the same file, the three-way
+# merge inside pop_stash used to silently restore the deleted trailing lines.
+# The bug was a missing branch in src/merge.rs::diff_hunks for pure tail
+# deletions when the LCS walk consumed `other` entirely.
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "pre-commit (stash=git) preserves fixer tail deletion when unstaged change is in middle" {
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+    steps = new Mapping<String, Step> {
+      ["strip-trailing-blank-lines"] {
+        glob = "*.yml"
+        stage = "*.yml"
+        // Remove all trailing blank lines, leaving exactly one final newline
+        fix = #"perl -i -pe 'BEGIN{undef $/} s/\n+\z/\n/' {{files}}"#
+      }
+    }
+  }
+}
+PKL
+    git add hk.pkl
+    git -c commit.gpgsign=false commit -m "init hk"
+    hk install
+
+    # Initial committed file (no trailing blank lines)
+    cat <<'EOF' > config.yml
+name: my-app
+version: 1.0
+deps:
+  flask: 2.0
+EOF
+    git add config.yml
+    git -c commit.gpgsign=false commit -m "base"
+
+    # Stage a change that adds trailing blank lines (fixer will remove these)
+    cat <<'EOF' > config.yml
+name: my-app
+version: 1.0
+deps:
+  flask: 2.0
+  redis: 4.0
+
+
+EOF
+    git add config.yml
+
+    # Add an unstaged change in the MIDDLE of the file (triggers stash flow)
+    cat <<'EOF' > config.yml
+name: my-app
+version: 2.0
+deps:
+  flask: 2.0
+  redis: 4.0
+
+
+EOF
+
+    run bash -lc 'git -c commit.gpgsign=false commit -m "redis"'
+    echo "$output"
+    assert_success
+
+    # After the commit: fixer's tail deletion is preserved on disk and the
+    # worktree retains the version=2.0 unstaged change.
+    expected=$'name: my-app\nversion: 2.0\ndeps:\n  flask: 2.0\n  redis: 4.0\n'
+    actual="$(cat config.yml)"$'\n'
+    [ "$actual" = "$expected" ]
+
+    # The committed (HEAD) content is the fixer's output: redis added, no
+    # trailing blank lines.
+    expected_head=$'name: my-app\nversion: 1.0\ndeps:\n  flask: 2.0\n  redis: 4.0\n'
+    actual_head="$(git show HEAD:config.yml)"$'\n'
+    [ "$actual_head" = "$expected_head" ]
+}


### PR DESCRIPTION
## Summary

- Fixes [#929](https://github.com/jdx/hk/discussions/929): fixer changes that remove trailing lines were silently undone when the worktree had an unrelated unstaged change in the middle of the same file.
- Root cause in `src/merge.rs::diff_hunks`: when the LCS walk consumed `other` entirely after a matching line, `cur_start` was `None` and `j == m`, so neither post-loop branch fired and the deletion of `base[i..n]` was dropped. `three_way_merge_hunks` then copied the removed lines back in verbatim.
- Fix: emit an empty-lines deletion hunk for `base[i..n]` when the post-loop state indicates a pure tail deletion.

## Test plan

- [x] New unit test `diff_emits_pure_tail_deletion_hunk` directly asserts the previously-missing hunk.
- [x] New unit test `merge_preserves_fixer_tail_deletion_with_middle_worktree_change` covers the end-to-end three-way merge from the discussion.
- [x] New bats test `test/fixer_tail_deletion_with_middle_unstaged.bats` reproduces the exact scenario from the discussion through a real `git commit` and verifies both worktree and HEAD content.
- [x] `cargo test` — all 158 Rust tests pass.
- [x] Re-ran related newline/stash/EOF bats tests (`stash_default`, `fix_preserves_unstaged_newline`, `pre_commit_preserves_eof_newline`, `newline_stripping_bug`, `pre_commit_prettier_commits_fixer_changes`, `pre_commit_prettier_restaging`) — all 14 pass.
- [x] Manually reproduced with the older `hk 1.44.1` binary to confirm the bug exists pre-fix, then re-ran with the patched binary to confirm the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies core diff/merge behavior used during stash-based pre-commit fixes; mistakes could drop or misapply edits in edge cases. Added regression tests reduce risk but the change affects merge correctness across file-ending scenarios.
> 
> **Overview**
> Fixes `src/merge.rs::diff_hunks` to emit a **pure tail-deletion** hunk (empty `lines` over `base[i..n]`) when `other` ends after an LCS match, preventing trailing-line removals from being silently lost during `three_way_merge_hunks`.
> 
> Adds targeted regression coverage: new Rust unit tests for tail-deletion cases and an end-to-end `bats` test reproducing the stash-based pre-commit scenario where a fixer strips trailing blank lines while the worktree has a middle-of-file unstaged change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e24e25b573681278ea5370c41eee25b8812b1bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->