### PR TITLE
fix(check): fall back when merge base is missing

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1479,10 +1479,7 @@ impl Git {
 fn collect_existing_paths_from_diff(diff: Diff<'_>) -> Result<Vec<PathBuf>> {
     let mut files = BTreeSet::new();
     diff.foreach(
-        &mut |_, _| true,
-        None,
-        None,
-        Some(&mut |diff_delta, _, _| {
+        &mut |diff_delta, _| {
             if let Some(path) = diff_delta.new_file().path() {
                 let path_buf = PathBuf::from(path);
                 if path_buf.exists() {
@@ -1490,7 +1487,10 @@ fn collect_existing_paths_from_diff(diff: Diff<'_>) -> Result<Vec<PathBuf>> {
                 }
             }
             true
-        }),
+        },
+        None,
+        None,
+        None,
     )
     .wrap_err("Failed to process diff")?;
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -2,6 +2,7 @@ use std::{
     collections::BTreeSet,
     ffi::{CString, OsString},
     path::PathBuf,
+    process::Command,
 };
 
 use crate::Result;
@@ -10,7 +11,7 @@ use crate::settings::Settings;
 use crate::ui::style;
 use clx::progress::{ProgressJob, ProgressJobBuilder, ProgressStatus};
 use eyre::{WrapErr, eyre};
-use git2::{Repository, StatusOptions, StatusShow};
+use git2::{Diff, ErrorCode, Repository, StatusOptions, StatusShow};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 #[cfg(unix)]
@@ -1424,54 +1425,47 @@ impl Git {
                 .revparse_single(to_ref)
                 .wrap_err(format!("Failed to parse reference: {to_ref}"))?;
 
-            // Find the merge base between the two references
-            let merge_base = repo
-                .merge_base(from_obj.id(), to_obj.id())
-                .wrap_err("Failed to find merge base")?;
-            let merge_base_obj = repo
-                .find_object(merge_base, None)
-                .wrap_err("Failed to find merge base object")?;
-            let merge_base_tree = merge_base_obj
-                .peel_to_tree()
-                .wrap_err("Failed to get tree for merge base")?;
-
             let to_tree = to_obj
                 .peel_to_tree()
                 .wrap_err(format!("Failed to get tree for reference: {to_ref}"))?;
 
-            let diff = repo
-                .diff_tree_to_tree(Some(&merge_base_tree), Some(&to_tree), None)
-                .wrap_err("Failed to get diff between references")?;
+            // Prefer merge-base semantics (`from...to`). In shallow clones the
+            // merge base can be missing, so fall back to a direct `from..to`
+            // diff instead of failing the whole run.
+            let diff = match repo.merge_base(from_obj.id(), to_obj.id()) {
+                Ok(merge_base) => {
+                    let merge_base_obj = repo
+                        .find_object(merge_base, None)
+                        .wrap_err("Failed to find merge base object")?;
+                    let merge_base_tree = merge_base_obj
+                        .peel_to_tree()
+                        .wrap_err("Failed to get tree for merge base")?;
+                    repo.diff_tree_to_tree(Some(&merge_base_tree), Some(&to_tree), None)
+                        .wrap_err("Failed to get diff between references")?
+                }
+                Err(err) if err.code() == ErrorCode::NotFound => {
+                    let from_tree = from_obj
+                        .peel_to_tree()
+                        .wrap_err(format!("Failed to get tree for reference: {from_ref}"))?;
+                    repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), None)
+                        .wrap_err("Failed to get fallback diff between references")?
+                }
+                Err(err) => return Err(err).wrap_err("Failed to find merge base"),
+            };
 
-            let mut files = BTreeSet::new();
-            diff.foreach(
-                &mut |_, _| true,
-                None,
-                None,
-                Some(&mut |diff_delta, _, _| {
-                    if let Some(path) = diff_delta.new_file().path() {
-                        let path_buf = PathBuf::from(path);
-                        if path_buf.exists() {
-                            files.insert(path_buf);
-                        }
-                    }
-                    true
-                }),
-            )
-            .wrap_err("Failed to process diff")?;
-
-            Ok(files.into_iter().collect())
+            collect_existing_paths_from_diff(diff)
         } else {
-            // Use git merge-base to find the common ancestor
-            let merge_base = xx::process::sh(&format!("git merge-base {from_ref} {to_ref}"))?;
-            let merge_base = merge_base.trim();
+            let range = match git_merge_base(from_ref, to_ref)? {
+                Some(merge_base) => format!("{}..{}", merge_base.trim(), to_ref),
+                None => format!("{from_ref}..{to_ref}"),
+            };
 
             let output = git_read([
                 "diff",
                 "-z",
                 "--name-only",
                 "--diff-filter=ACMRTUXB",
-                format!("{merge_base}..{to_ref}").as_str(),
+                range.as_str(),
             ])?;
             Ok(output
                 .split('\0')
@@ -1479,6 +1473,45 @@ impl Git {
                 .map(PathBuf::from)
                 .collect())
         }
+    }
+}
+
+fn collect_existing_paths_from_diff(diff: Diff<'_>) -> Result<Vec<PathBuf>> {
+    let mut files = BTreeSet::new();
+    diff.foreach(
+        &mut |_, _| true,
+        None,
+        None,
+        Some(&mut |diff_delta, _, _| {
+            if let Some(path) = diff_delta.new_file().path() {
+                let path_buf = PathBuf::from(path);
+                if path_buf.exists() {
+                    files.insert(path_buf);
+                }
+            }
+            true
+        }),
+    )
+    .wrap_err("Failed to process diff")?;
+
+    Ok(files.into_iter().collect())
+}
+
+fn git_merge_base(from_ref: &str, to_ref: &str) -> Result<Option<String>> {
+    let output = Command::new("git")
+        .args(["merge-base", from_ref, to_ref])
+        .output()
+        .wrap_err("Failed to run git merge-base")?;
+
+    match output.status.code() {
+        Some(0) => String::from_utf8(output.stdout)
+            .map(Some)
+            .map_err(|err| eyre!("git merge-base output is not valid UTF-8: {err}")),
+        Some(1) => Ok(None),
+        _ => Err(eyre!(
+            "Failed to find merge base: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )),
     }
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -1444,11 +1444,26 @@ impl Git {
                         .wrap_err("Failed to get diff between references")?
                 }
                 Err(err) if err.code() == ErrorCode::NotFound => {
-                    let from_tree = from_obj
-                        .peel_to_tree()
-                        .wrap_err(format!("Failed to get tree for reference: {from_ref}"))?;
-                    repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), None)
-                        .wrap_err("Failed to get fallback diff between references")?
+                    if let Some(merge_base) = git_merge_base(from_ref, to_ref)? {
+                        let merge_base_obj = repo
+                            .find_object(
+                                git2::Oid::from_str(merge_base.trim())
+                                    .wrap_err("Failed to parse git merge-base output")?,
+                                None,
+                            )
+                            .wrap_err("Failed to find merge base object")?;
+                        let merge_base_tree = merge_base_obj
+                            .peel_to_tree()
+                            .wrap_err("Failed to get tree for merge base")?;
+                        repo.diff_tree_to_tree(Some(&merge_base_tree), Some(&to_tree), None)
+                            .wrap_err("Failed to get diff between references")?
+                    } else {
+                        let from_tree = from_obj
+                            .peel_to_tree()
+                            .wrap_err(format!("Failed to get tree for reference: {from_ref}"))?;
+                        repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), None)
+                            .wrap_err("Failed to get fallback diff between references")?
+                    }
                 }
                 Err(err) => return Err(err).wrap_err("Failed to find merge base"),
             };

