### PR TITLE
fix(stash): don't split last-line edits of partially-staged files on restore

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -275,13 +275,18 @@ impl Git {
         cmd = cmd.arg(stash_ref);
 
         // Read patch content from git
-        let patch_content = match cmd.read() {
+        let mut patch_content = match cmd.read() {
             Ok(content) => content,
             Err(e) => {
                 warn!("Failed to generate stash patch: {}", e);
                 return;
             }
         };
+        // read() strips the trailing newline, but git apply rejects a patch
+        // without one as corrupt, so restore it
+        if !patch_content.is_empty() && !patch_content.ends_with('\n') {
+            patch_content.push('\n');
+        }
 
         // Write patch file
         if let Err(e) = std::fs::write(&patch_path, patch_content) {
@@ -1219,9 +1224,16 @@ impl Git {
                     {
                         // Try strict prefix first
                         let mut tail_opt = w.strip_prefix(i);
-                        // If that fails, allow a single trailing newline discrepancy
+                        // If that fails, allow a single trailing newline discrepancy, but only
+                        // when the worktree is exactly the index minus its trailing newline.
+                        // A non-empty remainder here means the LAST LINE was edited (e.g.
+                        // i="…l3\n", w="…l3 edited\n"), which is not a pure tail insertion;
+                        // treating it as one would split the edit onto a new line. Leave those
+                        // to the regular three-way merge instead.
                         if tail_opt.is_none() && i.ends_with('\n') {
-                            tail_opt = w.strip_prefix(&i[..i.len().saturating_sub(1)]);
+                            tail_opt = w
+                                .strip_prefix(&i[..i.len().saturating_sub(1)])
+                                .filter(|tail| tail.is_empty());
                         }
                         if let Some(tail) = tail_opt {
                             // If w == i (no tail), tail is empty; otherwise append tail to fixer

--- a/test/stash_restore_last_line_edit.bats
+++ b/test/stash_restore_last_line_edit.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+
+# Regression test for https://github.com/jdx/hk/discussions/965
+# A file with both staged and unstaged hunks where the unstaged edit touches the
+# LAST line must be restored intact after pre-commit. Previously the stash
+# restore misclassified the last-line edit as a "pure tail insertion" and split
+# it onto a new line with a leading space.
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+create_config_with_stash_method() {
+    local method="$1"
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    fix = true
+    stash = "$method"
+    steps {
+      ["noop"] {
+        glob = "*.txt"
+        check_first = false
+        fix = "true"
+      }
+    }
+  }
+}
+EOF
+    git add hk.pkl
+    git commit -m "init"
+}
+
+prepare_partially_staged_last_line_edit() {
+    # Base commit
+    printf 'l1\nl2\nl3: tail\n' > f.txt
+    git add f.txt
+    git commit -m "base"
+
+    # Stage an edit to the first line
+    printf 'l1 STAGED\nl2\nl3: tail\n' > f.txt
+    git add f.txt
+
+    # Unstaged edit to the LAST line
+    printf 'l1 STAGED\nl2\nl3: tail UNSTAGED\n' > f.txt
+}
+
+assert_last_line_restored_intact() {
+    run cat f.txt
+    assert_output "l1 STAGED
+l2
+l3: tail UNSTAGED"
+}
+
+@test "stash=git: unstaged edit to last line of partially-staged file survives pre-commit" {
+    create_config_with_stash_method git
+    prepare_partially_staged_last_line_edit
+    hk run pre-commit
+    assert_last_line_restored_intact
+}
+
+@test "stash=patch-file: unstaged edit to last line of partially-staged file survives pre-commit" {
+    create_config_with_stash_method patch-file
+    prepare_partially_staged_last_line_edit
+    hk run pre-commit
+    assert_last_line_restored_intact
+}
+
+@test "stash backup patch is valid for git apply" {
+    export HK_STATE_DIR="$TEST_TEMP_DIR/hk-state"
+    create_config_with_stash_method git
+    prepare_partially_staged_last_line_edit
+    hk run pre-commit
+
+    patch=$(ls "$HK_STATE_DIR"/patches/*.patch | head -1)
+    assert [ -n "$patch" ]
+    # The backup patch must parse (it previously lacked a trailing newline,
+    # which git apply rejects as a corrupt patch)
+    run git apply --numstat "$patch"
+    assert_success
+}


### PR DESCRIPTION
Fixes the bug reported in #965: any file with both staged and unstaged hunks where the unstaged edit touches the **last line** came back corrupted after `hk run pre-commit` — the edit was split onto a new line with a leading space. Reproduced with both `stash = "git"` and `stash = "patch-file"`, even when no fix command modifies the file.

## Primary fix: tail-insertion misclassification (`src/git.rs`)

The "pure tail insertion" special case in the manual stash restore had a newline-tolerant fallback that stripped the index snapshot's trailing newline before the prefix check. Since the index snapshot nearly always ends with `\n`, a last-line edit (`l3: tail` → `l3: tail UNSTAGED`) was misclassified as a tail insertion, producing `fixer content + " UNSTAGED\n"`.

Key invariant: if the strict prefix check already failed, a non-empty remainder after stripping the newline can only mean the last line was *edited* — a remainder starting with `\n` would have passed the strict check. So the fallback now only accepts an **empty** remainder (worktree = index minus its EOF newline, the case it was added for in #304). Last-line edits fall through to the regular three-way merge, which handles them correctly.

## Secondary fix: corrupt backup patch

`cmd.read()` strips the trailing newline from `git stash show -p` output, so the recovery patch written to the state dir failed `git apply --check` with `error: corrupt patch at line N`. The trailing newline is now restored before writing.

## Testing

- New regression test `test/stash_restore_last_line_edit.bats`: last-line edit survives pre-commit with `stash = "git"` and `stash = "patch-file"`, and the backup patch parses with `git apply --numstat`
- The discussion's exact repro now restores `l3: tail UNSTAGED` intact; staged content unaffected
- All existing stash-related bats tests pass (30 tests across 13 files), including `pre_commit_restores_unstaged_over_fixer_regression.bats` — the test that motivated the special case in #304
- `cargo test` (164 passed), `cargo clippy`, `cargo fmt --check` all clean

*This PR was generated by Claude Code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trailing newline preservation when generating stashed patches
  * Improved handling of unstaged edits affecting the last line of partially-staged files

* **Tests**
  * Added regression test for stash restoration when the last line is edited, covering multiple stash modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->