### PR TITLE
docs: link to all sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ See docs: https://hk.jdx.dev/
 
 hk is sponsored by [37signals](https://37signals.com).
 
+[View all sponsors](https://en.dev/sponsors.html).
+
 ## Demo
 
 ![hk demo](docs/public/hk-demo.gif)


### PR DESCRIPTION
## Summary
- add a README link to the full en.dev sponsors page

## Tests
- not run (README-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation change with no runtime or security impact.
> 
> **Overview**
> Adds a **[View all sponsors](https://en.dev/sponsors.html)** link in the README **Sponsors** section, directly under the existing 37signals sponsorship line, so readers can open the full en.dev sponsors page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d77797ffaa1911d5149103f870191da40bb6298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "View all sponsors" link to the Sponsors section in the README for easier access to the complete list of sponsors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->