### PR TITLE
feat(config): inherit step settings from groups

### DIFF
--- a/bin/generate_docs.rs
+++ b/bin/generate_docs.rs
@@ -382,7 +382,7 @@ fn generate_pkl_config_doc() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Process Steps
-    md.push_str("## `hooks.<HOOK>.steps.<STEP|GROUP>`\n\n");
+    md.push_str("## `hooks.<HOOK>.steps.<STEP>`\n\n");
     let properties = config_json["classes"]["Step"]["properties"]
         .as_object()
         .expect("Expected Step class in Config.pkl");
@@ -392,6 +392,22 @@ fn generate_pkl_config_doc() -> Result<(), Box<dyn std::error::Error>> {
         }
         md.push_str(&format_property_doc(
             &format!("<STEP>.{}", key),
+            value,
+            "###",
+        ));
+    }
+
+    // Process Groups
+    md.push_str("## `hooks.<HOOK>.steps.<GROUP>`\n\n");
+    let properties = config_json["classes"]["Group"]["properties"]
+        .as_object()
+        .expect("Expected Group class in Config.pkl");
+    for (key, value) in properties {
+        if key == "_type" {
+            continue;
+        }
+        md.push_str(&format_property_doc(
+            &format!("<GROUP>.{}", key),
             value,
             "###",
         ));

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,6 +151,35 @@ hooks {
 }
 ```
 
+Groups may define a small set of step settings that child steps inherit when they do not define their own value:
+
+- `dir`
+- `prefix`
+- `workspace_indicator`
+- `shell`
+- `stage`
+- `exclude`
+
+Inheritance uses simple override semantics. If a child step defines the field, the child value is used. Otherwise, the group value is copied to the step. Values are not merged.
+
+```pkl
+local frontend = new Group {
+    dir = "packages/frontend"
+    prefix = "mise x --"
+    steps {
+        ["prettier"] = (Builtins.prettier) {
+            batch = true
+        }
+        ["eslint"] = (Builtins.eslint) {
+            dir = "different/path"
+            batch = true
+        }
+    }
+}
+```
+
+In this example, `prettier` inherits `dir = "packages/frontend"` and `prefix = "mise x --"`. `eslint` keeps its explicit `dir = "different/path"` and still inherits `prefix = "mise x --"`.
+
 ## Git status in conditions and templates
 
 hk provides the current git status to both condition expressions and Tera templates via a `git` object. This lets you avoid shelling out in conditions (e.g., `exec('git …')`).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,12 +153,14 @@ hooks {
 
 Groups may define a small set of step settings that child steps inherit when they do not define their own value:
 
-- `dir`
-- `prefix`
-- `workspace_indicator`
-- `shell`
-- `stage`
-- `exclude`
+| Group option | Inherited step option | Type |
+| --- | --- | --- |
+| `dir` | `dir` | `String?` |
+| `prefix` | `prefix` | `String?` |
+| `workspace_indicator` | `workspace_indicator` | `String?` |
+| `shell` | `shell` | `(String \| Script)?` |
+| `stage` | `stage` | `(String \| List<String>)?` |
+| `exclude` | `exclude` | `(String \| List<String> \| Regex)?` |
 
 Inheritance uses simple override semantics. If a child step defines the field, the child value is used. Otherwise, the group value is copied to the step. Values are not merged.
 

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -2,105 +2,9 @@
 
 This example shows a monorepo with frontend, backend, infrastructure, and shared steps.
 
-## Original style
+Groups can set common step attributes such as `dir`, `workspace_indicator`, `prefix`, `shell`, `stage`, and `exclude`. Child steps inherit those values by default, but a child can still set its own value when it needs different behavior. Child values replace group values; they are not merged.
 
-Before group-level step defaults, repeated settings such as `dir` and `workspace_indicator` had to be set on each child step.
-
-```pkl
-/// Example configuration for a monorepo with multiple languages
-/// * Frontend: JavaScript/TypeScript with React
-/// * Backend: Rust
-/// * Infrastructure: Terraform
-/// * Uses groups to organize steps by component
-
-amends "package://github.com/jdx/hk/releases/download/v1.47.0/hk@1.47.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.47.0/hk@1.47.0#/Builtins.pkl"
-
-// Frontend linters (JavaScript/TypeScript)
-local frontend = new Group {
-  steps {
-    ["prettier"] = (Builtins.prettier) {
-      dir = "frontend"
-      batch = true
-    }
-    ["eslint"] = (Builtins.eslint) {
-      dir = "frontend"
-      batch = true
-    }
-    ["stylelint"] = (Builtins.stylelint) {
-      glob = List("frontend/**/*.css", "frontend/**/*.scss")
-    }
-  }
-}
-
-// Backend linters (Rust)
-local backend = new Group {
-  steps {
-    ["cargo_fmt"] = (Builtins.cargo_fmt) {
-      workspace_indicator = "Cargo.toml"
-      dir = "backend"
-    }
-    ["cargo_clippy"] = (Builtins.cargo_clippy) {
-      workspace_indicator = "Cargo.toml"
-      dir = "backend"
-    }
-    ["cargo_check"] = (Builtins.cargo_check) {
-      dir = "backend"
-      // Only run in CI or with "full" profile
-      profiles = List("ci", "full")
-    }
-  }
-}
-
-// Infrastructure linters (Terraform)
-local infrastructure = new Group {
-  steps {
-    ["terraform"] = (Builtins.terraform) {
-      glob = List("infrastructure/**/*.tf")
-    }
-    ["tflint"] = (Builtins.tf_lint) {
-      glob = List("infrastructure/**/*.tf")
-    }
-  }
-}
-
-// Shared linters (apply to all components)
-local shared = new Mapping<String, Step> {
-  ["markdown"] = (Builtins.markdown_lint) {
-    glob = List("**/*.md")
-    exclude = List("**/node_modules/**", "**/target/**")
-  }
-  ["yaml"] = (Builtins.yamllint) {
-    glob = List("**/*.yaml", "**/*.yml")
-    exclude = List("**/node_modules/**")
-  }
-}
-
-hooks {
-  ["pre-commit"] {
-    fix = true
-    stash = "git"
-    steps {
-      ["frontend"] = frontend
-      ["backend"] = backend
-      ["infrastructure"] = infrastructure
-      ...shared
-    }
-  }
-  ["check"] {
-    steps {
-      ["frontend"] = frontend
-      ["backend"] = backend
-      ["infrastructure"] = infrastructure
-      ...shared
-    }
-  }
-}
-```
-
-## Simplified with group options
-
-Group-level `dir` and `workspace_indicator` remove repeated child step settings. A child step can still override any inherited field by setting its own value.
+## Configuration
 
 ```pkl
 /// Example configuration for a monorepo with multiple languages
@@ -114,6 +18,7 @@ import "package://github.com/jdx/hk/releases/download/v1.47.0/hk@1.47.0#/Builtin
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {
+  // Inherited by frontend steps unless a child overrides `dir`.
   dir = "frontend"
   steps {
     ["prettier"] = (Builtins.prettier) {
@@ -123,20 +28,23 @@ local frontend = new Group {
       batch = true
     }
     ["stylelint"] = (Builtins.stylelint) {
-      glob = List("**/*.css", "**/*.scss")
+      // Override the group dir for a step that scans files from the repo root.
+      dir = "."
+      glob = List("frontend/**/*.css", "frontend/**/*.scss", "packages/design-system/**/*.scss")
     }
   }
 }
 
 // Backend linters (Rust)
 local backend = new Group {
+  // Inherited by all backend steps.
   dir = "backend"
   workspace_indicator = "Cargo.toml"
   steps {
     ["cargo_fmt"] = Builtins.cargo_fmt
     ["cargo_clippy"] = Builtins.cargo_clippy
     ["cargo_check"] = (Builtins.cargo_check) {
-      // Only run in CI or with "full" profile
+      // Only run in CI or with "full" profile.
       profiles = List("ci", "full")
     }
   }
@@ -145,12 +53,15 @@ local backend = new Group {
 // Infrastructure linters (Terraform)
 local infrastructure = new Group {
   dir = "infrastructure"
+  exclude = List("**/.terraform/**")
   steps {
     ["terraform"] = (Builtins.terraform) {
       glob = "**/*.tf"
     }
     ["tflint"] = (Builtins.tf_lint) {
       glob = "**/*.tf"
+      // Child exclude replaces the group exclude, so repeat common exclusions.
+      exclude = List("**/.terraform/**", "modules/vendor/**")
     }
   }
 }
@@ -189,14 +100,8 @@ hooks {
 }
 ```
 
-## Description
-
-Example configuration for a monorepo with multiple languages
-* Frontend: JavaScript/TypeScript with React
-* Backend: Rust
-* Infrastructure: Terraform
-* Uses groups to organize steps by component
-
 ## Key Features
 
-- Standard configuration
+- Group-level defaults keep shared settings close to the component they apply to.
+- Child steps can override inherited values when a tool needs a different working directory, glob, shell, stage, prefix, workspace indicator, or exclude list.
+- Override semantics are simple: a child value replaces the group value instead of merging with it.

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -1,5 +1,11 @@
 # Example: monorepo
 
+This example shows a monorepo with frontend, backend, infrastructure, and shared steps.
+
+## Original style
+
+Before group-level step defaults, repeated settings such as `dir` and `workspace_indicator` had to be set on each child step.
+
 ```pkl
 /// Example configuration for a monorepo with multiple languages
 /// * Frontend: JavaScript/TypeScript with React
@@ -54,6 +60,97 @@ local infrastructure = new Group {
     }
     ["tflint"] = (Builtins.tf_lint) {
       glob = List("infrastructure/**/*.tf")
+    }
+  }
+}
+
+// Shared linters (apply to all components)
+local shared = new Mapping<String, Step> {
+  ["markdown"] = (Builtins.markdown_lint) {
+    glob = List("**/*.md")
+    exclude = List("**/node_modules/**", "**/target/**")
+  }
+  ["yaml"] = (Builtins.yamllint) {
+    glob = List("**/*.yaml", "**/*.yml")
+    exclude = List("**/node_modules/**")
+  }
+}
+
+hooks {
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+    steps {
+      ["frontend"] = frontend
+      ["backend"] = backend
+      ["infrastructure"] = infrastructure
+      ...shared
+    }
+  }
+  ["check"] {
+    steps {
+      ["frontend"] = frontend
+      ["backend"] = backend
+      ["infrastructure"] = infrastructure
+      ...shared
+    }
+  }
+}
+```
+
+## Simplified with group options
+
+Group-level `dir` and `workspace_indicator` remove repeated child step settings. A child step can still override any inherited field by setting its own value.
+
+```pkl
+/// Example configuration for a monorepo with multiple languages
+/// * Frontend: JavaScript/TypeScript with React
+/// * Backend: Rust
+/// * Infrastructure: Terraform
+/// * Uses groups to organize steps by component
+
+amends "package://github.com/jdx/hk/releases/download/v1.47.0/hk@1.47.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.47.0/hk@1.47.0#/Builtins.pkl"
+
+// Frontend linters (JavaScript/TypeScript)
+local frontend = new Group {
+  dir = "frontend"
+  steps {
+    ["prettier"] = (Builtins.prettier) {
+      batch = true
+    }
+    ["eslint"] = (Builtins.eslint) {
+      batch = true
+    }
+    ["stylelint"] = (Builtins.stylelint) {
+      glob = List("**/*.css", "**/*.scss")
+    }
+  }
+}
+
+// Backend linters (Rust)
+local backend = new Group {
+  dir = "backend"
+  workspace_indicator = "Cargo.toml"
+  steps {
+    ["cargo_fmt"] = Builtins.cargo_fmt
+    ["cargo_clippy"] = Builtins.cargo_clippy
+    ["cargo_check"] = (Builtins.cargo_check) {
+      // Only run in CI or with "full" profile
+      profiles = List("ci", "full")
+    }
+  }
+}
+
+// Infrastructure linters (Terraform)
+local infrastructure = new Group {
+  dir = "infrastructure"
+  steps {
+    ["terraform"] = (Builtins.terraform) {
+      glob = "**/*.tf"
+    }
+    ["tflint"] = (Builtins.tf_lint) {
+      glob = "**/*.tf"
     }
   }
 }

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -896,6 +896,24 @@ class StepTestExpect {
 }
 
 class Group {
+  /// Optional working directory inherited by child steps that do not set `dir`.
+  dir: String?
+
+  /// Optional command prefix inherited by child steps that do not set `prefix`.
+  prefix: String?
+
+  /// Optional workspace indicator inherited by child steps that do not set `workspace_indicator`.
+  workspace_indicator: String?
+
+  /// Optional shell inherited by child steps that do not set `shell`.
+  shell: (String | Script)?
+
+  /// Optional staging globs inherited by child steps that do not set `stage`.
+  stage: (String | List<String>)?
+
+  /// Optional exclude patterns inherited by child steps that do not set `exclude`.
+  exclude: (String | List<String> | Regex)?
+
   steps: Mapping<String, Step> = new Mapping<String, Step> {}
 }
 
@@ -908,7 +926,14 @@ output {
       }
       [Group] = (g) -> new Dynamic {
         _type = "group"
-        ...g.toDynamic()
+        ...g
+          .toMap()
+          .mapValues((k, v) ->
+            if (k == "stage" && v is String)
+              List(v)
+            else
+              v
+          )
       }
       [Step] = (s) -> new Dynamic {
         _type = "step"

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -896,24 +896,39 @@ class StepTestExpect {
 }
 
 class Group {
-  /// Optional working directory inherited by child steps that do not set `dir`.
+  /// Working directory inherited by child steps that do not set `dir`.
+  ///
+  /// This is copied to each child step as a default; child step values override it completely.
   dir: String?
 
-  /// Optional command prefix inherited by child steps that do not set `prefix`.
+  /// Command prefix inherited by child steps that do not set `prefix`.
+  ///
+  /// This is copied to each child step as a default; child step values override it completely.
   prefix: String?
 
-  /// Optional workspace indicator inherited by child steps that do not set `workspace_indicator`.
+  /// Workspace indicator inherited by child steps that do not set `workspace_indicator`.
+  ///
+  /// This is copied to each child step as a default; child step values override it completely.
   workspace_indicator: String?
 
-  /// Optional shell inherited by child steps that do not set `shell`.
+  /// Shell inherited by child steps that do not set `shell`.
+  ///
+  /// This is copied to each child step as a default; child step values override it completely.
   shell: (String | Script)?
 
-  /// Optional staging globs inherited by child steps that do not set `stage`.
+  /// Staging globs inherited by child steps that do not set `stage`.
+  ///
+  /// This is copied to each child step as a default; child step values override it completely.
+  /// Group and step values are never merged.
   stage: (String | List<String>)?
 
-  /// Optional exclude patterns inherited by child steps that do not set `exclude`.
+  /// Exclude patterns inherited by child steps that do not set `exclude`.
+  ///
+  /// This is copied to each child step as a default; child step values override it completely.
+  /// Group and step values are never merged.
   exclude: (String | List<String> | Regex)?
 
+  /// Child steps in this group.
   steps: Mapping<String, Step> = new Mapping<String, Step> {}
 }
 

--- a/src/step_group.rs
+++ b/src/step_group.rs
@@ -2,12 +2,15 @@ use clx::progress::{ProgressJob, ProgressJobBuilder, ProgressStatus};
 use eyre::Context;
 use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
+use serde_with::{DisplayFromStr, PickFirst, serde_as};
 
 use crate::{
-    Result, glob, hook::StepOrGroup, step::RunType, step_context::StepContext,
+    Result, glob,
+    hook::{HookContext, StepOrGroup},
+    step::{Pattern, RunType, Script, Step},
+    step_context::StepContext,
     step_depends::StepDepends,
 };
-use crate::{hook::HookContext, step::Step};
 
 use std::{
     collections::{HashMap, HashSet},
@@ -15,11 +18,19 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+#[serde_as]
 #[derive(Debug, Clone, Default, Deserialize, Serialize, Eq, PartialEq)]
 pub struct StepGroup {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub _type: Option<String>,
     pub name: Option<String>,
+    pub workspace_indicator: Option<String>,
+    pub prefix: Option<String>,
+    pub dir: Option<String>,
+    #[serde_as(as = "Option<PickFirst<(_, DisplayFromStr)>>")]
+    pub shell: Option<Script>,
+    pub stage: Option<Vec<String>>,
+    pub exclude: Option<Pattern>,
     #[serde(default)]
     pub steps: IndexMap<String, Step>,
 }
@@ -47,7 +58,32 @@ impl StepGroupContext {
 impl StepGroup {
     pub fn init(&mut self, name: &str) -> Result<()> {
         self.name = Some(name.to_string());
+        let workspace_indicator = self.workspace_indicator.clone();
+        let prefix = self.prefix.clone();
+        let dir = self.dir.clone();
+        let shell = self.shell.clone();
+        let stage = self.stage.clone();
+        let exclude = self.exclude.clone();
+
         for (step_name, step) in self.steps.iter_mut() {
+            if step.workspace_indicator.is_none() {
+                step.workspace_indicator = workspace_indicator.clone();
+            }
+            if step.prefix.is_none() {
+                step.prefix = prefix.clone();
+            }
+            if step.dir.is_none() {
+                step.dir = dir.clone();
+            }
+            if step.shell.is_none() {
+                step.shell = shell.clone();
+            }
+            if step.stage.is_none() {
+                step.stage = stage.clone();
+            }
+            if step.exclude.as_ref().is_none_or(Pattern::is_empty) {
+                step.exclude = exclude.clone();
+            }
             step.init(step_name)?;
         }
         Ok(())
@@ -80,6 +116,7 @@ impl StepGroup {
                 _type: None,
                 name: None,
                 steps,
+                ..Default::default()
             })
             .collect()
     }
@@ -233,5 +270,75 @@ impl StepGroup {
         }
 
         Ok(files_in_contention)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_inherits_group_fields_without_merging_child_overrides() {
+        let group_shell: Script = "bash -o errexit -c".parse().unwrap();
+        let child_shell: Script = "zsh -o errexit -c".parse().unwrap();
+        let group_exclude = Pattern::Globs(vec!["**/*.snap".to_string()]);
+        let child_exclude = Pattern::Globs(vec!["**/*.fixture.js".to_string()]);
+
+        let mut inherited_step = Step::default();
+        inherited_step.check = Some("echo inherited".parse().unwrap());
+        inherited_step.exclude = Some(Pattern::Globs(vec![]));
+
+        let mut override_step = Step::default();
+        override_step.check = Some("echo override".parse().unwrap());
+        override_step.dir = Some("different/path".to_string());
+        override_step.prefix = Some("npm exec --".to_string());
+        override_step.workspace_indicator = Some("eslint.config.js".to_string());
+        override_step.shell = Some(child_shell.clone());
+        override_step.stage = Some(vec!["eslint-output/**".to_string()]);
+        override_step.exclude = Some(child_exclude.clone());
+
+        let mut group = StepGroup {
+            dir: Some("packages/frontend".to_string()),
+            prefix: Some("mise x --".to_string()),
+            workspace_indicator: Some("package.json".to_string()),
+            shell: Some(group_shell.clone()),
+            stage: Some(vec!["dist/**".to_string()]),
+            exclude: Some(group_exclude.clone()),
+            steps: IndexMap::from([
+                ("prettier".to_string(), inherited_step),
+                ("eslint".to_string(), override_step),
+            ]),
+            ..Default::default()
+        };
+
+        group.init("frontend").unwrap();
+
+        let prettier = group.steps.get("prettier").unwrap();
+        assert_eq!(prettier.dir.as_deref(), Some("packages/frontend"));
+        assert_eq!(prettier.prefix.as_deref(), Some("mise x --"));
+        assert_eq!(
+            prettier.workspace_indicator.as_deref(),
+            Some("package.json")
+        );
+        assert_eq!(prettier.shell.as_ref(), Some(&group_shell));
+        assert_eq!(
+            prettier.stage.as_deref(),
+            Some(&["dist/**".to_string()][..])
+        );
+        assert_eq!(prettier.exclude.as_ref(), Some(&group_exclude));
+
+        let eslint = group.steps.get("eslint").unwrap();
+        assert_eq!(eslint.dir.as_deref(), Some("different/path"));
+        assert_eq!(eslint.prefix.as_deref(), Some("npm exec --"));
+        assert_eq!(
+            eslint.workspace_indicator.as_deref(),
+            Some("eslint.config.js")
+        );
+        assert_eq!(eslint.shell.as_ref(), Some(&child_shell));
+        assert_eq!(
+            eslint.stage.as_deref(),
+            Some(&["eslint-output/**".to_string()][..])
+        );
+        assert_eq!(eslint.exclude.as_ref(), Some(&child_exclude));
     }
 }

--- a/test/group_inheritance.bats
+++ b/test/group_inheritance.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "group inherited dir and prefix apply to child steps" {
+    mkdir -p packages/frontend different/path
+    echo "console.log('frontend')" > packages/frontend/app.js
+    echo "console.log('override')" > different/path/app.js
+    echo "{}" > packages/frontend/package.json
+    echo "{}" > different/path/package.json
+    git add packages/frontend/app.js packages/frontend/package.json different/path/app.js different/path/package.json
+    git commit -m "add test files"
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["check"] {
+        steps {
+            ["frontend"] = new Group {
+                dir = "packages/frontend"
+                prefix = "env GROUP_PREFIX=1"
+                workspace_indicator = "package.json"
+                shell = "bash -o errexit -c"
+                stage = "dist/**"
+                exclude = List("**/*.snap")
+                steps {
+                    ["prettier"] {
+                        check = "sh -c 'printf %s \"\$GROUP_PREFIX\" > {{root}}/inherited-prefix.txt; pwd > {{root}}/inherited-dir.txt'"
+                        glob = "*.js"
+                        fix = "true"
+                    }
+                    ["eslint"] {
+                        dir = "different/path"
+                        check = "sh -c 'printf %s \"\$GROUP_PREFIX\" > {{root}}/override-prefix.txt; pwd > {{root}}/override-dir.txt'"
+                        glob = "*.js"
+                        fix = "true"
+                    }
+                }
+            }
+        }
+    }
+}
+EOF
+
+    run hk check --all
+    assert_success
+
+    assert_file_contains inherited-prefix.txt "1"
+    assert_file_contains inherited-dir.txt "/packages/frontend"
+    assert_file_contains override-prefix.txt "1"
+    assert_file_contains override-dir.txt "/different/path"
+}
+
+@test "group inherited exclude filters child step files" {
+    mkdir -p packages/frontend
+    echo "console.log('frontend')" > packages/frontend/app.js
+    echo "snapshot" > packages/frontend/app.snap
+    git add packages/frontend/app.js packages/frontend/app.snap
+    git commit -m "add test files"
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["check"] {
+        steps {
+            ["frontend"] = new Group {
+                dir = "packages/frontend"
+                exclude = List("**/*.snap")
+                steps {
+                    ["list-files"] {
+                        check = "printf '%s\\n' {{files}} > {{root}}/seen-files.txt"
+                        glob = List("*.js", "*.snap")
+                    }
+                }
+            }
+        }
+    }
+}
+EOF
+
+    run hk check --all
+    assert_success
+
+    assert_file_contains seen-files.txt "app.js"
+    assert_file_not_contains seen-files.txt "app.snap"
+}
+
+@test "group inherited stage stages child fix output" {
+    mkdir -p packages/frontend/dist/assets
+    echo "console.log('frontend')" > packages/frontend/app.js
+    echo "old" > packages/frontend/dist/assets/output.txt
+    git add packages/frontend/app.js packages/frontend/dist/assets/output.txt
+    git commit -m "add test files"
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["fix"] {
+        fix = true
+        steps {
+            ["frontend"] = new Group {
+                dir = "packages/frontend"
+                stage = "dist/**"
+                steps {
+                    ["build"] {
+                        glob = "dist/assets/*.txt"
+                        fix = "printf generated > dist/assets/output.txt"
+                    }
+                }
+            }
+        }
+    }
+}
+EOF
+
+    echo "dirty" > packages/frontend/dist/assets/output.txt
+
+    run hk run fix
+    assert_success
+
+    run git diff --name-only --cached
+    assert_success
+    assert_output --partial "packages/frontend/dist/assets/output.txt"
+}


### PR DESCRIPTION
## Summary
- allow `Group` to define inherited defaults for `dir`, `prefix`, `workspace_indicator`, `shell`, `stage`, and `exclude`
- copy group values into child steps only when the child leaves that field unset; child values remain full overrides with no merge behavior
- document group inheritance and add regression coverage for Pkl config execution plus Rust override semantics

## Testing
- `mise x rust@latest -- cargo test`
- `PATH="/Users/DeRoseR/.cargo/bin:$PATH" mise x rust@latest -- bats --jobs 1 test/group_inheritance.bats`
- `PATH="/Users/DeRoseR/.cargo/bin:$PATH" target/debug/hk check pkl/Config.pkl src/step_group.rs test/group_inheritance.bats docs/configuration.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Groups can define defaults (dir, prefix, workspace indicator, shell, stage, exclude) that are applied to child steps; child-defined values replace group defaults.

* **Documentation**
  * Configuration guide and monorepo example updated with a new section and example illustrating inheritance and override semantics.

* **Tests**
  * Added a test validating that group defaults propagate to child steps without overriding explicit child settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->