### PR TITLE
fix(check): parse check_diff output for fix suggestions

### DIFF
--- a/src/step/output.rs
+++ b/src/step/output.rs
@@ -89,11 +89,13 @@ impl Step {
     ///
     /// * `ctx` - The step context
     /// * `job` - The current job
-    /// * `cmd_result` - Optional command result (for filtering files from check_list_files output)
+    /// * `run_cmd` - Optional command that produced cmd_result
+    /// * `cmd_result` - Optional command result (for filtering files from check output)
     pub(crate) fn collect_fix_suggestion(
         &self,
         ctx: &StepContext,
         job: &StepJob,
+        run_cmd: Option<&super::types::Script>,
         cmd_result: Option<&ensembler::CmdResult>,
     ) {
         // Only suggest fixes when the entire hook run is in check mode,
@@ -101,14 +103,27 @@ impl Step {
         if !matches!(ctx.hook_ctx.run_type, RunType::Check) || self.fix.is_none() {
             return;
         }
-        // Prefer filtering files if check_list_files output is available
+        // Prefer filtering files when the failed check command can identify
+        // the files needing fixes.
         let mut suggest_files = job.files.clone();
-        if let Some(result) = cmd_result
-            && self.check_list_files.is_some()
-        {
-            let (files, _extras) = self.filter_files_from_check_list(&job.files, &result.stdout);
+        if let (Some(run_cmd), Some(result)) = (run_cmd, cmd_result) {
+            let (files, parser) = if Some(run_cmd) == self.check_diff.as_ref() {
+                let (files, _extras) =
+                    self.filter_files_from_check_diff(&job.files, &result.stdout);
+                (files, Some("check_diff"))
+            } else if Some(run_cmd) == self.check_list_files.as_ref() {
+                let (files, _extras) =
+                    self.filter_files_from_check_list(&job.files, &result.stdout);
+                (files, Some("check_list_files"))
+            } else {
+                (vec![], None)
+            };
             if !files.is_empty() {
                 suggest_files = files;
+            } else if let Some(parser) = parser {
+                debug!(
+                    "{self}: {parser} output did not match any job files; suggesting all job files"
+                );
             }
         }
         // Build a minimal context based on the suggested files, honoring dir/workspace

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -303,7 +303,7 @@ impl Step {
                     );
 
                     // If we're in check mode and a fix command exists, collect a helpful suggestion
-                    self.collect_fix_suggestion(ctx, job, Some(&e.3));
+                    self.collect_fix_suggestion(ctx, job, run_cmd, Some(&e.3));
                 }
                 if job.check_first && job.run_type == RunType::Check {
                     ctx.progress.set_status(ProgressStatus::Warn);

--- a/test/check_fix_suggestion.bats
+++ b/test/check_fix_suggestion.bats
@@ -61,6 +61,31 @@ EOF
     refute_output --partial "b.js"
 }
 
+@test "check failure with check_diff filters files in suggestion when list-files also exists" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["fmt"] {
+        check_diff = "sh -c 'printf \"%s\n\" \"--- a.js\" \"+++ a.js\" \"@@ -1 +1 @@\" \"-bad\" \"+good\"; exit 1'"
+        check_list_files = "sh -c 'echo b.js; exit 1'"
+        fix = "echo fix {{files}}"
+      }
+    }
+  }
+}
+EOF
+
+    echo "bad" > a.js
+    echo "good" > b.js
+
+    run hk check a.js b.js
+    assert_failure
+    assert_output --partial "To fix, run: echo fix a.js"
+    refute_output --partial "To fix, run: echo fix a.js b.js"
+}
+
 @test "check failure with multi-line fix suggests hk fix command" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"


### PR DESCRIPTION
## Summary
- parse failed check output for fix suggestions using the command that actually ran
- use the diff parser for `check_diff` instead of falling through to `check_list_files`
- add a regression covering steps that define both `check_diff` and `check_list_files`

Fixes discussion #942.

## Verification
- `cargo fmt --check`
- `cargo check --features git2/vendored-openssl`
- `cargo build --features git2/vendored-openssl`
- `PATH="$PWD/test/bats/bin:$PWD/target/debug:/Users/jdx/.local/share/mise/installs/pkl/0.31.1:$PATH" test/bats/bin/bats test/check_fix_suggestion.bats`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only change to post-check fix hints and logging; no auth, execution, or hook orchestration changes beyond matching parsers to the failed command.
> 
> **Overview**
> **Check-mode “To fix, run” hints** now narrow `{{files}}` using the **same command that actually failed**, not only when `check_list_files` is configured.
> 
> On failure, `collect_fix_suggestion` receives the executed check script. If it was **`check_diff`**, stdout is parsed with the unified-diff helper; if it was **`check_list_files`**, the list parser is used. When a parser runs but matches no job files, a **debug** log notes that the full job file set is still suggested.
> 
> The runner passes the failed **`run_cmd`** into that path. A **bats** case covers steps with both **`check_diff`** and **`check_list_files`**, ensuring the suggestion follows diff output (e.g. only `a.js`) instead of list-files output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 784a58fc7619701c84ae2207b8565481aa247ef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->