### PR TITLE
chore(ci): use shared coderabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+remote_config:
+  repository: "jdx/coderabbit"
+  ref: "main"
+  path: ".coderabbit.yaml"


### PR DESCRIPTION
## Summary
- Point this repository's CodeRabbit YAML at the shared `jdx/coderabbit` configuration.
- Keep CodeRabbit settings centralized across the en.dev CLI repositories.

## Validation
- YAML-only configuration change; not run.

*This PR was created by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only CI/tooling config with no runtime, auth, or application code changes.
> 
> **Overview**
> **Centralizes CodeRabbit settings** by adding a new `.coderabbit.yaml` that uses `remote_config` instead of duplicating rules in this repo.
> 
> The file points at repository `jdx/coderabbit`, branch `main`, and path `.coderabbit.yaml`, so local CodeRabbit behavior follows the shared org config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77fc988f4b500c4c10bd3cea7005d897b197876b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->