### PR TITLE
chore: release v1.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## [1.49.0](https://github.com/jdx/hk/compare/v1.48.0..v1.49.0) - 2026-07-01
+
+### 🚀 Features
+
+- **(builtins)** use `types = List("text")` instead of `glob = "**/*"` for  text-only hooks by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#997](https://github.com/jdx/hk/pull/997)
+- **(builtins)** add rubocop_server linter with --server mode by [@andyw8](https://github.com/andyw8) in [#995](https://github.com/jdx/hk/pull/995)
+- **(builtins)** add .config/ and pyproject.toml project indicators for ryl by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#998](https://github.com/jdx/hk/pull/998)
+- **(builtins)** add shellharden linter by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#996](https://github.com/jdx/hk/pull/996)
+
+### 🐛 Bug Fixes
+
+- **(builtins)** update betterleaks tests for aws composite rule by [@risu729](https://github.com/risu729) in [#1006](https://github.com/jdx/hk/pull/1006)
+- **(stash)** preserve tail deletion after overlapping worktree hunk by [@jdx](https://github.com/jdx) in [#990](https://github.com/jdx/hk/pull/990)
+
+### 📚 Documentation
+
+- link to all sponsors by [@jdx](https://github.com/jdx) in [#991](https://github.com/jdx/hk/pull/991)
+- clarify contribution fit by [@jdx](https://github.com/jdx) in [#992](https://github.com/jdx/hk/pull/992)
+
+### 🧪 Testing
+
+- **(setup)** fix ci-nogit failures from mise and aube upstream changes by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#1002](https://github.com/jdx/hk/pull/1002)
+
+### 🛡️ Security
+
+- **(deps)** update actions/checkout action to v6.0.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#984](https://github.com/jdx/hk/pull/984)
+
+### 🔍 Other Changes
+
+- **(ci)** bump pr-closer action by [@jdx](https://github.com/jdx) in [#989](https://github.com/jdx/hk/pull/989)
+- **(ci)** use shared coderabbit config by [@jdx](https://github.com/jdx) in [#993](https://github.com/jdx/hk/pull/993)
+- **(ci)** fix nscloud cache action version comments by [@jdx](https://github.com/jdx) in [#1019](https://github.com/jdx/hk/pull/1019)
+- Enable Entire for Codex by [@jdx](https://github.com/jdx) in [#1010](https://github.com/jdx/hk/pull/1010)
+
+### 📦️ Dependency Updates
+
+- update jdx/mise-action action to v4.1.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#987](https://github.com/jdx/hk/pull/987)
+- update anthropics/claude-code-action action to v1.0.137 by [@renovate[bot]](https://github.com/renovate[bot]) in [#986](https://github.com/jdx/hk/pull/986)
+- update anthropics/claude-code-action action to v1.0.146 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1000](https://github.com/jdx/hk/pull/1000)
+- lock file maintenance lockfile maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#994](https://github.com/jdx/hk/pull/994)
+- update anthropics/claude-code-action action to v1.0.152 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1012](https://github.com/jdx/hk/pull/1012)
+- update actions-rust-lang/setup-rust-toolchain digest to 166cdcf by [@renovate[bot]](https://github.com/renovate[bot]) in [#1011](https://github.com/jdx/hk/pull/1011)
+- update rust crate itertools to 0.15 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1014](https://github.com/jdx/hk/pull/1014)
+- update jdx/mise-action action to v4.2.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1013](https://github.com/jdx/hk/pull/1013)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1016](https://github.com/jdx/hk/pull/1016)
+- update actions/checkout action to v7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1015](https://github.com/jdx/hk/pull/1015)
+- exempt pklr from release age by [@jdx](https://github.com/jdx) in [#1017](https://github.com/jdx/hk/pull/1017)
+- bump pklr to 1.1.1 by [@jdx](https://github.com/jdx) in [#1018](https://github.com/jdx/hk/pull/1018)
+
+### New Contributors
+
+- @risu729 made their first contribution in [#1006](https://github.com/jdx/hk/pull/1006)
+- @andyw8 made their first contribution in [#995](https://github.com/jdx/hk/pull/995)
+
 ## [1.48.0](https://github.com/jdx/hk/compare/v1.47.0..v1.48.0) - 2026-06-11
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -141,14 +141,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -471,9 +472,9 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1029,7 +1030,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.48.0"
+version = "1.49.0"
 dependencies = [
  "arc-swap",
  "chrono",
@@ -1344,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1389,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -1564,9 +1565,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -2371,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2972,9 +2973,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2992,9 +2993,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4008,9 +4009,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "hk"
 repository = "https://github.com/jdx/hk"
 rust-version = "1.88.0"
-version = "1.48.0"
+version = "1.49.0"
 
 [[bin]]
 name = "generate-docs"

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 90+ pre-configured linters and formatters through the `Builtins` mod
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -4943,7 +4943,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.48.0",
+  "version": "1.49.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.48.0
+**Version**: 1.49.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // linters can be manually defined
@@ -239,8 +239,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -273,7 +273,7 @@ Add steps to your hkrc. hk merges them into every project's hooks — steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -366,7 +366,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,8 +105,8 @@ Separately from global *hooks*, you can also create a global *config* file that 
 This will generate a `hk.pkl` file in the root of the repository, here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // linters can be manually defined

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -43,7 +43,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
 
 `pre-commit` {
     ["prelint"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,8 +3,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,8 +3,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,8 +3,8 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,8 +4,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -7,8 +7,8 @@
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
 
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -7,8 +7,8 @@
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
 
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -13,8 +13,8 @@ Groups can set common step attributes such as `dir`, `workspace_indicator`, `pre
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -8,8 +8,8 @@
 /// * Sorts imports with isort
 /// * Validates with flake8
 
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
 amends "pkl/Config.pkl"
 import "pkl/Builtins.pkl"
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.48.0"
+version "1.49.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)" hide=#true global=#true {


### PR DESCRIPTION
### 🚀 Features

- **(builtins)** use `types = List("text")` instead of `glob = "**/*"` for  text-only hooks by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#997](https://github.com/jdx/hk/pull/997)
- **(builtins)** add rubocop_server linter with --server mode by [@andyw8](https://github.com/andyw8) in [#995](https://github.com/jdx/hk/pull/995)
- **(builtins)** add .config/ and pyproject.toml project indicators for ryl by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#998](https://github.com/jdx/hk/pull/998)
- **(builtins)** add shellharden linter by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#996](https://github.com/jdx/hk/pull/996)

### 🐛 Bug Fixes

- **(builtins)** update betterleaks tests for aws composite rule by [@risu729](https://github.com/risu729) in [#1006](https://github.com/jdx/hk/pull/1006)
- **(stash)** preserve tail deletion after overlapping worktree hunk by [@jdx](https://github.com/jdx) in [#990](https://github.com/jdx/hk/pull/990)

### 📚 Documentation

- link to all sponsors by [@jdx](https://github.com/jdx) in [#991](https://github.com/jdx/hk/pull/991)
- clarify contribution fit by [@jdx](https://github.com/jdx) in [#992](https://github.com/jdx/hk/pull/992)

### 🧪 Testing

- **(setup)** fix ci-nogit failures from mise and aube upstream changes by [@hituzi-no-sippo](https://github.com/hituzi-no-sippo) in [#1002](https://github.com/jdx/hk/pull/1002)

### 🛡️ Security

- **(deps)** update actions/checkout action to v6.0.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#984](https://github.com/jdx/hk/pull/984)

### 🔍 Other Changes

- **(ci)** bump pr-closer action by [@jdx](https://github.com/jdx) in [#989](https://github.com/jdx/hk/pull/989)
- **(ci)** use shared coderabbit config by [@jdx](https://github.com/jdx) in [#993](https://github.com/jdx/hk/pull/993)
- **(ci)** fix nscloud cache action version comments by [@jdx](https://github.com/jdx) in [#1019](https://github.com/jdx/hk/pull/1019)
- Enable Entire for Codex by [@jdx](https://github.com/jdx) in [#1010](https://github.com/jdx/hk/pull/1010)

### 📦️ Dependency Updates

- update jdx/mise-action action to v4.1.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#987](https://github.com/jdx/hk/pull/987)
- update anthropics/claude-code-action action to v1.0.137 by [@renovate[bot]](https://github.com/renovate[bot]) in [#986](https://github.com/jdx/hk/pull/986)
- update anthropics/claude-code-action action to v1.0.146 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1000](https://github.com/jdx/hk/pull/1000)
- lock file maintenance lockfile maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#994](https://github.com/jdx/hk/pull/994)
- update anthropics/claude-code-action action to v1.0.152 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1012](https://github.com/jdx/hk/pull/1012)
- update actions-rust-lang/setup-rust-toolchain digest to 166cdcf by [@renovate[bot]](https://github.com/renovate[bot]) in [#1011](https://github.com/jdx/hk/pull/1011)
- update rust crate itertools to 0.15 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1014](https://github.com/jdx/hk/pull/1014)
- update jdx/mise-action action to v4.2.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1013](https://github.com/jdx/hk/pull/1013)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1016](https://github.com/jdx/hk/pull/1016)
- update actions/checkout action to v7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1015](https://github.com/jdx/hk/pull/1015)
- exempt pklr from release age by [@jdx](https://github.com/jdx) in [#1017](https://github.com/jdx/hk/pull/1017)
- bump pklr to 1.1.1 by [@jdx](https://github.com/jdx) in [#1018](https://github.com/jdx/hk/pull/1018)

### New Contributors

- @risu729 made their first contribution in [#1006](https://github.com/jdx/hk/pull/1006)
- @andyw8 made their first contribution in [#995](https://github.com/jdx/hk/pull/995)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation string updates with lockfile refreshes; no application logic changes in this diff.
> 
> **Overview**
> **Release v1.49.0** — bumps the crate and CLI from `1.48.0` to `1.49.0` (`Cargo.toml`, `hk.usage.kdl`, generated CLI docs) and refreshes `Cargo.lock` (including `hk` and assorted transitive crate updates).
> 
> Adds the **1.49.0** section to `CHANGELOG.md` and rewrites Pkl `amends` / `import` package URLs across docs, examples, and `hk-example.pkl` to point at the **v1.49.0** GitHub release artifacts.
> 
> The changelog documents what ships in this tag (not introduced in this diff alone): new builtins (**rubocop_server**, **shellharden**, ryl indicators), text-only hooks using `types = List("text")`, a **stash** fix for tail deletion after overlapping worktree hunks, plus CI/docs/deps maintenance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb333bdcf7e95974900bd8be23ce31d5604ad04d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->