### PR TITLE
fix(pre-push): correct inverted ref filter and handle new-branch pushes

### DIFF
--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -80,13 +80,23 @@ impl PrePush {
                 // Either no refs were provided on stdin, or the first ref is
                 // a new-branch push (remote sha is all-zeros). Fall back to
                 // the remote-tracking branch if it exists, then to the
-                // repository's default branch.
+                // repository's default branch on the target remote.
                 let remote = self.remote.as_deref().unwrap_or("origin");
                 let repo = Git::new()?; // TODO: remove this extra repo creation
                 if let Some(rb) = repo.matching_remote_branch(remote)? {
                     rb
-                } else {
+                } else if remote == "origin" {
                     repo.resolve_default_branch()
+                } else {
+                    // resolve_default_branch is internally hardcoded to
+                    // origin, so for a non-origin remote derive the bare
+                    // branch name and rebind it onto the actual remote.
+                    let default = repo.resolve_default_branch();
+                    let bare = default
+                        .rsplit_once('/')
+                        .map(|(_, name)| name)
+                        .unwrap_or(&default);
+                    format!("refs/remotes/{remote}/{bare}")
                 }
             }
         });

--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -2,14 +2,10 @@ use std::io::IsTerminal;
 use std::io::Read;
 
 use crate::hook_options::HookOptions;
-use crate::{Result, git::Git};
-
-// Git represents a missing ref as an all-zeros SHA. The length depends on the
-// repository's hash algorithm (40 chars for SHA-1, 64 for SHA-256), so check
-// the contents rather than comparing against a fixed-width constant.
-fn is_zero_sha(sha: &str) -> bool {
-    !sha.is_empty() && sha.bytes().all(|b| b == b'0')
-}
+use crate::{
+    Result,
+    git::{Git, is_zero_sha},
+};
 
 #[derive(clap::Args)]
 #[clap(visible_alias = "pp")]

--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -55,16 +55,16 @@ impl PrePush {
             let mut input = String::new();
             std::io::stdin().read_to_string(&mut input)?;
             self.hook.tctx.insert("hook_stdin", &input);
+            // Note: we deliberately keep deletions (local sha all-zeros) in
+            // the list. The downstream EMPTY_REF guard in hook.rs detects
+            // `to_ref` of all-zeros and short-circuits to an empty file set
+            // — dropping deletions here would route them through
+            // `files_between_refs(default_branch, "HEAD")` and lint
+            // unrelated files.
             input
                 .lines()
                 .filter(|line| !line.is_empty())
                 .map(PrePushRefs::from)
-                .filter(|refs| {
-                    // Skip branch deletions: a local sha of all-zeros means
-                    // we're deleting the remote branch — there are no files
-                    // to lint for a deletion.
-                    !is_zero_sha(&refs.to.1)
-                })
                 .collect::<Vec<_>>()
         };
         trace!("to_be_updated_refs: {to_be_updated_refs:?}");

--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -85,12 +85,14 @@ impl PrePush {
                     repo.resolve_default_branch()
                 } else {
                     // resolve_default_branch is internally hardcoded to
-                    // origin, so for a non-origin remote derive the bare
-                    // branch name and rebind it onto the actual remote.
+                    // origin, so for a non-origin remote strip the known
+                    // origin prefix and rebind onto the actual remote.
+                    // Use strip_prefix (not rsplit) so multi-segment branch
+                    // names like "release/v1" are preserved intact.
                     let default = repo.resolve_default_branch();
                     let bare = default
-                        .rsplit_once('/')
-                        .map(|(_, name)| name)
+                        .strip_prefix("refs/remotes/origin/")
+                        .or_else(|| default.strip_prefix("origin/"))
                         .unwrap_or(&default);
                     format!("refs/remotes/{remote}/{bare}")
                 }

--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -4,6 +4,8 @@ use std::io::Read;
 use crate::hook_options::HookOptions;
 use crate::{Result, git::Git};
 
