### PR TITLE
fix(step): prefer check_list_files in check-first

### DIFF
--- a/pkl/builtins/yamlfmt.pkl
+++ b/pkl/builtins/yamlfmt.pkl
@@ -8,7 +8,20 @@ import "./test/helpers.pkl"
 }
 yamlfmt = new Config.Step {
   glob = List("**/*.yml", "**/*.yaml")
-  check_diff = "yamlfmt -lint {{ files }}"
+  check = "yamlfmt -lint {{ files }}"
+  check_list_files = new Config.Script {
+    windows = ""
+    other =
+      """
+      output=$(yamlfmt -lint -quiet {{ files }})
+      code=$?
+      if [ $code -eq 0 ]; then
+        exit 0
+      fi
+      printf "%s\n" "$output" | sed '1,/^$/d'
+      exit $code
+      """
+  }
   fix = "yamlfmt {{ files }}"
   tests {
     local const testMaker = new helpers.TestMaker {

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -115,6 +115,7 @@ impl Step {
                 if job.check_first {
                     let prev_run_type = job.run_type;
                     job.run_type = RunType::Check;
+                    let check_first_cmd = step.check_first_cmd().cloned();
                     // Stash check output in case the second run is cancelled by fail_fast
                     let mut check_first_output: Option<(String, String, String)> = None;
                     match step.run(&ctx, &mut job).await {
@@ -133,12 +134,22 @@ impl Step {
                                     debug!("{step}: check stderr output:\n{}", stderr);
                                 }
                                 check_first_output = Some((stdout.clone(), stderr.clone(), combined.clone()));
-                                // Use check_diff parser if check_diff is defined, otherwise check_list_files
-                                let is_check_diff = step.check_diff.is_some();
-                                let (files, extras) = if is_check_diff {
+                                // Parse according to the check-first command that actually ran.
+                                // Platform-specific Script values can be empty, in which case
+                                // check_first_cmd falls back to the next available command.
+                                let ran_check_diff = check_first_cmd
+                                    .as_ref()
+                                    .is_some_and(|cmd| step.check_diff.as_ref() == Some(cmd));
+                                let ran_check_list_files =
+                                    check_first_cmd.as_ref().is_some_and(|cmd| {
+                                        step.check_list_files.as_ref() == Some(cmd)
+                                    });
+                                let (files, extras) = if ran_check_diff {
                                     step.filter_files_from_check_diff(&job.files, stdout)
-                                } else {
+                                } else if ran_check_list_files {
                                     step.filter_files_from_check_list(&job.files, stdout)
+                                } else {
+                                    (job.files.clone(), Vec::new())
                                 };
                                 for f in extras {
                                     warn!(
@@ -148,10 +159,10 @@ impl Step {
                                 }
 
                                 // For check_diff: if no parseable files, keep all original files
-                                if files.is_empty() && is_check_diff {
+                                if files.is_empty() && ran_check_diff {
                                     debug!("{step}: check_diff returned no parseable files, will run fixer on all original files");
                                     // Keep all original files for check_diff when diff parsing fails
-                                } else if files.is_empty() {
+                                } else if files.is_empty() && ran_check_list_files {
                                     // For check_list_files: non-zero exit with no files is an error
                                     // (Tool failed, not "files need fixing")
                                     error!("{step}: check_list_files failed with no files in output");
@@ -162,7 +173,7 @@ impl Step {
 
                                 // Try to apply diff directly when check_diff is defined and we're in Fix mode
                                 // (prev_run_type is the original mode; job.run_type was temporarily changed to Check)
-                                if is_check_diff && prev_run_type == RunType::Fix {
+                                if ran_check_diff && prev_run_type == RunType::Fix {
                                     match step.apply_diff_output(stdout) {
                                         Ok(true) => {
                                             // Diff applied successfully - no need to run fixer

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -369,12 +369,14 @@ impl Step {
 
     /// Get the command to run in "check first" mode.
     ///
-    /// Prefers check_diff, then check, then check_list_files.
+    /// Prefers check_diff, then check_list_files, then check.
     pub fn check_first_cmd(&self) -> Option<&Script> {
+        let is_present = |s: &&Script| !s.to_string().trim().is_empty();
         self.check_diff
             .as_ref()
-            .or(self.check.as_ref())
-            .or(self.check_list_files.as_ref())
+            .filter(is_present)
+            .or_else(|| self.check_list_files.as_ref().filter(is_present))
+            .or_else(|| self.check.as_ref().filter(is_present))
     }
 
     /// Check if this step has a command for the given run type.

--- a/test/check_list_files_empty_with_stderr.bats
+++ b/test/check_list_files_empty_with_stderr.bats
@@ -115,6 +115,66 @@ EOF
     assert_output --partial "formatted test.txt"
 }
 
+@test "check_first prefers check_list_files over check" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    steps {
+      ["format"] {
+        check_first = true
+        glob = List("*.txt")
+        stage = List("<JOB_FILES>")
+        check = "sh -c 'echo generic-check; exit 1'"
+        check_list_files = "sh -c 'echo needs-format.txt; exit 1'"
+        fix = "echo 'formatted' {{files}}"
+      }
+    }
+  }
+}
+EOF
+    echo 'needs formatting' > needs-format.txt
+    echo 'already formatted' > already-format.txt
+    git add needs-format.txt already-format.txt
+
+    run hk fix
+    assert_success
+    assert_output --partial "formatted needs-format.txt"
+    refute_output --partial "formatted already-format.txt"
+    refute_output --partial "generic-check"
+}
+
+@test "check_first falls back when check_list_files is empty on this platform" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    steps {
+      ["format"] {
+        check_first = true
+        glob = List("*.txt")
+        stage = List("<JOB_FILES>")
+        check = "sh -c 'echo generic-check; exit 1'"
+        check_list_files = new Script {
+          linux = ""
+          other = "sh -c 'echo needs-format.txt; exit 1'"
+        }
+        fix = "echo 'formatted' {{files}}"
+      }
+    }
+  }
+}
+EOF
+    echo 'needs formatting' > needs-format.txt
+    echo 'already formatted' > already-format.txt
+    git add needs-format.txt already-format.txt
+
+    run hk fix
+    assert_success
+    assert_output --partial "generic-check"
+    assert_output --partial "formatted already-format.txt needs-format.txt"
+}
+
 @test "check_list_files with non-zero exit should be an error" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
@@ -133,6 +193,7 @@ exit 1
         fix = "echo 'would format' {{files}}"
       }
       ["other-step"] {
+        depends = "format"
         glob = List("*.txt")
         fix = "echo 'other'"
       }


### PR DESCRIPTION
## Summary
- prefer `check_list_files` over generic `check` when hk runs the check-first path
- keep `check_diff` as the highest-priority check-first command so direct patch application still wins
- skip empty platform-specific check-first scripts and parse check-first output based on the command that actually ran
- update the `yamlfmt` builtin to use `yamlfmt -lint` for normal checks and `yamlfmt -lint -quiet` for Unix list-file filtering

## Tests
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/home/risu/.cache/cargo-target/hk-64dddbacda667e8e mise run test:bats test/check_list_files_empty_with_stderr.bats`
- `hk test --step yamlfmt` with a temp config including `Builtins.yamlfmt`
- `hk validate`
