### PR TITLE
feat(run): add staged-only hook scope

### DIFF
--- a/docs/cli/check.md
+++ b/docs/cli/check.md
@@ -79,6 +79,10 @@ Skip specific step(s)
 
 Enable auto-staging of fixed files
 
+### `--staged`
+
+Run on staged files only without stashing unstaged changes
+
 ### `--stash <STASH>`
 
 Stash method to use for git hooks

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -283,6 +283,16 @@
             "global": false
           },
           {
+            "name": "staged",
+            "usage": "--staged",
+            "help": "Run on staged files only without stashing unstaged changes",
+            "help_first_line": "Run on staged files only without stashing unstaged changes",
+            "short": [],
+            "long": ["staged"],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "stash",
             "usage": "--stash <STASH>",
             "help": "Stash method to use for git hooks",
@@ -711,6 +721,16 @@
             "help_first_line": "Enable auto-staging of fixed files",
             "short": [],
             "long": ["stage"],
+            "hide": false,
+            "global": false
+          },
+          {
+            "name": "staged",
+            "usage": "--staged",
+            "help": "Run on staged files only without stashing unstaged changes",
+            "help_first_line": "Run on staged files only without stashing unstaged changes",
+            "short": [],
+            "long": ["staged"],
             "hide": false,
             "global": false
           },
@@ -1214,6 +1234,16 @@
                 "global": false
               },
               {
+                "name": "staged",
+                "usage": "--staged",
+                "help": "Run on staged files only without stashing unstaged changes",
+                "help_first_line": "Run on staged files only without stashing unstaged changes",
+                "short": [],
+                "long": ["staged"],
+                "hide": false,
+                "global": false
+              },
+              {
                 "name": "stash",
                 "usage": "--stash <STASH>",
                 "help": "Stash method to use for git hooks",
@@ -1529,6 +1559,16 @@
                 "global": false
               },
               {
+                "name": "staged",
+                "usage": "--staged",
+                "help": "Run on staged files only without stashing unstaged changes",
+                "help_first_line": "Run on staged files only without stashing unstaged changes",
+                "short": [],
+                "long": ["staged"],
+                "hide": false,
+                "global": false
+              },
+              {
                 "name": "stash",
                 "usage": "--stash <STASH>",
                 "help": "Stash method to use for git hooks",
@@ -1813,6 +1853,16 @@
                 "help_first_line": "Enable auto-staging of fixed files",
                 "short": [],
                 "long": ["stage"],
+                "hide": false,
+                "global": false
+              },
+              {
+                "name": "staged",
+                "usage": "--staged",
+                "help": "Run on staged files only without stashing unstaged changes",
+                "help_first_line": "Run on staged files only without stashing unstaged changes",
+                "short": [],
+                "long": ["staged"],
                 "hide": false,
                 "global": false
               },
@@ -2114,6 +2164,16 @@
                 "global": false
               },
               {
+                "name": "staged",
+                "usage": "--staged",
+                "help": "Run on staged files only without stashing unstaged changes",
+                "help_first_line": "Run on staged files only without stashing unstaged changes",
+                "short": [],
+                "long": ["staged"],
+                "hide": false,
+                "global": false
+              },
+              {
                 "name": "stash",
                 "usage": "--stash <STASH>",
                 "help": "Stash method to use for git hooks",
@@ -2411,6 +2471,16 @@
                 "global": false
               },
               {
+                "name": "staged",
+                "usage": "--staged",
+                "help": "Run on staged files only without stashing unstaged changes",
+                "help_first_line": "Run on staged files only without stashing unstaged changes",
+                "short": [],
+                "long": ["staged"],
+                "hide": false,
+                "global": false
+              },
+              {
                 "name": "stash",
                 "usage": "--stash <STASH>",
                 "help": "Stash method to use for git hooks",
@@ -2695,6 +2765,16 @@
                 "help_first_line": "Enable auto-staging of fixed files",
                 "short": [],
                 "long": ["stage"],
+                "hide": false,
+                "global": false
+              },
+              {
+                "name": "staged",
+                "usage": "--staged",
+                "help": "Run on staged files only without stashing unstaged changes",
+                "help_first_line": "Run on staged files only without stashing unstaged changes",
+                "short": [],
+                "long": ["staged"],
                 "hide": false,
                 "global": false
               },
