### PR TITLE
feat(builtins): use `types = List("text")` instead of `glob = "**/*"` for  text-only hooks

### DIFF
--- a/pkl/builtins/byte_order_marker.pkl
+++ b/pkl/builtins/byte_order_marker.pkl
@@ -7,7 +7,7 @@ import "./test/helpers.pkl"
   description = "Detect UTF-8 BOM"
 }
 byte_order_marker = new Config.Step {
-  glob = "**/*"
+  types = List("text")
   check_diff = "hk util check-byte-order-marker --diff {{files}}"
   fix = "hk util fix-byte-order-marker {{files}}"
   tests {

--- a/pkl/builtins/check_executables_have_shebangs.pkl
+++ b/pkl/builtins/check_executables_have_shebangs.pkl
@@ -6,7 +6,7 @@ import "../Config.pkl"
   description = "Verify executable files have shebang lines"
 }
 check_executables_have_shebangs = new Config.Step {
-  glob = "**/*"
+  types = List("text")
   check = "hk util check-executables-have-shebangs {{files}}"
   tests {
     ["detects executable without shebang"] {

--- a/pkl/builtins/check_merge_conflict.pkl
+++ b/pkl/builtins/check_merge_conflict.pkl
@@ -7,7 +7,7 @@ import "./test/helpers.pkl"
   description = "Detect merge conflict markers"
 }
 check_merge_conflict = new Config.Step {
-  glob = "**/*"
+  types = List("text")
   check = "hk util check-merge-conflict --assume-in-merge {{files}}"
   tests {
     local const testMaker = new helpers.TestMaker {}

--- a/pkl/builtins/detect_private_key.pkl
+++ b/pkl/builtins/detect_private_key.pkl
@@ -7,7 +7,7 @@ import "./test/helpers.pkl"
   description = "Detect accidentally committed private keys"
 }
 detect_private_key = new Config.Step {
-  glob = "**/*"
+  types = List("text")
   check = "hk util detect-private-key {{files}}"
   tests {
     local const testMaker = new helpers.TestMaker {}

--- a/pkl/builtins/dprint.pkl
+++ b/pkl/builtins/dprint.pkl
@@ -6,7 +6,7 @@ import "../Config.pkl"
   description = "Pluggable code formatter"
 }
 dprint = new Config.Step {
-  glob = "**/*"
+  types = List("text")
   check = "dprint check --allow-no-files {{ files }}"
   check_list_files = "dprint check --allow-no-files --list-different {{ files }}"
   fix = "dprint fmt --allow-no-files {{ files }}"

--- a/pkl/builtins/fix_smart_quotes.pkl
+++ b/pkl/builtins/fix_smart_quotes.pkl
@@ -7,7 +7,7 @@ import "./test/helpers.pkl"
   description = "Replace smart quotes with regular quotes"
 }
 fix_smart_quotes = new Config.Step {
-  glob = "**/*"
+  types = List("text")
   check_diff = "hk util fix-smart-quotes --diff {{files}}"
   fix = "hk util fix-smart-quotes {{files}}"
   tests {

--- a/pkl/builtins/mixed_line_ending.pkl
+++ b/pkl/builtins/mixed_line_ending.pkl
@@ -7,7 +7,7 @@ import "./test/helpers.pkl"
   description = "Detect and fix mixed line endings"
 }
 mixed_line_ending = new Config.Step {
-  glob = "**/*"
+  types = List("text")
   check_diff = "hk util mixed-line-ending --diff {{files}}"
   fix = "hk util mixed-line-ending --fix {{files}}"
   tests {

--- a/pkl/builtins/newlines.pkl
+++ b/pkl/builtins/newlines.pkl
@@ -7,7 +7,7 @@ import "./test/helpers.pkl"
   description = "Ensure files end with newline"
 }
 newlines = new Config.Step {
-  glob = "**/*"
+  types = List("text")
   check_diff = "hk util end-of-file-fixer --diff {{files}}"
   fix = "hk util end-of-file-fixer --fix {{files}}"
   tests {

--- a/pkl/builtins/trailing_whitespace.pkl
+++ b/pkl/builtins/trailing_whitespace.pkl
@@ -7,7 +7,7 @@ import "./test/helpers.pkl"
   description = "Detect and remove trailing whitespace"
 }
 trailing_whitespace = new Config.Step {
-  glob = "**/*"
+  types = List("text")
   check_diff = "hk util trailing-whitespace --diff {{files}}"
   fix = "hk util trailing-whitespace --fix {{files}}"
   tests {

--- a/pkl/builtins/typos.pkl
+++ b/pkl/builtins/typos.pkl
@@ -7,7 +7,7 @@ import "./test/helpers.pkl"
   description = "Source code spell checker"
 }
 typos = new Config.Step {
-  glob = "**/*"
+  types = List("text")
   check_diff =
     """
     output=$(typos --force-exclude --diff {{files}})

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,47 @@
+test(setup): exempt nanoid from aube trust-downgrade policy
+
+## Problem
+
+`ci-nogit` started failing with `ERR_AUBE_TRUST_DOWNGRADE` when installing
+the npm-backed test tooling (`stylelint`, `vite-plus`):
+
+```
+ERR_AUBE_TRUST_DOWNGRADE
+  × failed to resolve dependencies
+  ╰─▶ trust downgrade for nanoid@3.3.14 (trustPolicy=no-downgrade): earlier
+      published version 5.1.12 had trusted publisher but this version has no
+      trust evidence
+```
+
+A recent aube release enabled `trustPolicy = no-downgrade` by default. It
+rejects any version whose trust evidence is weaker than an earlier-published
+version of the same package. `nanoid@3.3.14` (the 3.x maintenance line) lacks
+the trusted-publisher evidence that the 5.x line carries, so aube treats it as
+a possible supply-chain downgrade and aborts the install.
+
+This is upstream behavior, not a hk change — runs before the aube release
+passed; runs after fail.
+
+## Why a version bump doesn't help
+
+`nanoid@3.3.x` is pulled transitively via `postcss` (`nanoid@^3.3.12`), which
+both `stylelint` and `vite-plus` depend on. Verified that even the latest
+`stylelint` (17.13.0) still resolves `nanoid@3.3.14` and trips the same error,
+because postcss stays on the CJS-compatible nanoid 3.x line. Updating the tools
+does not avoid the issue.
+
+## Fix
+
+Add `nanoid` to `trustPolicyExclude` in the test aube config, mirroring the
+targeted, per-package approach used for `allowedUnpopularPackages` in #1002.
+This is test tooling and `nanoid@3.3.14` is not a confirmed compromise — just
+an older release line without trusted-publisher metadata.
+
+## Verification
+
+- Reproduced `ERR_AUBE_TRUST_DOWNGRADE` locally with aube 1.18.2.
+- Confirmed `trustPolicyExclude = ["nanoid"]` lets the install resolve
+  (`+ nanoid@3.3.14`).
+- Confirmed `aube config get` reads both keys correctly from the commented TOML.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
Replace glob = "**/*" with types = List("text") in builtins that operate on file content rather than file metadata:
byte_order_marker, check_executables_have_shebangs, check_merge_conflict, detect_private_key, dprint, fix_smart_quotes, mixed_line_ending, newlines, trailing_whitespace, typos.

The following three builtins intentionally keep glob = "**/*" to cover all file types including binaries:
- check_added_large_files: large files are more often binaries (images, videos, compiled artifacts) than text files
- check_case_conflict: filename case conflicts can occur for any file type
- check_symlinks: symlinks can point to binary files or directories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added test configuration documentation describing dependency installation handling and trust policy management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->