### PR TITLE
fix(step): account for cmd command-line limit

### DIFF
--- a/src/step/batching.rs
+++ b/src/step/batching.rs
@@ -14,9 +14,19 @@ use crate::tera;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use super::types::Step;
+use super::{ShellType, types::Step};
+
+const CMD_COMMAND_LINE_LIMIT: usize = 8191;
+const CMD_COMMAND_LINE_SAFE_LIMIT: usize = CMD_COMMAND_LINE_LIMIT / 2;
 
 impl Step {
+    fn auto_batch_safe_limit(&self) -> usize {
+        match self.shell_type() {
+            ShellType::Cmd => CMD_COMMAND_LINE_SAFE_LIMIT,
+            _ => *env::ARG_MAX / 2,
+        }
+    }
+
     /// Estimates the size of the `{{files}}` template variable expansion.
     ///
     /// Used as a fallback when rendering the run command fails (e.g. the
@@ -71,7 +81,8 @@ impl Step {
 
     /// Automatically batch jobs whose rendered run command would exceed the safe ARG_MAX limit.
     ///
-    /// Uses 50% of `ARG_MAX` as the safety margin (accounts for env vars and the command itself).
+    /// Uses 50% of the effective command-line limit as the safety margin
+    /// (accounts for env vars, shell wrappers, and the command itself).
     /// Renders the actual run command with each candidate file subset; if the rendered command
     /// fits, no batching is performed. Otherwise binary-searches the largest batch size whose
     /// rendered command still fits.
@@ -88,7 +99,7 @@ impl Step {
             return jobs;
         }
 
-        let safe_limit = *env::ARG_MAX / 2;
+        let safe_limit = self.auto_batch_safe_limit();
         let mut batched_jobs = Vec::with_capacity(jobs.len());
 
         for job in jobs {
@@ -149,6 +160,55 @@ impl Step {
         }
 
         batched_jobs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::step::RunType;
+    use crate::step_job::StepJob;
+
+    #[test]
+    fn cmd_shell_uses_cmd_command_line_limit() {
+        let step = Step {
+            shell: Some("cmd.exe".parse().unwrap()),
+            ..Default::default()
+        };
+
+        assert_eq!(step.auto_batch_safe_limit(), CMD_COMMAND_LINE_SAFE_LIMIT);
+    }
+
+    #[test]
+    fn non_cmd_shell_uses_arg_max_limit() {
+        let step = Step {
+            shell: Some("sh".parse().unwrap()),
+            ..Default::default()
+        };
+
+        assert_eq!(step.auto_batch_safe_limit(), *env::ARG_MAX / 2);
+    }
+
+    #[test]
+    fn cmd_shell_auto_batches_below_unix_arg_max() {
+        let step = Step {
+            name: "test".to_string(),
+            shell: Some("cmd.exe".parse().unwrap()),
+            check: Some("echo {{files}}".parse().unwrap()),
+            ..Default::default()
+        };
+        let files = (0..400)
+            .map(|i| {
+                PathBuf::from(format!(
+                    "directory/with/a/long/path/file_with_a_long_name_{i}.txt"
+                ))
+            })
+            .collect();
+        let job = StepJob::new(Arc::new(step.clone()), files, RunType::Check);
+
+        let jobs = step.auto_batch_jobs(vec![job], &tera::Context::default());
+
+        assert!(jobs.len() > 1);
     }
 }
 


### PR DESCRIPTION
## Summary
- make auto-batching use a smaller effective command-line limit for `cmd.exe` steps
- keep non-cmd shells on the existing `ARG_MAX / 2` behavior
- add regression coverage for medium-sized `{{files}}` commands that should batch under `cmd.exe`

Fixes discussion #971.

## Tests
- `cargo fmt --check`
- `cargo test step::batching`
- `mise run test:cargo`

*This PR was generated by Claude Code.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command batching to respect shell-specific safety limits, ensuring better handling of large file lists across different shell environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to batching threshold selection with tests; no auth, security, or execution-path changes beyond when jobs are split.
> 
> **Overview**
> **Auto-batching** for steps that expand `{{files}}` on the command line now picks a **shell-specific safe length** instead of always using half of Unix `ARG_MAX`.
> 
> For **`cmd.exe`** steps, the limit is **4095 bytes** (half of Windows’ ~8191-character command-line cap). Other shells still use **`*env::ARG_MAX / 2`**. `auto_batch_jobs` calls the new `auto_batch_safe_limit()` so medium-sized file lists that were fine on Unix no longer blow past `cmd` limits without splitting.
> 
> Regression tests cover the limit helper for `cmd` vs `sh` and an integration case where ~400 long paths must batch under `cmd.exe`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee43c8804a71fb7b6f8436370f12d55b51ea6e4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->