### PR TITLE
fix(stash): preserve tail deletion after overlapping worktree hunk

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -115,10 +115,27 @@ pub fn three_way_merge_hunks(base: &str, fixer: Option<&str>, worktree: Option<&
             let mut idx = 0usize;
             let mut fi = 0usize;
             let mut wi = 0usize;
-            let fixer_hunks = diff_hunks(base, f, HunkSource::Fixer);
+            let mut fixer_hunks = diff_hunks(base, f, HunkSource::Fixer);
             let work_hunks = diff_hunks(base, w, HunkSource::Worktree);
 
             while fi < fixer_hunks.len() || wi < work_hunks.len() {
+                while fi < fixer_hunks.len() && fixer_hunks[fi].start < idx {
+                    // A worktree hunk may consume only the front of a fixer
+                    // deletion. Keep the unconsumed tail deletion instead of
+                    // dropping the whole hunk.
+                    if fixer_hunks[fi].lines.is_empty() && fixer_hunks[fi].end > idx {
+                        fixer_hunks[fi].start = idx;
+                        break;
+                    }
+                    fi += 1;
+                }
+                while wi < work_hunks.len() && work_hunks[wi].start < idx {
+                    wi += 1;
+                }
+                if fi >= fixer_hunks.len() && wi >= work_hunks.len() {
+                    break;
+                }
+
                 let fh = fixer_hunks.get(fi);
                 let wh = work_hunks.get(wi);
 
@@ -152,13 +169,6 @@ pub fn three_way_merge_hunks(base: &str, fixer: Option<&str>, worktree: Option<&
                     wi += 1;
                 } else {
                     fi += 1;
-                }
-                // Skip any hunks that begin before the current position to avoid partial re-application
-                while fi < fixer_hunks.len() && fixer_hunks[fi].start < idx {
-                    fi += 1;
-                }
-                while wi < work_hunks.len() && work_hunks[wi].start < idx {
-                    wi += 1;
                 }
             }
             // Tail unchanged
@@ -241,5 +251,17 @@ mod tests {
         let work = Some("name: my-app\nversion: 2.0\ndeps:\n  flask\n\n\n");
         let merged = three_way_merge_hunks(base, fixer, work);
         assert_eq!(merged, "name: my-app\nversion: 2.0\ndeps:\n  flask\n");
+    }
+
+    #[test]
+    fn merge_preserves_fixer_tail_deletion_when_worktree_overlaps_start() {
+        // Regression test for discussion #988: the worktree edit overlaps the
+        // start of a fixer tail deletion, but the rest of the deletion still
+        // needs to be applied.
+        let base = "l1 STAGED\nl2\nl3\nl4\nl5\n";
+        let fixer = Some("l1 STAGED\nl2\n");
+        let work = Some("l1 STAGED\nl2\nl3 UNSTAGED\nl4\nl5\n");
+        let merged = three_way_merge_hunks(base, fixer, work);
+        assert_eq!(merged, "l1 STAGED\nl2\nl3 UNSTAGED\n");
     }
 }


### PR DESCRIPTION
## Summary

- keep the unconsumed tail of a pure fixer deletion when a worktree hunk overlaps only the start of it
- add a regression test for discussion #988's overlapping worktree/fixer tail-deletion case

## Tests

- `cargo fmt --check`
- `cargo test merge::tests -- --nocapture`
- manual #988 repro with `target/debug/hk run pre-commit` and `stash = "patch-file"`

Fixes discussion #988.

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core merge logic used when combining fixer and worktree patches; incorrect hunk handling could corrupt merged file content, though scope is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes **three-way merge** in `three_way_merge_hunks` when a **worktree hunk overlaps only the beginning** of a **fixer pure-deletion** hunk (empty `lines`). Previously those fixer hunks were skipped entirely once `idx` moved past their start, so trailing lines the fixer should remove could reappear in the merged output.
> 
> At each loop iteration, fixer hunks with `start < idx` are handled explicitly: **pure deletions** with `end > idx` are **trimmed** (`start = idx`) and kept instead of discarded. The duplicate end-of-iteration skip logic for stale hunks was removed in favor of this upfront pass. **`fixer_hunks`** is now **mutable** to support trimming.
> 
> Adds regression test **`merge_preserves_fixer_tail_deletion_when_worktree_overlaps_start`** for discussion #988 (worktree edit mid-file while fixer deletes the tail).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06b58a3831615633c61cd39819a1649c94beb02d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where file deletions could be incorrectly dropped during merge when concurrent edits overlapped
  * Streamlined merge processing logic

* **Tests**
  * Added regression test for merge scenarios with overlapping edits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->