--- a/test/git.bats
+++ b/test/git.bats
@@ -128,6 +128,70 @@ EOF
     assert_output --partial "print-files – main.txt"
 }
 
+@test "files_between_refs falls back to two-dot diff without merge base using libgit2" {
+    echo "main content" > main.txt
+    git add main.txt
+    git commit -m "main commit"
+    MAIN_COMMIT=$(git rev-parse HEAD)
+
+    git checkout --orphan unrelated
+    git rm -rf .
+    echo "unrelated content" > unrelated.txt
+    git add unrelated.txt
+    git commit -m "unrelated commit"
+    UNRELATED_COMMIT=$(git rev-parse HEAD)
+    git checkout main
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["print-files"] {
+                check = "echo '{{files}}'"
+            }
+        }
+    }
+}
+EOF
+
+    HK_LIBGIT2=1 run hk check --from-ref=$UNRELATED_COMMIT --to-ref=$MAIN_COMMIT
+    assert_success
+    assert_output --partial "print-files – main.txt"
+}
+
+@test "files_between_refs falls back to two-dot diff without merge base using shell git" {
+    echo "main content" > main.txt
+    git add main.txt
+    git commit -m "main commit"
+    MAIN_COMMIT=$(git rev-parse HEAD)
+
+    git checkout --orphan unrelated
+    git rm -rf .
+    echo "unrelated content" > unrelated.txt
+    git add unrelated.txt
+    git commit -m "unrelated commit"
+    UNRELATED_COMMIT=$(git rev-parse HEAD)
+    git checkout main
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["print-files"] {
+                check = "echo '{{files}}'"
+            }
+        }
+    }
+}
+EOF
+
+    HK_LIBGIT2=0 run hk check --from-ref=$UNRELATED_COMMIT --to-ref=$MAIN_COMMIT
+    assert_success
+    assert_output --partial "print-files – main.txt"
+}
+
 @test "files staged for deletion are not included with --all" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"

