### PR TITLE
fix(install): use absolute commands for global hooks

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -1,21 +1,13 @@
 use crate::{Result, config::Config, env, git_util};
 use eyre::bail;
 use log::warn;
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
 use std::process::Command;
 
-/// Hook events installed when `--global` is used and no project `hk.pkl` is
-/// available to enumerate them. Kept to the commonly-useful client-side hooks.
-const DEFAULT_GLOBAL_EVENTS: &[&str] = &[
-    "commit-msg",
-    "post-checkout",
-    "post-commit",
-    "post-merge",
-    "post-rewrite",
-    "pre-commit",
-    "pre-push",
-    "pre-rebase",
-    "prepare-commit-msg",
-];
+/// Hook events installed by default for `hk install --global` when no project
+/// config is available to enumerate a more specific set.
+const CORE_GLOBAL_EVENTS: &[&str] = &["commit-msg", "pre-commit", "pre-push", "prepare-commit-msg"];
 
 /// Sets up git hooks to run hk.
 ///
@@ -67,11 +59,7 @@ pub struct Install {
 
 impl Install {
     pub async fn run(&self) -> Result<()> {
-        let command = if *env::HK_MISE || self.mise {
-            "mise x -- hk"
-        } else {
-            "hk"
-        };
+        let use_mise = *env::HK_MISE || self.mise;
 
         if self.global {
             if !git_util::git_at_least(2, 54) {
@@ -79,7 +67,9 @@ impl Install {
                     "`hk install --global` requires Git 2.54+ (config-based hooks). Detected git version does not support this. Upgrade git, or install per-repo with `hk install`."
                 );
             }
-            return install_global(command);
+            let command = global_hook_command(use_mise)?;
+            let events = global_hook_events()?;
+            return install_global(&events, &command);
         }
 
         if !self.force_local && has_global_hk_hooks()? {
@@ -98,17 +88,13 @@ impl Install {
             return Ok(());
         }
 
+        let command = local_hook_command(use_mise);
         let use_config_hooks = !self.legacy && git_util::git_at_least(2, 54);
 
         // Load and validate the project config before touching anything, so a
         // broken `hk.pkl` doesn't leave the repo with its prior hooks removed.
         let config = Config::get()?;
-        let events: Vec<String> = config
-            .hooks
-            .keys()
-            .filter(|h| h.as_str() != "check" && h.as_str() != "fix")
-            .cloned()
-            .collect();
+        let events = hook_events(&config);
 
         // Clean up any prior installation so modes don't accumulate.
         let removed = remove_local_shims()? + remove_local_config_entries()?;
@@ -125,11 +111,11 @@ impl Install {
         }
 
         if use_config_hooks {
-            let result = install_local_config(&events, command);
+            let result = install_local_config(&events, &command);
             warn_if_global_overlap(&events);
             result
         } else {
-            install_local_shims(&events, command)
+            install_local_shims(&events, &command)
         }
     }
 }
@@ -159,6 +145,153 @@ fn has_global_hk_hooks() -> Result<bool> {
     }
 }
 
+fn local_hook_command(use_mise: bool) -> OsString {
+    if use_mise {
+        OsString::from("mise x -- hk")
+    } else {
+        OsString::from("hk")
+    }
+}
+
+fn global_hook_command(use_mise: bool) -> Result<OsString> {
+    if use_mise {
+        let mise = xx::file::which("mise")
+            .ok_or_else(|| eyre::eyre!("could not find mise on PATH for global hook install"))?;
+        Ok(mise_hook_command(&mise))
+    } else {
+        let hk = std::env::current_exe()?;
+        Ok(hk_hook_command(&hk))
+    }
+}
+
+fn global_hook_events() -> Result<Vec<String>> {
+    if Config::project_config_exists() {
+        let events = hook_events(&Config::get()?);
+        if !events.is_empty() {
+            return Ok(events);
+        }
+    }
+    Ok(CORE_GLOBAL_EVENTS
+        .iter()
+        .map(|event| event.to_string())
+        .collect())
+}
+
+fn hook_events(config: &Config) -> Vec<String> {
+    config
+        .hooks
+        .keys()
+        .filter(|h| h.as_str() != "check" && h.as_str() != "fix")
+        .cloned()
+        .collect()
+}
+
+fn hk_hook_command(hk: &Path) -> OsString {
+    shell_path_for_command(hk)
+}
+
+fn mise_hook_command(mise: &Path) -> OsString {
+    let mut command = shell_path_for_command(mise);
+    command.push(" x hk -- hk");
+    command
+}
+
+fn shell_path_for_command(path: &Path) -> OsString {
+    if let Some(home_relative) = home_relative_command_path(path) {
+        return home_relative;
+    }
+    shell_quote_path(path)
+}
+
+fn home_relative_command_path(path: &Path) -> Option<OsString> {
+    let home = dirs::home_dir()?;
+    let relative = path.strip_prefix(home).ok()?;
+    if relative.as_os_str().is_empty() || !is_shell_safe_path(relative) {
+        return None;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let mut path = b"~/".to_vec();
+        path.extend_from_slice(relative.as_os_str().as_bytes());
+        Some(OsString::from_vec(path))
+    }
+
+    #[cfg(not(unix))]
+    {
+        Some(OsString::from(format!("~/{}", relative.display())))
+    }
+}
+
+fn is_shell_safe_path(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        path.as_os_str().as_bytes().iter().all(is_shell_safe_byte)
+    }
+
+    #[cfg(not(unix))]
+    {
+        path.to_string_lossy()
+            .bytes()
+            .all(|b| is_shell_safe_byte(&b))
+    }
+}
+
+fn is_shell_safe_byte(b: &u8) -> bool {
+    matches!(
+        b,
+        b'a'..=b'z'
+            | b'A'..=b'Z'
+            | b'0'..=b'9'
+            | b'_'
+            | b'@'
+            | b'%'
+            | b'+'
+            | b'='
+            | b':'
+            | b','
+            | b'.'
+            | b'/'
+            | b'-'
+    )
+}
+
+fn shell_quote_path(path: &Path) -> OsString {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let bytes = path.as_os_str().as_bytes();
+        if bytes.iter().all(is_shell_safe_byte) {
+            return OsString::from_vec(bytes.to_vec());
+        }
+
+        let mut quoted = vec![b'\''];
+        for b in bytes {
+            if *b == b'\'' {
+                quoted.extend_from_slice(b"'\\''");
+            } else {
+                quoted.push(*b);
+            }
+        }
+        quoted.push(b'\'');
+        OsString::from_vec(quoted)
+    }
+
+    #[cfg(not(unix))]
+    {
+        let path = path.to_string_lossy();
+        if path.bytes().all(|b| is_shell_safe_byte(&b)) {
+            OsString::from(path.as_ref())
+        } else {
+            OsString::from(format!("'{}'", path.replace('\'', r#"'\''"#)))
+        }
+    }
+}
 /// Git aggregates `hook.<name>.command` values across scopes, so a local
 /// install on top of a global one fires hk twice per event. Warn the user
 /// and point them at the `enabled = false` escape hatch.
@@ -189,14 +322,14 @@ fn warn_if_global_overlap(events: &[String]) {
     );
 }
 
-fn install_global(command: &str) -> Result<()> {
+fn install_global(events: &[String], command: &OsStr) -> Result<()> {
     remove_config_entries("--global")?;
-    for event in DEFAULT_GLOBAL_EVENTS {
+    for event in events {
         write_config_hook("--global", command, event)?;
     }
     println!(
         "Installed hk global hooks in ~/.gitconfig for: {}",
-        DEFAULT_GLOBAL_EVENTS.join(", ")
+        events.join(", ")
     );
     println!(
         "In repos without an hk.pkl, hk exits silently — add one with `hk init` to enable hooks."
@@ -204,7 +337,7 @@ fn install_global(command: &str) -> Result<()> {
     Ok(())
 }
 
-fn install_local_config(events: &[String], command: &str) -> Result<()> {
+fn install_local_config(events: &[String], command: &OsStr) -> Result<()> {
     for event in events {
         write_config_hook("--local", command, event)?;
         println!("Installed hk hook via git config: hook.hk-{event}.command");
@@ -212,7 +345,7 @@ fn install_local_config(events: &[String], command: &str) -> Result<()> {
     Ok(())
 }
 
-fn install_local_shims(events: &[String], command: &str) -> Result<()> {
+fn install_local_shims(events: &[String], command: &OsStr) -> Result<()> {
     let git_path = git_util::find_git_path()?;
     let hooks = match git_util::worktree_hooks_path() {
         Some(path) => {
@@ -226,7 +359,10 @@ fn install_local_shims(events: &[String], command: &str) -> Result<()> {
     };
     for event in events {
         let hook_file = hooks.join(event);
-        xx::file::write(&hook_file, git_hook_content(command, event))?;
+        xx::file::write(
+            &hook_file,
+            git_hook_content(&command.to_string_lossy(), event),
+        )?;
         xx::file::make_executable(&hook_file)?;
         println!("Installed hk hook: {}", hook_file.display());
     }
@@ -235,17 +371,30 @@ fn install_local_shims(events: &[String], command: &str) -> Result<()> {
 
 /// Write both `hook.hk-<event>.command` and `hook.hk-<event>.event` at the
 /// given scope (`--local` or `--global`).
-fn write_config_hook(scope: &str, command: &str, event: &str) -> Result<()> {
+fn write_config_hook(scope: &str, command: &OsStr, event: &str) -> Result<()> {
     let name = format!("hk-{event}");
     let cmd_key = format!("hook.{name}.command");
     let event_key = format!("hook.{name}.event");
     // Mirror the shim's HK=0 escape hatch so users can still disable hooks
     // with `HK=0 git commit` under config-based hooks.
-    let cmd_value = format!(r#"test "${{HK:-1}}" = "0" || {command} run {event} --from-hook "$@""#);
+    let mut cmd_value = OsString::from(r#"test "${HK:-1}" = "0" || "#);
+    cmd_value.push(command);
+    cmd_value.push(format!(r#" run {event} --from-hook "$@""#));
 
-    run_git(&["config", scope, cmd_key.as_str(), cmd_value.as_str()])?;
+    run_git([
+        OsString::from("config"),
+        OsString::from(scope),
+        OsString::from(cmd_key.as_str()),
+        cmd_value,
+    ])?;
     // .event is multi-valued; replace-all keeps re-install idempotent.
-    run_git(&["config", scope, "--replace-all", event_key.as_str(), event])?;
+    run_git([
+        OsString::from("config"),
+        OsString::from(scope),
+        OsString::from("--replace-all"),
+        OsString::from(event_key.as_str()),
+        OsString::from(event),
+    ])?;
     Ok(())
 }
 
@@ -287,7 +436,7 @@ pub(crate) fn remove_config_entries(scope: &str) -> Result<usize> {
     let mut removed = 0;
     for key in keys {
         if seen.insert(key.clone()) {
-            run_git(&["config", scope, "--unset-all", key.as_str()])?;
+            run_git(["config", scope, "--unset-all", key.as_str()])?;
             // Count one per hook event, not one per key (command + event).
             if key.ends_with(".command") {
                 removed += 1;
@@ -327,10 +476,23 @@ pub(crate) fn remove_local_shims() -> Result<usize> {
     Ok(removed)
 }
 
-fn run_git(args: &[&str]) -> Result<()> {
-    let status = Command::new("git").args(args).status()?;
+fn run_git<I, S>(args: I) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let args: Vec<OsString> = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_os_string())
+        .collect();
+    let status = Command::new("git").args(&args).status()?;
     if !status.success() {
-        bail!("git {} failed", args.join(" "));
+        let args = args
+            .iter()
+            .map(|arg| arg.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ");
+        bail!("git {args} failed");
     }
     Ok(())
 }
@@ -383,4 +545,54 @@ fn check_hooks_path_config() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn global_hk_command_uses_quoted_absolute_path() {
+        assert_eq!(
+            hk_hook_command(Path::new("/tmp/hk bin/hk")).to_string_lossy(),
+            "'/tmp/hk bin/hk'"
+        );
+    }
+
+    #[test]
+    fn global_mise_command_requests_hk_tool_explicitly() {
+        assert_eq!(
+            mise_hook_command(Path::new("/opt/homebrew/bin/mise")).to_string_lossy(),
+            "/opt/homebrew/bin/mise x hk -- hk"
+        );
+    }
+
+    #[test]
+    fn global_hook_command_uses_tilde_for_home_relative_paths() {
+        let home = dirs::home_dir().expect("home directory should exist");
+
+        assert_eq!(
+            hk_hook_command(&home.join(".local/bin/hk")).to_string_lossy(),
+            "~/.local/bin/hk"
+        );
+    }
+
+    #[test]
+    fn local_mise_command_keeps_existing_behavior() {
+        assert_eq!(local_hook_command(true), OsString::from("mise x -- hk"));
+        assert_eq!(local_hook_command(false), OsString::from("hk"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_quote_path_preserves_non_utf8_bytes() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let path = Path::new(OsStr::from_bytes(b"/tmp/hk-\xFF/bin/hk"));
+        let quoted = shell_quote_path(path);
+
+        assert!(quoted.into_vec().contains(&0xFF));
+    }
 }

--- a/test/install_global.bats
+++ b/test/install_global.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+require_git_2_54() {
+    local version major minor
+    version="$(git version | awk '{print $3}')"
+    major="${version%%.*}"
+    minor="${version#*.}"
+    minor="${minor%%.*}"
+    if [ "$major" -lt 2 ] || { [ "$major" -eq 2 ] && [ "$minor" -lt 54 ]; }; then
+        skip "hk install --global requires Git 2.54+"
+    fi
+}
+
+@test "hk install --global writes an absolute hk command" {
+    require_git_2_54
+
+    run hk install --global
+    assert_success
+
+    run git config --global --get hook.hk-pre-commit.command
+    assert_success
+    assert_output --partial 'run pre-commit --from-hook "$@"'
+    refute_output --partial '|| hk run'
+
+    run git config --global --get hook.hk-pre-rebase.command
+    assert_failure
+
+    mkdir "$TEST_TEMP_DIR/src/without-hk"
+    cd "$TEST_TEMP_DIR/src/without-hk"
+    git init .
+
+    command="$(git config --global --get hook.hk-pre-commit.command)"
+    run env PATH="/usr/bin:/bin:/usr/sbin:/sbin" sh -c "$command" hook-shim
+    assert_success
+}
+
+@test "hk install --global uses project hooks when hk config exists" {
+    require_git_2_54
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-rebase"] {
+        steps {
+            ["noop"] { check = "exit 0" }
+        }
+    }
+}
+EOF
+
+    run hk install --global
+    assert_success
+
+    run git config --global --get hook.hk-pre-rebase.command
+    assert_success
+    assert_output --partial 'run pre-rebase --from-hook "$@"'
+
+    run git config --global --get hook.hk-pre-commit.command
+    assert_failure
+}
+
+@test "hk install --global --mise writes home-relative mise with explicit hk tool" {
+    require_git_2_54
+
+    mkdir "$TEST_TEMP_DIR/bin"
+    cat >"$TEST_TEMP_DIR/bin/mise" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+    chmod +x "$TEST_TEMP_DIR/bin/mise"
+    PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+    run hk install --global --mise
+    assert_success
+
+    run git config --global --get hook.hk-pre-commit.command
+    assert_success
+    assert_output --partial "~/bin/mise x hk -- hk run pre-commit --from-hook"
+    refute_output --partial '|| mise x -- hk run'
+
+    command="$(git config --global --get hook.hk-pre-commit.command)"
+    run env PATH="/usr/bin:/bin:/usr/sbin:/sbin" sh -c "$command" hook-shim
+    assert_success
+}


### PR DESCRIPTION
## Summary
- resolve global hook commands to absolute hk/mise paths at install time
- use `mise x hk -- hk` for global --mise hooks so hk is requested explicitly
- add regression coverage for global hook config in sanitized PATH environments

## Validation
- `cargo test cli::install`
- `cargo build`
- `./test/bats/bin/bats test/install_global.bats`

Fixes #937

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `hk install --global` writes Git config hook commands (path resolution/quoting and default event selection), which could break hook execution on some environments if edge cases were missed.
> 
> **Overview**
> `hk install --global` now writes **shell-safe, resolved commands** into `hook.hk-*.command` by computing an absolute `hk` path (or `mise` path) at install time, using `~/` when home-relative and quoting otherwise; global `--mise` installs also switch to `mise x hk -- hk` to explicitly request the `hk` tool.
> 
> Global installs now pick hook events from the project `hk.pkl` when present (falling back to a reduced core set), and the installer internals were updated to pass commands as `OsStr`/`OsString` to better support non-UTF8 paths. Adds Rust unit tests plus a new `bats` suite validating global hook behavior in a sanitized `PATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dde71b8faf2aac62b4e1021fc941cc32d7a903c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->