### PR TITLE
feat(builtins): add .config/ and pyproject.toml project indicators for ryl

### DIFF
--- a/pkl/builtins/ryl.pkl
+++ b/pkl/builtins/ryl.pkl
@@ -5,12 +5,16 @@ import "./test/helpers.pkl"
 @Builtins.meta {
   category = "YAML"
   description = "Re-implementation of yamllint in Rust"
+  // https://ryl-docs.pages.dev/getting-started/quickstart/#configure-for-your-project
   project_indicators {
     new { file = "ryl.toml" }
     new { file = ".ryl.toml" }
+    new { file = ".config/ryl.toml" }
+    new { file = ".config/.ryl.toml" }
     new { file = ".yamllint" }
     new { file = ".yamllint.yml" }
     new { file = ".yamllint.yaml" }
+    new { file = "pyproject.toml"; contains = "[tool.ryl]" }
   }
 }
 ryl = new Config.Step {

--- a/pkl/builtins/ryl_markdown.pkl
+++ b/pkl/builtins/ryl_markdown.pkl
@@ -5,12 +5,16 @@ import "./test/helpers.pkl"
 @Builtins.meta {
   category = "Markdown"
   description = "Lint YAML embedded in Markdown (front matter + fenced yaml blocks) with ryl"
+  // https://ryl-docs.pages.dev/getting-started/quickstart/#configure-for-your-project
   project_indicators {
     new { file = "ryl.toml" }
     new { file = ".ryl.toml" }
+    new { file = ".config/ryl.toml" }
+    new { file = ".config/.ryl.toml" }
     new { file = ".yamllint" }
     new { file = ".yamllint.yml" }
     new { file = ".yamllint.yaml" }
+    new { file = "pyproject.toml"; contains = "[tool.ryl]" }
   }
 }
 ryl_markdown = new Config.Step {

--- a/test/builtin_tool_stubs/ryl
+++ b/test/builtin_tool_stubs/ryl
@@ -1,4 +1,4 @@
 #!/usr/bin/env -S mise tool-stub
 
-version = "0.15.0"
+version = "0.20.0"
 tool = "aqua:owenlamont/ryl"


### PR DESCRIPTION
https://ryl-docs.pages.dev/getting-started/quickstart/#configure-for-your-project
> To keep config out of the project root, ryl also discovers a ryl-native TOML config inside a repo-local .config/ directory (the RuboCop/rumdl convention). At each directory in the upward search the candidates are tried in this order, and the first match wins:
> 
> 1. .ryl.toml
> 1. ryl.toml
> 1. .config/.ryl.toml
> 1. .config/ryl.toml
> 1. pyproject.toml (only when it has a [tool.ryl] table)
> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated tool version to 0.20.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->