### PR TITLE
chore(ci): close failing or conflicted PRs sooner

### DIFF
--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -16,14 +16,24 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
-          CUTOFF=$(date -u -d '30 days ago' +%Y-%m-%d)
-          gh pr list -R "$REPO" --state open --search "updated:<$CUTOFF -author:jdx -label:keep-open sort:updated-asc" --json number,statusCheckRollup --limit 500 | \
-          jq -r '.[] | [.number, (if (.statusCheckRollup | length > 0) and ([.statusCheckRollup[].conclusion] | index("FAILURE") or index("failure")) then "failing" else "passing" end)] | @tsv' | \
-          while read -r pr status; do
-            echo "Closing PR #$pr (checks: $status)"
-            if [ "$status" = "failing" ]; then
-              gh pr close "$pr" -R "$REPO" -c "This PR has been open for more than 30 days without activity. Note: CI checks were failing, which may be why it wasn't reviewed. Feel free to reopen or create a new PR if you'd like to continue working on this."
-            else
-              gh pr close "$pr" -R "$REPO" -c "This PR has been open for more than 30 days without activity. Feel free to reopen or create a new PR if you'd like to continue working on this."
-            fi
+          CUTOFF=$(date -u -d '7 days ago' +%Y-%m-%d)
+          gh pr list -R "$REPO" --state open --search "updated:<$CUTOFF -author:jdx -label:keep-open sort:updated-asc" --json number,mergeStateStatus,statusCheckRollup --limit 500 | \
+          jq -r '
+            def failed_check:
+              (.statusCheckRollup | length > 0) and
+              ([.statusCheckRollup[].conclusion // "" | ascii_upcase] | any(. == "FAILURE" or . == "TIMED_OUT" or . == "ACTION_REQUIRED" or . == "STARTUP_FAILURE"));
+
+            .[]
+            | failed_check as $failed
+            | (.mergeStateStatus == "DIRTY") as $conflicted
+            | if $failed and $conflicted then [.number, "failing checks and merge conflicts"]
+              elif $failed then [.number, "failing checks"]
+              elif $conflicted then [.number, "merge conflicts"]
+              else empty
+              end
+            | @tsv
+          ' | \
+          while IFS=$'\t' read -r pr reason; do
+            echo "Closing PR #$pr ($reason)"
+            gh pr close "$pr" -R "$REPO" -c "This PR has had $reason for more than 7 days. Feel free to reopen or create a new PR if you'd like to continue working on this."
           done


### PR DESCRIPTION
## Summary
- close inactive PRs after 7 days only when they have failing checks or merge conflicts
- include merge state in the PR closer query and close with the specific reason
- keep existing exclusions for @jdx-authored and keep-open PRs

## Validation
- actionlint .github/workflows/pr-closer.yml
- git diff --check
- jq filter sample validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automatically closes PRs based on CI/merge-state signals, so incorrect detection or query logic could prematurely close legitimate PRs. Changes are limited to a scheduled GitHub Actions workflow.
> 
> **Overview**
> Updates the `pr-closer` workflow to **reduce the inactivity cutoff from 30 days to 7 days**, but only close PRs that have *failing checks* and/or *merge conflicts*.
> 
> The action now queries `mergeStateStatus` and expands failure detection (e.g., `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`), and posts a closure comment that includes the specific reason for closing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eb35dbebff1b45d01be8e67dc936821de48f20a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->