@@ -3006,6 +3086,16 @@
                 "global": false
               },
               {
+                "name": "staged",
+                "usage": "--staged",
+                "help": "Run on staged files only without stashing unstaged changes",
+                "help_first_line": "Run on staged files only without stashing unstaged changes",
+                "short": [],
+                "long": ["staged"],
+                "hide": false,
+                "global": false
+              },
+              {
                 "name": "stash",
                 "usage": "--stash <STASH>",
                 "help": "Stash method to use for git hooks",
@@ -3308,6 +3398,16 @@
                 "help_first_line": "Enable auto-staging of fixed files",
                 "short": [],
                 "long": ["stage"],
+                "hide": false,
+                "global": false
+              },
+              {
+                "name": "staged",
+                "usage": "--staged",
+                "help": "Run on staged files only without stashing unstaged changes",
+                "help_first_line": "Run on staged files only without stashing unstaged changes",
+                "short": [],
+                "long": ["staged"],
                 "hide": false,
                 "global": false
               },
@@ -3627,6 +3727,16 @@
                 "global": false
               },
               {
+                "name": "staged",
+                "usage": "--staged",
+                "help": "Run on staged files only without stashing unstaged changes",
+                "help_first_line": "Run on staged files only without stashing unstaged changes",
+                "short": [],
+                "long": ["staged"],
+                "hide": false,
+                "global": false
+              },
+              {
                 "name": "stash",
                 "usage": "--stash <STASH>",
                 "help": "Stash method to use for git hooks",
@@ -3915,6 +4025,16 @@
             "help_first_line": "Enable auto-staging of fixed files",
             "short": [],
             "long": ["stage"],
+            "hide": false,
+            "global": false
+          },
+          {
+            "name": "staged",
+            "usage": "--staged",
+            "help": "Run on staged files only without stashing unstaged changes",
+            "help_first_line": "Run on staged files only without stashing unstaged changes",
+            "short": [],
+            "long": ["staged"],
             "hide": false,
             "global": false
           },

--- a/docs/cli/fix.md
+++ b/docs/cli/fix.md
@@ -79,6 +79,10 @@ Skip specific step(s)
 
 Enable auto-staging of fixed files
 
+### `--staged`
+
+Run on staged files only without stashing unstaged changes
+
 ### `--stash <STASH>`
 
 Stash method to use for git hooks

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -79,6 +79,10 @@ Skip specific step(s)
 
 Enable auto-staging of fixed files
 
+### `--staged`
+
+Run on staged files only without stashing unstaged changes
+
 ### `--stash <STASH>`
 
 Stash method to use for git hooks

--- a/docs/cli/run/commit-msg.md
+++ b/docs/cli/run/commit-msg.md
@@ -81,6 +81,10 @@ Skip specific step(s)
 
 Enable auto-staging of fixed files
 
+### `--staged`
+
+Run on staged files only without stashing unstaged changes
+
 ### `--stash <STASH>`
 
 Stash method to use for git hooks

--- a/docs/cli/run/post-checkout.md
+++ b/docs/cli/run/post-checkout.md
@@ -88,6 +88,10 @@ Skip specific step(s)
 
 Enable auto-staging of fixed files
 
+### `--staged`
+
+Run on staged files only without stashing unstaged changes
+
 ### `--stash <STASH>`
 
 Stash method to use for git hooks

--- a/docs/cli/run/post-commit.md
+++ b/docs/cli/run/post-commit.md
@@ -76,6 +76,10 @@ Skip specific step(s)
 
 Enable auto-staging of fixed files
 
+### `--staged`
+
+Run on staged files only without stashing unstaged changes
+
 ### `--stash <STASH>`
 
 Stash method to use for git hooks

--- a/docs/cli/run/post-merge.md
+++ b/docs/cli/run/post-merge.md
@@ -80,6 +80,10 @@ Skip specific step(s)
 
 Enable auto-staging of fixed files
 
+### `--staged`
+
+Run on staged files only without stashing unstaged changes
+
 ### `--stash <STASH>`
 
 Stash method to use for git hooks

--- a/docs/cli/run/post-rewrite.md
+++ b/docs/cli/run/post-rewrite.md
@@ -80,6 +80,10 @@ Skip specific step(s)
 
 Enable auto-staging of fixed files
 