+const ZERO_SHA: &str = "0000000000000000000000000000000000000000";
+
 #[derive(clap::Args)]
 #[clap(visible_alias = "pp")]
 pub struct PrePush {
@@ -53,9 +55,10 @@ impl PrePush {
                 .filter(|line| !line.is_empty())
                 .map(PrePushRefs::from)
                 .filter(|refs| {
-                    // git uses this if the remote ref does not exist, we can just ignore it in that case and default to origin/HEAD
-                    refs.to.1 == "0000000000000000000000000000000000000000"
-                        && refs.from.1 != "0000000000000000000000000000000000000000"
+                    // Skip branch deletions: a local sha of all-zeros means
+                    // we're deleting the remote branch — there are no files
+                    // to lint for a deletion.
+                    refs.to.1 != ZERO_SHA
                 })
                 .collect::<Vec<_>>()
         };
@@ -63,12 +66,23 @@ impl PrePush {
 
         self.hook.from_ref = Some(match &self.hook.from_ref {
             Some(to_ref) => to_ref.clone(),
-            None if !to_be_updated_refs.is_empty() => to_be_updated_refs[0].from.1.clone(),
+            None if !to_be_updated_refs.is_empty()
+                && to_be_updated_refs[0].from.1 != ZERO_SHA =>
+            {
+                to_be_updated_refs[0].from.1.clone()
+            }
             None => {
+                // Either no refs were provided on stdin, or the first ref is
+                // a new-branch push (remote sha is all-zeros). Fall back to
+                // the remote-tracking branch if it exists, then to the
+                // repository's default branch.
                 let remote = self.remote.as_deref().unwrap_or("origin");
                 let repo = Git::new()?; // TODO: remove this extra repo creation
-                repo.matching_remote_branch(remote)?
-                    .unwrap_or(format!("refs/remotes/{remote}/HEAD"))
+                if let Some(rb) = repo.matching_remote_branch(remote)? {
+                    rb
+                } else {
+                    repo.resolve_default_branch()
+                }
             }
         });
         self.hook.to_ref = Some(

--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -66,9 +66,7 @@ impl PrePush {
 
         self.hook.from_ref = Some(match &self.hook.from_ref {
             Some(to_ref) => to_ref.clone(),
-            None if !to_be_updated_refs.is_empty()
-                && to_be_updated_refs[0].from.1 != ZERO_SHA =>
-            {
+            None if !to_be_updated_refs.is_empty() && to_be_updated_refs[0].from.1 != ZERO_SHA => {
                 to_be_updated_refs[0].from.1.clone()
             }
             None => {

--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -4,7 +4,12 @@ use std::io::Read;
 use crate::hook_options::HookOptions;
 use crate::{Result, git::Git};
 
-const ZERO_SHA: &str = "0000000000000000000000000000000000000000";
+// Git represents a missing ref as an all-zeros SHA. The length depends on the
+// repository's hash algorithm (40 chars for SHA-1, 64 for SHA-256), so check
+// the contents rather than comparing against a fixed-width constant.
+fn is_zero_sha(sha: &str) -> bool {
+    !sha.is_empty() && sha.bytes().all(|b| b == b'0')
+}
 
 #[derive(clap::Args)]
 #[clap(visible_alias = "pp")]
@@ -58,7 +63,7 @@ impl PrePush {
                     // Skip branch deletions: a local sha of all-zeros means
                     // we're deleting the remote branch — there are no files
                     // to lint for a deletion.
-                    refs.to.1 != ZERO_SHA
+                    !is_zero_sha(&refs.to.1)
                 })
                 .collect::<Vec<_>>()
         };
@@ -66,7 +71,9 @@ impl PrePush {
 
         self.hook.from_ref = Some(match &self.hook.from_ref {
             Some(to_ref) => to_ref.clone(),
-            None if !to_be_updated_refs.is_empty() && to_be_updated_refs[0].from.1 != ZERO_SHA => {
+            None if !to_be_updated_refs.is_empty()
+                && !is_zero_sha(&to_be_updated_refs[0].from.1) =>
+            {
                 to_be_updated_refs[0].from.1.clone()
             }
             None => {

--- a/src/git.rs
+++ b/src/git.rs
@@ -19,6 +19,16 @@ use xx::file::display_path;
 
 use crate::env;
 
+/// Returns true if the given string is git's all-zeros sha sentinel.
+///
+/// Git uses this to denote a missing ref (e.g., a deletion or a new branch
+/// in pre-push stdin). The length depends on the repository's hash algorithm
+/// — 40 chars for SHA-1, 64 for SHA-256 — so check the contents rather than
+/// comparing against a fixed-width constant.
+pub fn is_zero_sha(sha: &str) -> bool {
+    !sha.is_empty() && sha.bytes().all(|b| b == b'0')
+}
+
 fn git_cmd<I, S>(args: I) -> xx::process::XXExpression
 where
     I: IntoIterator<Item = S>,

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1170,7 +1170,6 @@ impl Hook {
         stash_method: StashMethod,
         file_progress: &ProgressJob,
     ) -> Result<BTreeSet<PathBuf>> {
-        const EMPTY_REF: &str = "0000000000000000000000000000000000000000";
         let stash = stash_method != StashMethod::None;
         let mut files = if let Some(files) = &opts.files {
             files
@@ -1195,7 +1194,7 @@ impl Hook {
             let all_files = all_files.into_iter().collect_vec();
             glob::get_matches(glob, &all_files)?.into_iter().collect()
         } else if let Some(from) = &opts.from_ref {
-            if opts.to_ref.as_deref() == Some(EMPTY_REF) {
+            if opts.to_ref.as_deref().map(crate::git::is_zero_sha) == Some(true) {
                 file_progress.prop("message", "No files to compare for remote branch deletion");
                 BTreeSet::new()
             } else {

--- a/test/pre_push.bats
+++ b/test/pre_push.bats
@@ -92,8 +92,17 @@ EOF
 
     hk install --legacy
 
-    # Deleting a remote branch should not try to lint anything — the
-    # pre-push filter must drop deletions (local sha is all-zeros).
+    # Add a file on main that WOULD fail linting if linted. This guards
+    # against a regression where deletions slip past the EMPTY_REF guard
+    # and end up running files_between_refs(default_branch, HEAD) — that
+    # diff would include this file and trigger a lint failure.
+    echo 'console.log("unformatted")' > unrelated.js
+    git add unrelated.js
+    git -c core.hooksPath=/dev/null commit -m "unrelated change on main"
+
+    # Deleting a remote branch should not lint anything — the EMPTY_REF
+    # guard in hook.rs short-circuits when to_ref is the all-zeros sha.
     run git push origin --delete feature/to-delete
     assert_success
+    refute_output --partial "[warn] unrelated.js"
 }

--- a/test/pre_push.bats
+++ b/test/pre_push.bats
@@ -38,3 +38,62 @@ EOF
     assert_failure
     assert_output --partial "[warn] test.js"
 }
+
+@test "pre-push hook on new branch first push" {
+    export NO_COLOR=1
+    if [ "$HK_LIBGIT2" = "0" ]; then
+        skip "libgit2 is not installed"
+    fi
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+hooks { ["pre-push"] { steps { ["prettier"] = Builtins.prettier } } }
+EOF
+    git add hk.pkl
+    git commit -m "install hk"
+    git push origin main
+    hk install --legacy
+
+    # Create a new branch with a file that needs linting and push it for the
+    # first time. The pre-push hook receives a remote sha of all-zeros for a
+    # new branch — the inverted filter regression caused this push to either
+    # error out resolving refs/remotes/origin/HEAD or skip linting entirely.
+    git checkout -b feature/new-thing
+    echo 'console.log("new")' > new.js
+    git add new.js
+    git commit -m "add new.js"
+    HK_LOG=trace run git push -u origin feature/new-thing
+    assert_failure
+    assert_output --partial "[warn] new.js"
+}
+
+@test "pre-push hook skips branch deletion" {
+    export NO_COLOR=1
+    if [ "$HK_LIBGIT2" = "0" ]; then
+        skip "libgit2 is not installed"
+    fi
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+hooks { ["pre-push"] { steps { ["prettier"] = Builtins.prettier } } }
+EOF
+    git add hk.pkl
+    git commit -m "install hk"
+    git push origin main
+
+    # Push a branch we'll later delete — install the hook only after this
+    # setup push so the initial push isn't gated on linting.
+    git checkout -b feature/to-delete
+    echo 'console.log("x")' > x.js
+    git add x.js
+    git commit -m "add x.js"
+    git push -u origin feature/to-delete
+    git checkout main
+
+    hk install --legacy
+
+    # Deleting a remote branch should not try to lint anything — the
+    # pre-push filter must drop deletions (local sha is all-zeros).
+    run git push origin --delete feature/to-delete
+    assert_success
+}


### PR DESCRIPTION
## Summary

Fixes the inverted pre-push ref filter reported in #930. The filter at `src/cli/run/pre_push.rs` was checking the local sha for all-zeros (a deletion) when the comment intended a check on the remote sha (a new branch). Effects:

- **Branch deletions** (local sha all-zeros) were *kept* and triggered linting against a deleted ref.
- **New-branch first pushes** (remote sha all-zeros) were *dropped* and fell through to a default that resolved `refs/remotes/origin/HEAD`, which often errors out with `Failed to parse reference: refs/remotes/origin/HEAD` (likely the root cause of #172).

## Changes

- `src/cli/run/pre_push.rs`: filter now drops only deletions. For new-branch pushes the `from_ref` falls back to the remote-tracking branch when present, otherwise to `Git::resolve_default_branch()` instead of the brittle `refs/remotes/origin/HEAD` literal.
- Extracted `ZERO_SHA` constant.
- `test/pre_push.bats`: added two regression tests — one for first-time push of a new branch (asserts linting actually runs), one verifying that a branch deletion isn't gated on linting.

## Test plan

- [x] `mise run test:bats test/pre_push.bats` (libgit2, nolibgit2, nogit variants)
- [x] `cargo test --bin hk`
- [x] `cargo clippy --bin hk --all-features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `pre-push` selects comparison refs, which can affect which files are linted (or whether pushes fail) across common git workflows. Covered by new regression tests for first-time branch pushes and remote branch deletions.
> 
> **Overview**
> Fixes `pre-push` stdin ref handling by introducing `git::is_zero_sha()` and using it to distinguish git’s all-zeros sentinel across SHA-1/SHA-256 repos.
> 
> `PrePush::run` now avoids using an all-zeros remote sha as `from_ref`, and instead falls back to a real remote-tracking branch or the resolved default branch (including non-`origin` remotes) rather than `refs/remotes/<remote>/HEAD`.
> 
> `hook.rs` switches the deletion short-circuit to `is_zero_sha`, and `test/pre_push.bats` adds regression coverage for *first push of a new branch* (lint runs) and *remote branch deletion* (no linting / no unrelated failures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637a4e142d01b61883530f47a27a77f41bc3c2fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->