### PR TITLE
fix(sponsors): remove singular sponsor link

### DIFF
--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -7,7 +7,7 @@ pub struct Sponsors {}
 impl Sponsors {
     pub async fn run(&self) -> Result<()> {
         println!(
-            "hk and the en.dev project family are sponsored by:\n\n  37signals - https://37signals.com\n\nView all sponsors: https://en.dev/sponsors.html\nSponsor en.dev: https://en.dev/sponsor.html"
+            "hk and the en.dev project family are sponsored by:\n\n  37signals - https://37signals.com\n\nView all sponsors: https://en.dev/sponsors.html"
         );
         Ok(())
     }


### PR DESCRIPTION
Remove the separate https://en.dev/sponsor.html line from the sponsors command output. The sponsors page is enough as the single destination.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to CLI printed text with no logic, security, or data impact.
> 
> **Overview**
> The **`hk sponsors`** CLI output no longer prints a separate **“Sponsor en.dev”** line pointing at `https://en.dev/sponsor.html`. Users still see the 37signals entry and the **“View all sponsors”** link to `https://en.dev/sponsors.html` as the single call-to-action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b15149e4ad67784e8458b4d3b9fb75f31b53d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sponsors command output to streamline the display, now showing the "View all sponsors" link alongside sponsor information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->