### PR TITLE
chore(ci): bump pr-closer action

### DIFF
--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -14,4 +14,4 @@ jobs:
       checks: read
       statuses: read
     steps:
-      - uses: jdx/pr-closer@44b9e7859d29e01b4b38e50e2ad6b5c5d00a6973 # v1.0.1
+      - uses: jdx/pr-closer@ddc40dfad5567fc7296a2463880c618344d26055 # v1.1.0


### PR DESCRIPTION
## Summary
- Bump `jdx/pr-closer` from `v1.0.1` to `v1.1.0`.
- Keep the action pinned by full commit SHA.

## Verification
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single third-party action version bump in CI with no application or auth logic changes.
> 
> **Overview**
> Updates the scheduled **`pr-closer`** workflow to use **`jdx/pr-closer` v1.1.0**, still pinned to commit **`ddc40dfad5567fc7296a2463880c618344d26055`** instead of the previous v1.0.1 SHA. No other workflow steps, triggers, or permissions change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b9a45c40885285fc3858c757177eff55329555d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions infrastructure for workflow automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->