### PR TITLE
feat(builtins): add rubocop_server linter with --server mode

### DIFF
--- a/pkl/builtins/rubocop_server.pkl
+++ b/pkl/builtins/rubocop_server.pkl
@@ -1,0 +1,16 @@
+import "../Builtins.pkl"
+import "./rubocop.pkl"
+
+@Builtins.meta {
+  category = "Ruby"
+  description = "Ruby style guide (using RuboCop's --server mode)"
+  project_indicators {
+    new { file = "Gemfile" }
+  }
+}
+rubocop_server = (rubocop.rubocop) {
+  // `--server`: Use a long-lived RuboCop server process to speed up repeated invocations.
+  check = "rubocop --server --force-exclusion {{ files }}"
+  check_list_files = "rubocop --server --force-exclusion --list-target-files {{ files }}"
+  fix = "rubocop --server --force-exclusion --autocorrect {{ files }}"
+}


### PR DESCRIPTION
## Summary
- Adds a new opt-in builtin `Builtins.rubocop_server`, a sibling of `Builtins.rubocop` that adds RuboCop's `--server` flag to `check`, `check_list_files`, and `fix`.
- `--server` runs a long-lived RuboCop daemon to speed up repeated invocations.

## Usage
```pkl
["rubocop"] = Builtins.rubocop_server
```