--- a/test/git.bats
+++ b/test/git.bats
@@ -158,6 +158,7 @@ EOF
     HK_LIBGIT2=1 run hk check --from-ref=$UNRELATED_COMMIT --to-ref=$MAIN_COMMIT
     assert_success
     assert_output --partial "print-files – main.txt"
+    refute_output --partial "unrelated.txt"
 }
 
 @test "files_between_refs falls back to two-dot diff without merge base using shell git" {
@@ -190,6 +191,7 @@ EOF
     HK_LIBGIT2=0 run hk check --from-ref=$UNRELATED_COMMIT --to-ref=$MAIN_COMMIT
     assert_success
     assert_output --partial "print-files – main.txt"
+    refute_output --partial "unrelated.txt"
 }
 
 @test "files staged for deletion are not included with --all" {


### PR DESCRIPTION
## Summary
- fall back to a two-dot ref diff when merge-base lookup reports no common base
- keep existing merge-base behavior for normal histories
- cover both libgit2 and shell-git paths with bats tests

Refs #972.

## Testing
- cargo fmt --check
- cargo check
- mise run test:bats test/git.bats

*This PR was generated by AI.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `--from-ref`/`--to-ref` file sets are computed in edge cases (no merge base), which can shift which files hooks run on versus the previous error behavior.
> 
> **Overview**
> **`files_between_refs`** no longer fails when libgit2 or git cannot find a merge base (e.g. shallow clones or unrelated histories). It still uses merge-base → diff-to-`to_ref` when a base exists; on **NotFound** it tries shell **`git merge-base`**, then falls back to a direct **`from..to`** tree/shell diff.
> 
> Diff path collection is centralized in **`collect_existing_paths_from_diff`**, and **`git_merge_base`** maps exit code 1 to “no common ancestor” instead of treating it as a hard error. The shell-git branch uses the same range logic (`merge_base..to` vs `from..to`).
> 
> Bats tests cover unrelated commits with **`HK_LIBGIT2=1`** and **`HK_LIBGIT2=0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 622f81428fba43da893c3b03cd6ec2b1d8d620f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diff collection robustness in shallow clones by refining merge-base handling and falling back to direct diffs when no common base is found.
  * Hardened handling of merge-base failures and sanitization of external command output to avoid false failures and missing file detections.

* **Tests**
  * Added tests verifying file detection for unrelated commits across both library-backed and shell-backed diff modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->