### PR TITLE
fix(pkl): bump pklr to 1.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,9 +2002,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pklr"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20777a0d202019336b7b4c2464fce8eeb6b4d7fb2dfa64d4a749fb4f30dfdcec"
+checksum = "0a71ac625195fbf97854f182ad5fa615dca27daa642627d76b1fedc457ce8fb9"
 dependencies = [
  "async-recursion",
  "indexmap 2.14.0",


### PR DESCRIPTION
## Summary
- update Cargo.lock to use pklr 1.0.6

## Why
This pulls in the pklr fix for `Mapping<String, Step | Group>` properties initialized with `new Mapping<String, Step> {}`, which caused hk configs like discussion #981 to fail validation under the default pklr backend.

## Test
- `cargo check`

Refs https://github.com/jdx/hk/discussions/981.

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency patch bump on the config parser with a targeted regression test; no hk application logic changes in the visible diff.
> 
> **Overview**
> Bumps the **`pklr`** dependency from **1.0.4** to **1.0.6** (lockfile pin) so hk picks up upstream fixes in the default PKL evaluator.
> 
> That release addresses validation of **`Mapping<String, Step | Group>`** hook `steps` when entries use inline **`new Group { ... }`** (and related `new Mapping<String, Step> {}` initialization), which previously caused configs to fail under the **pklr** backend.
> 
> A **bats** case in `test/pklr_backend.bats` locks in that inline-group hook shape so it stays valid after future bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bae9e0d5d19aa5b6ccc056fe4729ca395f0335d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->