### PR TITLE
fix(run): expose post-checkout hook variables

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -52,6 +52,7 @@ hooks {
 ## `prepare-commit-msg`
 
 Runs when `git commit` is run before the commit message is created. Useful for rendering a default commit message template.
+The `commit_msg_file`, `source`, and `sha` template variables are available in this hook. The raw git hook arguments are also available as `hook_args`.
 
 ```pkl
 hooks {
@@ -69,6 +70,7 @@ hooks {
 ## `commit-msg`
 
 Runs when `git commit` is run after the commit message is created. Useful for validating the commit message.
+The `commit_msg_file` template variable is available in this hook. The raw git hook arguments are also available as `hook_args`.
 
 ```pkl
 hooks {
@@ -82,6 +84,23 @@ hooks {
 }
 ```
 
+## `post-checkout`
+
+Runs after `git checkout` updates the worktree. The `prev_head`, `new_head`, and `is_branch_checkout` template variables are available in this hook. `is_branch_checkout` is a boolean value. The raw git hook arguments are also available as `hook_args`.
+
+```pkl
+hooks {
+    ["post-checkout"] {
+        steps {
+            ["restore-lfs"] {
+                check = "git lfs post-checkout {{ hook_args }}"
+            }
+        }
+    }
+}
+```
+
 ## Other Hooks
 
 Other git hooks are also supported. See <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks>.
+The raw arguments for hooks with dedicated handlers are available as `hook_args`; hooks without dedicated handlers get an empty `hook_args`.

--- a/src/cli/run/post_checkout.rs
+++ b/src/cli/run/post_checkout.rs
@@ -15,6 +15,11 @@ pub struct PostCheckout {
 
 impl PostCheckout {
     pub async fn run(mut self) -> Result<()> {
+        self.hook.tctx.insert("prev_head", &self.prev_head);
+        self.hook.tctx.insert("new_head", &self.new_head);
+        self.hook
+            .tctx
+            .insert("is_branch_checkout", &(self.is_branch_checkout == "1"));
         self.hook.tctx.insert(
             "hook_args",
             &format!(

--- a/test/hook_args.bats
+++ b/test/hook_args.bats
@@ -44,6 +44,24 @@ EOF
     assert_output --regexp "^[a-f0-9]+ [a-f0-9]+ 1$"
 }
 
+@test "post-checkout exposes named hook arguments" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["post-checkout"] {
+        steps {
+            ["capture"] { check = "echo {{ prev_head }} {{ new_head }} {{ is_branch_checkout }} > hook_args.txt" }
+        }
+    }
+}
+EOF
+    hk install
+    echo "test" > test.txt && git add test.txt && git commit -m "init"
+    git checkout -b feature
+    run cat hook_args.txt
+    assert_output --regexp "^[a-f0-9]+ [a-f0-9]+ true$"
+}
+
 @test "post-checkout hook_args works with git-lfs" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"


### PR DESCRIPTION
## Summary
- expose `prev_head`, `new_head`, and `is_branch_checkout` template variables for `post-checkout`
- add bats coverage for named post-checkout hook args
- document hook-specific template variables

## Tests
- `cargo fmt --check`
- `mise run test:bats test/hook_args.bats`

*This PR was generated by AI.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small template-context addition and docs/tests; no auth, persistence, or hook execution model changes.
> 
> **Overview**
> **`post-checkout`** hook steps can now use **`prev_head`**, **`new_head`**, and **`is_branch_checkout`** (boolean) in templates, not only the combined **`hook_args`** string. The runner maps Git’s `1`/`0` branch-checkout flag to a real boolean for templates.
> 
> **`docs/hooks.md`** documents hook-specific template variables for **`prepare-commit-msg`**, **`commit-msg`**, and **`post-checkout`**, plus when **`hook_args`** is populated vs empty.
> 
> A **bats** test asserts the named variables render correctly on branch checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9339a56f92c4e21ecffebbfa32745fa33dceade3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->