+### `--staged`
+
+Run on staged files only without stashing unstaged changes
+
 ### `--stash <STASH>`
 
 Stash method to use for git hooks

--- a/docs/cli/run/pre-commit.md
+++ b/docs/cli/run/pre-commit.md
@@ -79,6 +79,10 @@ Skip specific step(s)
 
 Enable auto-staging of fixed files
 
+### `--staged`
+
+Run on staged files only without stashing unstaged changes
+
 ### `--stash <STASH>`
 
 Stash method to use for git hooks

--- a/docs/cli/run/pre-push.md
+++ b/docs/cli/run/pre-push.md
@@ -85,6 +85,10 @@ Skip specific step(s)
 
 Enable auto-staging of fixed files
 
+### `--staged`
+
+Run on staged files only without stashing unstaged changes
+
 ### `--stash <STASH>`
 
 Stash method to use for git hooks

--- a/docs/cli/run/pre-rebase.md
+++ b/docs/cli/run/pre-rebase.md
@@ -84,6 +84,10 @@ Skip specific step(s)
 
 Enable auto-staging of fixed files
 
+### `--staged`
+
+Run on staged files only without stashing unstaged changes
+
 ### `--stash <STASH>`
 
 Stash method to use for git hooks

--- a/docs/cli/run/prepare-commit-msg.md
+++ b/docs/cli/run/prepare-commit-msg.md
@@ -89,6 +89,10 @@ Skip specific step(s)
 
 Enable auto-staging of fixed files
 
+### `--staged`
+
+Run on staged files only without stashing unstaged changes
+
 ### `--stash <STASH>`
 
 Stash method to use for git hooks

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -54,6 +54,7 @@ cmd check help="Checks code" {
         arg <STEP>
     }
     flag --stage help="Enable auto-staging of fixed files"
