### PR TITLE
feat(mise): support per-step workspace activation

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -99,6 +99,15 @@ If set to `true`:
 - When installing hooks with `hk install`, hk will use `mise x` to execute hooks which won't require activating mise to use mise tools
 - When generating files with `hk init`, hk will create a `mise.toml` file with hk configured
 
+## `HK_MISE_PER_STEP`
+
+Type: `bool`
+Default: `false`
+
+If set to `true`, steps without an explicit `workspace_indicator` are grouped by the nearest `mise.toml` or `.mise.toml`. hk also fills in missing mise-related step settings: for those implicitly grouped steps, if `dir` is unset, hk behaves as if `dir = "{{workspace}}"`; for any step, if `prefix` is unset, hk wraps step commands with `mise x --`. Explicit `workspace_indicator`, `dir`, and `prefix` settings are preserved. Nested mise tool versions are available when the step runs from that workspace, either through implicit grouping or an explicit `dir`. Steps that only run `hk util ...` commands are left unchanged.
+
+This is separate from `HK_MISE`: `HK_MISE` controls hook installation/init behavior, while `HK_MISE_PER_STEP` controls step command execution.
+
 ## `HK_SKIP_STEPS`
 
 Type: `string[]` (comma-separated list)

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -65,6 +65,19 @@ PRETTIER_CONFIG = ".prettierrc.json"
 
 mise has much more functionality around environment variables, so see the [mise docs](https://mise.jdx.dev/environments/) for more information.
 
+## Monorepos
+
+Set `HK_MISE_PER_STEP=1` when hk should resolve tools from nested mise configs. For steps without an explicit `workspace_indicator`, hk treats `mise.toml` and `.mise.toml` as workspace indicators.
+
+hk also fills in missing mise-related step settings: for implicitly grouped steps, if `dir` is unset, hk runs the step from the matched workspace; for any step, if `prefix` is unset, hk wraps commands with `mise x --`. Explicit `workspace_indicator`, `dir`, and `prefix` settings are preserved. Nested mise tool versions are available when the step runs from that workspace, either through implicit grouping or an explicit `dir`. Built-in `hk util ...` steps are not changed because they do not need mise-managed tools.
+
+```toml
+[env]
+HK_MISE_PER_STEP = 1
+```
+
+This is intentionally separate from `HK_MISE=1`. `HK_MISE=1` makes installed Git hooks launch hk through mise from the repository root; `HK_MISE_PER_STEP=1` makes individual step commands re-enter mise from their own working directories.
+
 ## Recommended Setup
 
 The recommended approach is to use `mise.toml` as the source of truth for your tools and environment, while using `hk` specifically for managing the Git lifecycle.

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -507,7 +507,7 @@ class Step {
   ///   }
   /// }
   /// ```
-  workspace_indicator: String?
+  workspace_indicator: (String | List<String>)?
 
   /// If set, run the linter scripts with this prefix, e.g.: "mise exec --" or "npm run".
   ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ impl Config {
     pub fn get() -> Result<Self> {
         let mut config = Self::load_project_config()?;
         config.apply_hkrc()?;
+        config.apply_mise_per_step_defaults();
         config.validate()?;
         Ok(config)
     }
@@ -638,6 +639,63 @@ impl Config {
         }
         Ok(())
     }
+
+    fn apply_mise_per_step_defaults(&mut self) {
+        if !*env::HK_MISE_PER_STEP {
+            return;
+        }
+        for hook in self.hooks.values_mut() {
+            for step_or_group in hook.steps.values_mut() {
+                match step_or_group {
+                    crate::hook::StepOrGroup::Step(step) => {
+                        apply_mise_per_step_defaults_to_step(step);
+                    }
+                    crate::hook::StepOrGroup::Group(group) => {
+                        for step in group.steps.values_mut() {
+                            apply_mise_per_step_defaults_to_step(step);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn apply_mise_per_step_defaults_to_step(step: &mut crate::step::Step) {
+    if step_uses_only_hk_util(step) {
+        return;
+    }
+    let has_explicit_workspace_indicator = step.workspace_indicator.is_some();
+    if !has_explicit_workspace_indicator {
+        step.workspace_indicator = Some(StringOrList::List(vec![
+            "mise.toml".to_string(),
+            ".mise.toml".to_string(),
+        ]));
+    }
+    if !has_explicit_workspace_indicator && step.dir.is_none() {
+        step.dir = Some("{{workspace}}".to_string());
+    }
+    if step.prefix.is_none() {
+        step.prefix = Some(crate::step::MISE_PREFIX.to_string());
+    }
+}
+
+fn step_uses_only_hk_util(step: &crate::step::Step) -> bool {
+    let commands = [
+        step.check.as_ref(),
+        step.check_list_files.as_ref(),
+        step.check_diff.as_ref(),
+        step.fix.as_ref(),
+    ];
+    let commands = commands
+        .into_iter()
+        .flatten()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    !commands.is_empty()
+        && commands
+            .iter()
+            .all(|cmd| cmd.trim_start().starts_with("hk util "))
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -701,7 +759,7 @@ pub struct UserStepConfig {
     pub exclude: Option<crate::step::Pattern>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum StringOrList {
     String(String),
@@ -716,6 +774,15 @@ impl IntoIterator for StringOrList {
         match self {
             StringOrList::String(s) => vec![s].into_iter(),
             StringOrList::List(list) => list.into_iter(),
+        }
+    }
+}
+
+impl StringOrList {
+    pub fn as_slice(&self) -> Vec<&str> {
+        match self {
+            StringOrList::String(s) => vec![s.as_str()],
+            StringOrList::List(list) => list.iter().map(String::as_str).collect(),
         }
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -57,6 +57,7 @@ pub static HK_STASH: LazyLock<Option<StashMethod>> = LazyLock::new(|| {
 pub static HK_STASH_UNTRACKED: LazyLock<bool> = LazyLock::new(|| !var_false("HK_STASH_UNTRACKED"));
 pub static HK_FIX: LazyLock<bool> = LazyLock::new(|| !var_false("HK_FIX"));
 pub static HK_MISE: LazyLock<bool> = LazyLock::new(|| var_true("HK_MISE"));
+pub static HK_MISE_PER_STEP: LazyLock<bool> = LazyLock::new(|| var_true("HK_MISE_PER_STEP"));
 pub static HK_SKIP_STEPS: LazyLock<IndexSet<String>> = LazyLock::new(|| {
     var_csv("HK_SKIP_STEPS")
         .or(var_csv("HK_SKIP_STEP"))

--- a/src/step/batching.rs
+++ b/src/step/batching.rs
@@ -50,12 +50,6 @@ impl Step {
         if run.trim().is_empty() {
             return None;
         }
-        let run = if let Some(prefix) = &self.prefix {
-            format!("{prefix} {run}")
-        } else {
-            run
-        };
-
         let mut temp = StepJob::new(
             Arc::clone(&original_job.step),
             files.to_vec(),
@@ -66,7 +60,9 @@ impl Step {
             temp = temp.with_workspace_indicator(wi.clone());
         }
         let tctx = temp.tctx(base_tctx);
-        tera::render(&run, &tctx).ok().map(|s| s.len())
+        tera::render(&run, &tctx)
+            .ok()
+            .map(|s| self.apply_prefix(&s).len())
     }
 
     /// Automatically batch jobs whose rendered run command would exceed the safe ARG_MAX limit.

--- a/src/step/check_parsing.rs
+++ b/src/step/check_parsing.rs
@@ -8,7 +8,7 @@
 
 use indexmap::IndexSet;
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use xx::file::display_path;
 
 use super::strip_orig_suffix;
@@ -50,10 +50,12 @@ impl Step {
         &self,
         original_files: &[PathBuf],
         stdout: &str,
+        output_dir: Option<&Path>,
     ) -> (Vec<PathBuf>, Vec<PathBuf>) {
         let listed: HashSet<PathBuf> = stdout
             .lines()
-            .map(|p| try_canonicalize(&PathBuf::from(p)))
+            .flat_map(|p| output_paths(p, output_dir))
+            .map(|p| try_canonicalize(&p))
             .collect();
         let files: IndexSet<PathBuf> = original_files
             .iter()
@@ -89,6 +91,7 @@ impl Step {
         &self,
         original_files: &[PathBuf],
         stdout: &str,
+        output_dir: Option<&Path>,
     ) -> (Vec<PathBuf>, Vec<PathBuf>) {
         let stdout = strip_orig_suffix(stdout);
 
@@ -120,6 +123,9 @@ impl Step {
                     } else {
                         path_str.trim()
                     };
+                    if path == "/dev/null" {
+                        continue;
+                    }
                     // Strip standard diff path prefixes (a/ or b/) if detected
                     let path = if should_strip_prefixes {
                         path.strip_prefix("a/")
@@ -128,7 +134,11 @@ impl Step {
                     } else {
                         path
                     };
-                    listed.insert(try_canonicalize(&PathBuf::from(path)));
+                    listed.extend(
+                        output_paths(path, output_dir)
+                            .into_iter()
+                            .map(|p| try_canonicalize(&p)),
+                    );
                 }
             } else if line.starts_with("+++ ")
                 && let Some(path_str) = line.strip_prefix("+++ ")
@@ -138,6 +148,9 @@ impl Step {
                 } else {
                     path_str.trim()
                 };
+                if path == "/dev/null" {
+                    continue;
+                }
                 // Strip standard diff path prefixes (a/ or b/) if detected
                 let path = if should_strip_prefixes {
                     path.strip_prefix("a/")
@@ -146,7 +159,11 @@ impl Step {
                 } else {
                     path
                 };
-                listed.insert(try_canonicalize(&PathBuf::from(path)));
+                listed.extend(
+                    output_paths(path, output_dir)
+                        .into_iter()
+                        .map(|p| try_canonicalize(&p)),
+                );
             }
         }
         let files: IndexSet<PathBuf> = original_files
@@ -160,5 +177,21 @@ impl Step {
             .filter(|f| !canonicalized_files.contains(f))
             .collect();
         (files.into_iter().collect(), extras)
+    }
+}
+
+fn output_paths(path: &str, output_dir: Option<&Path>) -> Vec<PathBuf> {
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        vec![path]
+    } else if let Some(output_dir) = output_dir {
+        let workspace_path = output_dir.join(&path);
+        if workspace_path.exists() {
+            vec![workspace_path]
+        } else {
+            vec![path]
+        }
+    } else {
+        vec![path]
     }
 }

--- a/src/step/diff.rs
+++ b/src/step/diff.rs
@@ -6,6 +6,7 @@
 
 use crate::Result;
 use std::io::Write;
+use std::path::Path;
 
 use super::strip_orig_suffix;
 use super::types::Step;
@@ -32,7 +33,11 @@ impl Step {
     /// * `Ok(true)` - Diff was applied successfully
     /// * `Ok(false)` - Diff application failed (caller should fall back to fixer)
     /// * `Err(_)` - Unexpected error
-    pub(crate) fn apply_diff_output(&self, stdout: &str) -> Result<bool> {
+    pub(crate) fn apply_diff_output(
+        &self,
+        stdout: &str,
+        output_dir: Option<&Path>,
+    ) -> Result<bool> {
         if stdout.trim().is_empty() {
             debug!("{}: no diff content to apply", self.name);
             return Ok(false);
@@ -59,15 +64,31 @@ impl Step {
             "-p0"
         };
 
-        // Use --whitespace=nowarn to avoid warnings about whitespace
-        // Run in the step's directory if configured (same as check_diff command)
+        if self.try_apply_diff(&diff_content, strip_level, output_dir)? {
+            debug!("{}: successfully applied diff", self.name);
+            Ok(true)
+        } else if output_dir.is_some() && self.try_apply_diff(&diff_content, strip_level, None)? {
+            debug!("{}: successfully applied diff from repo root", self.name);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn try_apply_diff(
+        &self,
+        diff_content: &str,
+        strip_level: &str,
+        output_dir: Option<&Path>,
+    ) -> Result<bool> {
+        // Use --whitespace=nowarn to avoid warnings about whitespace.
         let mut cmd = std::process::Command::new("git");
         cmd.args(["apply", strip_level, "--whitespace=nowarn", "-"])
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
 
-        if let Some(dir) = &self.dir {
+        if let Some(dir) = output_dir {
             cmd.current_dir(dir);
         }
 
@@ -81,7 +102,6 @@ impl Step {
             }
         };
 
-        // Write diff to stdin
         if let Some(stdin) = child.stdin.as_mut()
             && let Err(e) = stdin.write_all(diff_content.as_bytes())
         {
@@ -98,7 +118,6 @@ impl Step {
         };
 
         if output.status.success() {
-            debug!("{}: successfully applied diff", self.name);
             Ok(true)
         } else {
             let stderr_output = String::from_utf8_lossy(&output.stderr);

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -135,10 +135,19 @@ impl Step {
                                 check_first_output = Some((stdout.clone(), stderr.clone(), combined.clone()));
                                 // Use check_diff parser if check_diff is defined, otherwise check_list_files
                                 let is_check_diff = step.check_diff.is_some();
+                                let output_dir = job.effective_dir();
                                 let (files, extras) = if is_check_diff {
-                                    step.filter_files_from_check_diff(&job.files, stdout)
+                                    step.filter_files_from_check_diff(
+                                        &job.files,
+                                        stdout,
+                                        output_dir.as_deref(),
+                                    )
                                 } else {
-                                    step.filter_files_from_check_list(&job.files, stdout)
+                                    step.filter_files_from_check_list(
+                                        &job.files,
+                                        stdout,
+                                        output_dir.as_deref(),
+                                    )
                                 };
                                 for f in extras {
                                     warn!(
@@ -163,7 +172,7 @@ impl Step {
                                 // Try to apply diff directly when check_diff is defined and we're in Fix mode
                                 // (prev_run_type is the original mode; job.run_type was temporarily changed to Check)
                                 if is_check_diff && prev_run_type == RunType::Fix {
-                                    match step.apply_diff_output(stdout) {
+                                    match step.apply_diff_output(stdout, output_dir.as_deref()) {
                                         Ok(true) => {
                                             // Diff applied successfully - no need to run fixer
                                             debug!("{step}: diff applied successfully, skipping fixer");
@@ -172,8 +181,14 @@ impl Step {
                                             return Ok(job.files.clone());
                                         }
                                         Ok(false) => {
-                                            // Diff application failed - fall through to run fixer
-                                            debug!("{step}: diff application failed, falling back to fixer");
+                                            if step.fix.is_none() {
+                                                eyre::bail!(
+                                                    "{step}: check_diff could not be applied directly and no fix command is configured"
+                                                );
+                                            }
+                                            debug!(
+                                                "{step}: diff application failed, falling back to fixer"
+                                            );
                                         }
                                         Err(err) => {
                                             // Unexpected error - fall through to run fixer

--- a/src/step/filtering.rs
+++ b/src/step/filtering.rs
@@ -172,7 +172,11 @@ impl Step {
     /// The filtered list of files that match all criteria
     pub fn filter_files(&self, files: &[PathBuf]) -> Result<Vec<PathBuf>> {
         let mut files = files.to_vec();
-        if let Some(dir) = &self.dir {
+        let dir = self
+            .dir
+            .as_ref()
+            .filter(|dir| dir.as_str() != "{{workspace}}");
+        if let Some(dir) = dir {
             files.retain(|f| f.starts_with(dir));
             if files.is_empty() {
                 debug!("{self}: no files in {dir}");
@@ -182,12 +186,12 @@ impl Step {
         }
         if let Some(pattern) = &self.glob {
             // Use get_pattern_matches consistently for both globs and regex
-            files = glob::get_pattern_matches(pattern, &files, self.dir.as_deref())?;
+            files = glob::get_pattern_matches(pattern, &files, dir.map(String::as_str))?;
         }
         if let Some(pattern) = self.exclude.as_ref().filter(|pattern| !pattern.is_empty()) {
             // Use get_pattern_matches consistently for excludes too
             let excluded: HashSet<_> =
-                glob::get_pattern_matches(pattern, &files, self.dir.as_deref())?
+                glob::get_pattern_matches(pattern, &files, dir.map(String::as_str))?
                     .into_iter()
                     .collect();
             files.retain(|f| !excluded.contains(f));
@@ -245,13 +249,14 @@ impl Step {
     /// - `src/crate-1/Cargo.toml`
     /// - `src/crate-2/Cargo.toml`
     pub fn workspaces_for_files(&self, files: &[PathBuf]) -> Result<Option<IndexSet<PathBuf>>> {
-        let Some(workspace_indicator) = &self.workspace_indicator else {
+        let Some(workspace_indicators) = &self.workspace_indicator else {
             return Ok(None);
         };
+        let workspace_indicators = workspace_indicators.as_slice();
         let mut dirs = files.iter().filter_map(|f| f.parent()).collect_vec();
         let mut workspaces: IndexSet<PathBuf> = Default::default();
         while let Some(dir) = dirs.pop() {
-            if let Some(workspace) = xx::file::find_up(dir, &[workspace_indicator]) {
+            if let Some(workspace) = xx::file::find_up(dir, &workspace_indicators) {
                 workspaces.insert(workspace);
             }
         }

--- a/src/step/mod.rs
+++ b/src/step/mod.rs
@@ -46,6 +46,9 @@ mod types;
 
 // Re-export public API
 pub use expr_env::{EXPR_CTX, EXPR_ENV};
+
+/// The prefix string that triggers mise workspace wrapping for step commands.
+pub const MISE_PREFIX: &str = "mise x --";
 pub use shell::ShellType;
 pub use types::{OutputSummary, Pattern, RunType, Script, Step};
 

--- a/src/step/output.rs
+++ b/src/step/output.rs
@@ -106,23 +106,28 @@ impl Step {
         if let Some(result) = cmd_result
             && self.check_list_files.is_some()
         {
-            let (files, _extras) = self.filter_files_from_check_list(&job.files, &result.stdout);
+            let (files, _extras) = self.filter_files_from_check_list(
+                &job.files,
+                &result.stdout,
+                job.effective_dir().as_deref(),
+            );
             if !files.is_empty() {
                 suggest_files = files;
             }
         }
         // Build a minimal context based on the suggested files, honoring dir/workspace
-        let temp_job = StepJob::new(Arc::new(self.clone()), suggest_files, RunType::Fix);
+        let mut temp_job = StepJob::new(Arc::new(self.clone()), suggest_files, RunType::Fix);
+        if let Some(workspace_indicator) = job.workspace_indicator() {
+            temp_job = temp_job.with_workspace_indicator(workspace_indicator.clone());
+        }
         let suggest_ctx = temp_job.tctx(&ctx.hook_ctx.tctx);
-        if let Some(mut fix_cmd) = self
+        if let Some(fix_cmd) = self
             .run_cmd(RunType::Fix)
             .map(|s| s.to_string())
             .filter(|s| !s.trim().is_empty())
         {
-            if let Some(prefix) = &self.prefix {
-                fix_cmd = format!("{prefix} {fix_cmd}");
-            }
             if let Ok(rendered) = tera::render(&fix_cmd, &suggest_ctx) {
+                let rendered = self.apply_prefix(&rendered);
                 let is_multi_line = rendered.contains('\n');
                 if is_multi_line {
                     // Too long to inline; suggest hk fix with step filter

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -137,24 +137,23 @@ impl Step {
         } else {
             self.run_cmd(job.run_type)
         };
-        let Some(mut run) = run_cmd
+        let Some(run) = run_cmd
             .map(|s| s.to_string())
             .filter(|s| !s.trim().is_empty())
         else {
             eyre::bail!("{self}: no run command");
         };
-        if let Some(prefix) = &self.prefix {
-            run = format!("{prefix} {run}");
-        }
         // Render twice: once with the full file list for execution, and
         // once with the display context — which truncates `files` /
         // `workspace_files` to `first_file …` when there are multiple
         // files. A 98-file step would otherwise emit ~4KB of paths in the
         // progress message; this keeps the command shape and one
         // concrete example path visible without unbounded expansion.
-        let run_for_display =
-            tera::render(&run, &tctx.for_display()).unwrap_or_else(|_| run.clone());
+        let run_for_display = tera::render(&run, &tctx.for_display())
+            .map(|run| self.apply_prefix(&run))
+            .unwrap_or_else(|_| self.apply_prefix(&run));
         let run = tera::render(&run, &tctx)
+            .map(|run| self.apply_prefix(&run))
             .wrap_err_with(|| format!("{self}: failed to render command template"))?;
         let pattern_display = match &self.glob {
             Some(Pattern::Globs(g)) => g.join(" "),
@@ -229,7 +228,7 @@ impl Step {
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit());
         }
-        if let Some(dir) = &self.dir {
+        if let Some(dir) = job.effective_dir() {
             cmd = cmd.current_dir(dir);
         }
         for (key, value) in &self.env {
@@ -410,6 +409,45 @@ impl Step {
             "" if cfg!(windows) => ShellType::Cmd,
             "" => ShellType::Sh,
             _ => ShellType::Other(shell.to_string()),
+        }
+    }
+
+    pub(crate) fn apply_prefix(&self, run: &str) -> String {
+        match &self.prefix {
+            Some(prefix) if prefix == super::MISE_PREFIX => self.mise_wrapped_command(run),
+            Some(prefix) => format!("{prefix} {run}"),
+            None => run.to_string(),
+        }
+    }
+
+    /// Returns true if the command needs a shell wrapper (contains metacharacters).
+    fn needs_shell_wrap(cmd: &str) -> bool {
+        cmd.contains('|')
+            || cmd.contains(';')
+            || cmd.contains('&')
+            || cmd.contains('$')
+            || cmd.contains('`')
+            || cmd.contains('(')
+            || cmd.contains(')')
+            || cmd.contains('\n')
+    }
+
+    fn mise_wrapped_command(&self, run: &str) -> String {
+        if !Self::needs_shell_wrap(run) {
+            // Simple command: prepend mise x -- directly without shell layer
+            return format!("{} {run}", super::MISE_PREFIX);
+        }
+        if let Some(shell) = &self.shell {
+            let shell = shell.to_string();
+            format!("{} {shell} {}", super::MISE_PREFIX, self.shell_type().quote(run))
+        } else if cfg!(windows) {
+            format!("{} cmd.exe /c {}", super::MISE_PREFIX, self.shell_type().quote(run))
+        } else {
+            format!(
+                "{} sh -o errexit -c {}",
+                super::MISE_PREFIX,
+                self.shell_type().quote(run)
+            )
         }
     }
 

--- a/src/step/types.rs
+++ b/src/step/types.rs
@@ -7,6 +7,7 @@
 //! - [`RunType`] - Whether to run in check or fix mode
 //! - [`OutputSummary`] - How to capture and display command output
 
+use crate::config::StringOrList;
 use crate::step_test::StepTest;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -174,8 +175,8 @@ pub struct Step {
     #[serde_as(as = "Option<PickFirst<(_, DisplayFromStr)>>")]
     pub fix: Option<Script>,
 
-    /// File that indicates workspace roots (e.g., `Cargo.toml` for Rust)
-    pub workspace_indicator: Option<String>,
+    /// Files that indicate workspace roots (e.g., `Cargo.toml` for Rust)
+    pub workspace_indicator: Option<StringOrList>,
 
     /// Prefix to prepend to all commands
     pub prefix: Option<String>,

--- a/src/step_group.rs
+++ b/src/step_group.rs
@@ -198,10 +198,14 @@ impl StepGroup {
             .steps
             .values()
             .map(|step| {
+                let dir = step
+                    .dir
+                    .as_ref()
+                    .filter(|dir| dir.as_str() != "{{workspace}}");
                 let step_files = if let Some(pattern) = &step.glob {
                     // Use get_pattern_matches which handles dir filtering internally
-                    glob::get_pattern_matches(pattern, &files, step.dir.as_deref())?
-                } else if let Some(dir) = &step.dir {
+                    glob::get_pattern_matches(pattern, &files, dir.map(String::as_str))?
+                } else if let Some(dir) = dir {
                     // If dir is set without glob, filter files to that directory
                     files
                         .iter()

--- a/src/step_job.rs
+++ b/src/step_job.rs
@@ -70,7 +70,8 @@ impl StepJob {
         tctx.insert("step", &self.step.name);
 
         // Handle directory stripping for command execution context
-        let command_files = if let Some(dir) = &self.step.dir {
+        let effective_dir = self.effective_dir();
+        let command_files = if let Some(dir) = &effective_dir {
             self.files
                 .iter()
                 .map(|f| f.strip_prefix(dir).unwrap_or(f).to_path_buf())
@@ -89,6 +90,23 @@ impl StepJob {
             tctx.with_workspace_files(self.step.shell_type(), workspace_dir, &self.files);
         }
         tctx
+    }
+
+    pub fn effective_dir(&self) -> Option<PathBuf> {
+        match self.step.dir.as_deref() {
+            Some("{{workspace}}") => self
+                .workspace_indicator
+                .as_ref()
+                .map(|workspace_indicator| {
+                    workspace_indicator
+                        .parent()
+                        .filter(|p| !p.as_os_str().is_empty())
+                        .unwrap_or(std::path::Path::new("."))
+                        .to_path_buf()
+                }),
+            Some(dir) => Some(PathBuf::from(dir)),
+            None => None,
+        }
     }
 
     pub fn build_progress(&self, ctx: &StepContext) -> Arc<ProgressJob> {

--- a/test/apply_check_diff.bats
+++ b/test/apply_check_diff.bats
@@ -121,6 +121,77 @@ EOF
 FIXED"
 }
 
+@test "check_diff without fixer fails when apply fails" {
+    cat <<'SCRIPT' > formatter.sh
+#!/bin/bash
+echo "this is not a valid diff format"
+exit 1
+SCRIPT
+    chmod +x formatter.sh
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["fix"] {
+        fix = true
+        steps {
+            ["fmt"] {
+                glob = List("*.txt")
+                check_diff = "./formatter.sh {{files}}"
+            }
+        }
+    }
+}
+EOF
+
+    echo "hello" > test.txt
+
+    run hk fix test.txt
+    assert_failure
+    assert_output --partial "check_diff could not be applied directly and no fix command is configured"
+}
+
+@test "check_diff ignores dev null headers when applying deletes" {
+    cat <<'SCRIPT' > formatter.sh
+#!/bin/bash
+file="$1"
+if [ -f "$file" ]; then
+    echo "--- $file"
+    echo "+++ /dev/null"
+    echo "@@ -1 +0,0 @@"
+    echo "-$(cat "$file")"
+fi
+exit 1
+SCRIPT
+    chmod +x formatter.sh
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["fix"] {
+        fix = true
+        steps {
+            ["fmt"] {
+                glob = List("*.txt")
+                check_diff = "./formatter.sh {{files}}"
+                fix = "echo fallback"
+            }
+        }
+    }
+}
+EOF
+
+    echo "hello" > test.txt
+    git add test.txt
+    git commit -m "add test"
+
+    run hk fix test.txt
+    assert_success
+    refute_output --partial "file in check output not found"
+    run test -e test.txt
+    assert_failure
+}
+
 @test "check_diff applies diff when command exits nonzero with valid diff" {
     # Some tools like ruff, black, shfmt exit nonzero when files need changes
     # but still output a valid diff that can be applied

--- a/test/mise_per_step.bats
+++ b/test/mise_per_step.bats
@@ -1,0 +1,330 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper/common_setup'
+  _common_setup
+}
+
+teardown() {
+  _common_teardown
+}
+
+setup_mise_per_step_repo() {
+  mkdir -p "$TEST_TEMP_DIR/bin" packages/client/tools packages/server
+
+  cat > "$TEST_TEMP_DIR/bin/mise" <<'EOF'
+#!/bin/sh
+if [ "$1" != "x" ] || [ "$2" != "--" ]; then
+  echo "unexpected mise args: $*" >&2
+  exit 2
+fi
+shift 2
+if [ -x "tools/nested-tool" ]; then
+  PATH="$(pwd)/tools:$PATH"
+  HK_TEST_WORKSPACE="client"
+  export PATH HK_TEST_WORKSPACE
+elif [ -f ".mise.toml" ]; then
+  HK_TEST_WORKSPACE="server"
+  export HK_TEST_WORKSPACE
+fi
+exec "$@"
+EOF
+  chmod +x "$TEST_TEMP_DIR/bin/mise"
+
+  cat > packages/client/tools/nested-tool <<'EOF'
+#!/bin/sh
+printf 'nested-tool: pwd=%s args=%s env=%s\n' "$(pwd)" "$*" "$HK_TEST_WORKSPACE"
+EOF
+  chmod +x packages/client/tools/nested-tool
+
+  PATH="$TEST_TEMP_DIR/bin:$PATH"
+
+  touch mise.toml packages/client/mise.toml packages/server/.mise.toml
+  printf 'bad\n' > packages/client/main.go
+  printf 'server\n' > packages/server/main.go
+  git add .
+}
+
+@test "HK_MISE_PER_STEP wraps multiline scripts in workspace mise env" {
+  setup_mise_per_step_repo
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["nested-tool"] {
+        glob = "packages/client/*.go"
+        check = "nested-tool {{files}} && nested-tool {{files}}"
+      }
+    }
+  }
+}
+EOF
+
+  run env HK_MISE_PER_STEP=1 hk check --all --step nested-tool -v
+  assert_success
+  assert_output --partial "nested-tool: pwd="
+  assert_output --partial "packages/client"
+  assert_output --partial "args=main.go env=client"
+}
+
+@test "HK_MISE_PER_STEP check_list_files output may be workspace-relative" {
+  setup_mise_per_step_repo
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    fix = true
+    steps {
+      ["list"] {
+        glob = "packages/client/*.go"
+        check_list_files = "echo main.go; exit 1"
+        fix = "nested-tool {{files}}"
+      }
+    }
+  }
+}
+EOF
+
+  run env HK_MISE_PER_STEP=1 hk fix --all --step list -v
+  assert_success
+  assert_output --partial "nested-tool:"
+  assert_output --partial "args=main.go env=client"
+  refute_output --partial "file in check output not found"
+}
+
+@test "HK_MISE_PER_STEP check_list_files output may be repo-relative" {
+  setup_mise_per_step_repo
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    fix = true
+    steps {
+      ["list"] {
+        glob = "packages/client/*.go"
+        check_list_files = "echo packages/client/main.go; exit 1"
+        fix = "nested-tool {{files}}"
+      }
+    }
+  }
+}
+EOF
+
+  run env HK_MISE_PER_STEP=1 hk fix --all --step list -v
+  assert_success
+  assert_output --partial "nested-tool:"
+  assert_output --partial "args=main.go env=client"
+  refute_output --partial "file in check output not found"
+}
+
+@test "HK_MISE_PER_STEP applies workspace-relative check_diff" {
+  setup_mise_per_step_repo
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    fix = true
+    steps {
+      ["diff"] {
+        glob = "*.go"
+        check_diff = "printf -- '--- main.go\n+++ main.go\n@@ -1 +1 @@\n-bad\n+good\n'; exit 1"
+        fix = "printf fallback"
+      }
+    }
+  }
+}
+EOF
+
+  run env HK_MISE_PER_STEP=1 hk fix --all --step diff -v
+  assert_success
+  assert_output --partial "diff applied successfully"
+  run cat packages/client/main.go
+  assert_success
+  assert_output "good"
+}
+
+@test "HK_MISE_PER_STEP applies repo-relative check_diff from workspace cwd" {
+  setup_mise_per_step_repo
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    fix = true
+    steps {
+      ["diff"] {
+        glob = "packages/client/*.go"
+        check_diff = "printf -- '--- packages/client/main.go\n+++ packages/client/main.go\n@@ -1 +1 @@\n-bad\n+good\n'; exit 1"
+        fix = "printf fallback"
+      }
+    }
+  }
+}
+EOF
+
+  run env HK_MISE_PER_STEP=1 hk fix --all --step diff -v
+  assert_success
+  assert_output --partial "diff applied successfully"
+  run cat packages/client/main.go
+  assert_success
+  assert_output "good"
+}
+
+@test "HK_MISE_PER_STEP preserves explicit workspace_indicator cwd" {
+  setup_mise_per_step_repo
+  touch packages/client/go.mod
+  git add .
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["explicit"] {
+        glob = "packages/client/*.go"
+        workspace_indicator = "go.mod"
+        check = "printf 'pwd=%s files=%s workspace=%s env=%s' \$(pwd) '{{files}}' '{{workspace}}' \${HK_TEST_WORKSPACE-unset}"
+      }
+    }
+  }
+}
+EOF
+
+  run env HK_MISE_PER_STEP=1 hk check --all --step explicit -v
+  assert_success
+  assert_output --partial "files=packages/client/main.go workspace=packages/client env=unset"
+  refute_output --partial "files=main.go workspace=packages/client env=client"
+}
+
+@test "HK_MISE_PER_STEP respects configured shell when wrapping" {
+  setup_mise_per_step_repo
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["bash-shell"] {
+        glob = "packages/client/*.go"
+        shell = "bash -e -c"
+        check = "[[ \"\$HK_TEST_WORKSPACE\" == client ]] && nested-tool {{files}}"
+      }
+    }
+  }
+}
+EOF
+
+  run env HK_MISE_PER_STEP=1 hk check --all --step bash-shell -v
+  assert_success
+  assert_output --partial "mise x -- bash -e -c"
+  assert_output --partial "nested-tool:"
+  assert_output --partial "args=main.go env=client"
+}
+
+@test "HK_MISE_PER_STEP keeps root files outside nested mise roots" {
+  setup_mise_per_step_repo
+  printf 'root\n' > root.go
+  git add .
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["mixed"] {
+        glob = "**/*.go"
+        check = "if command -v nested-tool >/dev/null 2>&1; then nested-tool {{files}}; else printf 'root-files=%s' '{{files}}'; fi"
+      }
+    }
+  }
+}
+EOF
+
+  run env HK_MISE_PER_STEP=1 hk check --all --step mixed -v
+  assert_success
+  assert_output --partial "nested-tool:"
+  assert_output --partial "args=main.go env=client"
+  assert_output --partial "root-files=root.go"
+}
+
+@test "HK_MISE_PER_STEP does not create empty jobs for root mise config" {
+  setup_mise_per_step_repo
+  printf 'root\n' > root.go
+  git add .
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["root-only"] {
+        glob = "root.go"
+        check = "printf 'files=%s' '{{files}}'"
+      }
+    }
+  }
+}
+EOF
+
+  run env HK_MISE_PER_STEP=1 hk check --all --step root-only -v
+  assert_success
+  assert_output --partial "files=root.go"
+  refute_output --partial "0 files"
+}
+
+@test "HK_MISE_PER_STEP does not split or wrap pure hk util steps" {
+  setup_mise_per_step_repo
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["hk-util"] {
+        glob = "**/*.go"
+        check = "hk util check-byte-order-marker {{files}}"
+      }
+    }
+  }
+}
+EOF
+
+  run env HK_MISE_PER_STEP=1 hk check --all --step hk-util -v
+  assert_success
+  assert_output --partial "hk util check-byte-order-marker packages/client/main.go packages/server/main.go"
+  refute_output --partial "mise x --"
+  refute_output --partial "hk util check-byte-order-marker main.go"
+}
+
+@test "HK_MISE_PER_STEP resolves tools from explicit dir" {
+  setup_mise_per_step_repo
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["explicit-dir"] {
+        glob = "*.go"
+        dir = "packages/client"
+        check = "nested-tool {{files}}"
+      }
+    }
+  }
+}
+EOF
+
+  run hk check --all --step explicit-dir -v
+  assert_failure
+  assert_output --partial "nested-tool: command not found"
+
+  run env HK_MISE_PER_STEP=1 hk check --all --step explicit-dir -v
+  assert_success
+  assert_output --partial "nested-tool:"
+  assert_output --partial "args=main.go env=client"
+}

--- a/test/workspace_indicator.bats
+++ b/test/workspace_indicator.bats
@@ -96,3 +96,66 @@ EOF
   # No single job should contain all 8 files — they must be split across batches
   refute_output --partial "ws1/f1.js ws1/f2.js ws1/f3.js ws1/f4.js ws1/f5.js ws1/f6.js ws1/f7.js ws1/f8.js"
 }
+
+@test "HK_MISE_PER_STEP uses mise files as implicit workspace indicators and dir" {
+  rm -rf a b go.mod main.go hk.pkl
+  mkdir -p packages/client packages/server
+  printf '[env]\nHK_TEST_WORKSPACE = "client"\n' > packages/client/mise.toml
+  printf '[env]\nHK_TEST_WORKSPACE = "server"\n' > packages/server/.mise.toml
+  touch packages/client/main.go packages/server/main.go
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["go-check"] {
+        glob = "**/*.go"
+        check = "printf 'pwd=%s files=%s workspace=%s env=%s' \$(pwd) '{{files}}' '{{workspace}}' \$HK_TEST_WORKSPACE"
+      }
+    }
+  }
+}
+EOF
+
+  git add .
+
+  run env HK_MISE_PER_STEP=1 MISE_TRUSTED_CONFIG_PATHS="$PWD/packages/client/mise.toml:$PWD/packages/server/.mise.toml" hk check --all -v
+  assert_success
+  assert_output --partial "packages/client"
+  assert_output --partial "files=main.go workspace=packages/client"
+  assert_output --partial "env=client"
+  assert_output --partial "packages/server"
+  assert_output --partial "files=main.go workspace=packages/server"
+  assert_output --partial "env=server"
+}
+
+@test "HK_MISE_PER_STEP preserves explicit workspace_indicator and dir" {
+  rm -rf a b go.mod main.go hk.pkl
+  mkdir -p packages/client custom
+  touch packages/client/mise.toml packages/client/main.go
+  touch custom/ws custom/main.go
+
+  cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["custom-check"] {
+        glob = "**/*.go"
+        workspace_indicator = "ws"
+        dir = "custom"
+        check = "printf 'pwd=%s files=%s workspace=%s' \$(pwd) '{{files}}' '{{workspace}}'"
+      }
+    }
+  }
+}
+EOF
+
+  git add .
+
+  run env HK_MISE_PER_STEP=1 hk check --all -v
+  assert_success
+  assert_output --partial "files=main.go workspace=custom"
+  refute_output --partial "workspace=packages/client"
+}


### PR DESCRIPTION
## Summary
- add opt-in HK_MISE_PER_STEP support for resolving nested mise workspaces per step
- infer mise.toml/.mise.toml workspace indicators for steps without explicit workspace_indicator
- run implicit workspace steps from their matched workspace and wrap commands with mise x -- while preserving explicit overrides
- harden check_list_files/check_diff path handling for workspace cwd output

## Tests
- mise x rust@latest -- cargo fmt
- mise x rust@latest -- cargo build
- test/bats/bin/bats test/apply_check_diff.bats test/mise_per_step.bats test/workspace_indicator.bats
- mise x rust@latest -- cargo test test_arg_max_is_valid
- git diff --check

*This PR was generated with AI assistance.*