+    flag --staged help="Run on staged files only without stashing unstaged changes"
     flag --stash help="Stash method to use for git hooks" {
         arg <STASH> {
             choices git patch-file none
@@ -122,6 +123,7 @@ cmd fix help="Fixes code" {
         arg <STEP>
     }
     flag --stage help="Enable auto-staging of fixed files"
+    flag --staged help="Run on staged files only without stashing unstaged changes"
     flag --stash help="Stash method to use for git hooks" {
         arg <STASH> {
             choices git patch-file none
@@ -196,6 +198,7 @@ cmd run help="Run a hook" {
         arg <STEP>
     }
     flag --stage help="Enable auto-staging of fixed files"
+    flag --staged help="Run on staged files only without stashing unstaged changes"
     flag --stash help="Stash method to use for git hooks" {
         arg <STASH> {
             choices git patch-file none
@@ -238,6 +241,7 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --stage help="Enable auto-staging of fixed files"
+        flag --staged help="Run on staged files only without stashing unstaged changes"
         flag --stash help="Stash method to use for git hooks" {
             arg <STASH> {
                 choices git patch-file none
@@ -280,6 +284,7 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --stage help="Enable auto-staging of fixed files"
+        flag --staged help="Run on staged files only without stashing unstaged changes"
         flag --stash help="Stash method to use for git hooks" {
             arg <STASH> {
                 choices git patch-file none
@@ -324,6 +329,7 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --stage help="Enable auto-staging of fixed files"
+        flag --staged help="Run on staged files only without stashing unstaged changes"
         flag --stash help="Stash method to use for git hooks" {
             arg <STASH> {
                 choices git patch-file none
@@ -365,6 +371,7 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --stage help="Enable auto-staging of fixed files"
+        flag --staged help="Run on staged files only without stashing unstaged changes"
         flag --stash help="Stash method to use for git hooks" {
             arg <STASH> {
                 choices git patch-file none
@@ -407,6 +414,7 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --stage help="Enable auto-staging of fixed files"
+        flag --staged help="Run on staged files only without stashing unstaged changes"
         flag --stash help="Stash method to use for git hooks" {
             arg <STASH> {
                 choices git patch-file none
@@ -450,6 +458,7 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --stage help="Enable auto-staging of fixed files"
+        flag --staged help="Run on staged files only without stashing unstaged changes"
         flag --stash help="Stash method to use for git hooks" {
             arg <STASH> {
                 choices git patch-file none
@@ -492,6 +501,7 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --stage help="Enable auto-staging of fixed files"
+        flag --staged help="Run on staged files only without stashing unstaged changes"
         flag --stash help="Stash method to use for git hooks" {
             arg <STASH> {
                 choices git patch-file none
@@ -535,6 +545,7 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --stage help="Enable auto-staging of fixed files"
+        flag --staged help="Run on staged files only without stashing unstaged changes"
         flag --stash help="Stash method to use for git hooks" {
             arg <STASH> {
                 choices git patch-file none
@@ -579,6 +590,7 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --stage help="Enable auto-staging of fixed files"
+        flag --staged help="Run on staged files only without stashing unstaged changes"
         flag --stash help="Stash method to use for git hooks" {
             arg <STASH> {
                 choices git patch-file none

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -382,6 +382,18 @@ impl Hook {
         }
     }
 
+    fn resolve_stash_method_for_opts(&self, opts: &HookOptions) -> StashMethod {
+        if opts.staged {
+            StashMethod::None
+        } else if let Some(stash_str) = &opts.stash {
+            stash_str
+                .parse::<StashMethod>()
+                .unwrap_or(StashMethod::None)
+        } else {
+            self.resolve_stash_method(*env::HK_STASH)
+        }
+    }
+
     pub async fn plan(&self, opts: HookOptions) -> Result<()> {
         // Suppress progress output so plan output (especially JSON) is clean.
         clx::progress::set_output(ProgressOutput::Text);
@@ -389,13 +401,7 @@ impl Hook {
         let run_type = self.run_type(&opts);
         let repo = Arc::new(Mutex::new(Git::new()?));
         let git_status = repo.lock().await.status(None)?;
-        let stash_method = if let Some(stash_str) = &opts.stash {
-            stash_str
-                .parse::<StashMethod>()
-                .unwrap_or(StashMethod::None)
-        } else {
-            self.resolve_stash_method(*env::HK_STASH)
-        };
+        let stash_method = self.resolve_stash_method_for_opts(&opts);
         let progress = ProgressJobBuilder::new()
             .status(ProgressStatus::Hide)
             .build();
@@ -713,13 +719,7 @@ impl Hook {
         let run_type = self.run_type(&opts);
         let repo = Arc::new(Mutex::new(Git::new()?));
         let git_status = repo.lock().await.status(None)?;
-        let stash_method = if let Some(stash_str) = &opts.stash {
-            stash_str
-                .parse::<StashMethod>()
-                .unwrap_or(StashMethod::None)
-        } else {
-            self.resolve_stash_method(*env::HK_STASH)
-        };
+        let stash_method = self.resolve_stash_method_for_opts(&opts);
         let progress = ProgressJobBuilder::new()
             .status(ProgressStatus::Hide)
             .build();
@@ -842,13 +842,7 @@ impl Hook {
         let should_stage = should_stage && !(self.fail_on_fix && matches!(run_type, RunType::Fix));
         let repo = Arc::new(Mutex::new(Git::new()?));
         let groups = self.get_step_groups(&opts);
-        let stash_method = if let Some(stash_str) = &opts.stash {
-            stash_str
-                .parse::<StashMethod>()
-                .unwrap_or(StashMethod::None)
-        } else {
-            self.resolve_stash_method(*env::HK_STASH)
-        };
+        let stash_method = self.resolve_stash_method_for_opts(&opts);
         let total_steps: usize = groups.iter().map(|g| g.steps.len()).sum();
         let hk_progress = self.start_hk_progress(run_type, total_steps);
         let file_progress = ProgressJobBuilder::new().body(
@@ -1219,7 +1213,7 @@ impl Hook {
                 all_files.extend(git_status.untracked_files.iter().cloned());
             }
             all_files
-        } else if stash {
+        } else if opts.staged || stash {
             file_progress.prop("message", "Fetching staged files");
             git_status.staged_files.iter().cloned().collect()
         } else {

--- a/src/hook_options.rs
+++ b/src/hook_options.rs
@@ -6,7 +6,7 @@ pub(crate) struct HookOptions {
     #[clap(conflicts_with_all = &["all", "fix", "check"], value_hint = clap::ValueHint::FilePath)]
     pub files: Option<Vec<String>>,
     /// Run on all files instead of just staged files
-    #[clap(short, long)]
+    #[clap(short, long, conflicts_with = "staged")]
     pub all: bool,
     /// Run check command instead of fix command
     #[clap(short, long, overrides_with = "fix")]
@@ -58,6 +58,12 @@ pub(crate) struct HookOptions {
     /// Enable auto-staging of fixed files
     #[clap(long, overrides_with = "no_stage")]
     pub stage: bool,
+    /// Run on staged files only without stashing unstaged changes
+    #[clap(
+        long,
+        conflicts_with_all = &["files", "all", "from_ref", "glob", "pr", "stash", "to_ref"]
+    )]
+    pub staged: bool,
     /// Stash method to use for git hooks
     #[clap(long, value_parser = ["git", "patch-file", "none"])]
     pub stash: Option<String>,
@@ -73,6 +79,15 @@ pub(crate) struct HookOptions {
 }
 
 impl HookOptions {
+    fn validate(&self) -> Result<()> {
+        if self.staged && self.stash.is_some() {
+            return Err(eyre::eyre!(
+                "argument '--staged' cannot be used with '--stash <STASH>'"
+            ));
+        }
+        Ok(())
+    }
+
     pub fn should_stage(&self) -> Option<bool> {
         if self.stage {
             Some(true)
@@ -84,6 +99,7 @@ impl HookOptions {
     }
 
     pub(crate) async fn run(mut self, name: &str) -> Result<()> {
+        self.validate()?;
         // Under `--from-hook`, short-circuit *before* loading the config. A
         // broken user-global hkrc (or missing `pkl`) shouldn't fail every
         // `git commit` in a repo that doesn't even use hk — which is the

--- a/test/staged_flag.bats
+++ b/test/staged_flag.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "hk run pre-commit --staged only passes staged files and does not stash" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        stash = true
+        steps {
+            ["capture"] {
+                check = "printf '%s\n' {{files}} > seen.txt"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "init"
+
+    echo "tracked" > tracked.txt
+    git add tracked.txt
+    git commit -m "add tracked"
+
+    echo "unstaged" >> tracked.txt
+    echo "staged" > staged.txt
+    git add staged.txt
+    echo "untracked" > untracked.txt
+
+    run hk run pre-commit --staged
+    assert_success
+
+    run cat seen.txt
+    assert_output "staged.txt"
+
+    run cat tracked.txt
+    assert_output $'tracked\nunstaged'
+
+    assert_file_exists untracked.txt
+
+    run git stash list
+    assert_output ""
+}
+
+@test "hk run pre-commit --staged conflicts with explicit stash option" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["check"] {
+                check = "true"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "init"
+
+    run hk run pre-commit --staged --stash git
+    assert_failure
+    assert_output --partial "cannot be used with"
+}


### PR DESCRIPTION
## Summary
- add `--staged` to run hooks against staged files without requiring stash
- keep `--stash none` from mutating the worktree while selecting staged-only files
- add a Bats regression for staged-only/no-stash behavior

Fixes discussion #940.

## Test
- `cargo fmt --check`
- `cargo check -F git2/vendored-openssl`
- `cargo build -F git2/vendored-openssl`
- `mise exec -- test/bats/bin/bats --jobs 1 test/staged_flag.bats`

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI and file-selection change with targeted tests; no auth or data paths, though incorrect stash/file scope could surprise users on commit.
> 
> **Overview**
> Adds **`--staged`** to `hk run`, `check`, `fix`, and hook subcommands so hooks run on **staged files only** while leaving unstaged and untracked changes untouched (no git stash).
> 
> **Runtime behavior:** `HookOptions` gains `staged` with clap conflicts (e.g. vs `--all`, `--stash`, PR/ref modes). When set, `resolve_stash_method_for_opts` forces **`StashMethod::None`** even if the hook config enables stash, and `file_list` uses the same staged-only path as the stash workflow (`opts.staged || stash`). A runtime check rejects `--staged` together with `--stash`.
> 
> **Docs/tests:** Generated CLI docs (`commands.json`, markdown), `hk.usage.kdl`, and a Bats suite verify only staged files are passed, the worktree is unchanged, and no stash entry is created.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2313e1521c706b2d71af5c5f16409f3e09d2d0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->