### PR TITLE
test(setup): fix ci-nogit failures from mise and aube upstream changes

### DIFF
--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -23,6 +23,11 @@ _common_setup() {
     export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
     export HOME="$TEST_TEMP_DIR"
 
+    # Install tool user configs into the temp HOME so tools behave correctly in tests.
+    export XDG_CONFIG_HOME="$HOME/.config"
+    mkdir -p "$XDG_CONFIG_HOME"
+    cp -r "$PROJECT_ROOT/test/test_helper/xdg_config/." "$XDG_CONFIG_HOME/"
+
     git config --global init.defaultBranch main
 
     # Only set user config if not already set (to avoid overriding existing config)

--- a/test/test_helper/xdg_config/aube/config.toml
+++ b/test/test_helper/xdg_config/aube/config.toml
@@ -1,0 +1,1 @@
+allowedUnpopularPackages = ["@contextlint/cli"]

--- a/test/test_helper/xdg_config/mise/config.toml
+++ b/test/test_helper/xdg_config/mise/config.toml
@@ -1,0 +1,2 @@
+[tools]
+uv = "latest"


### PR DESCRIPTION
## Summary

Fix two independent `ci-nogit` failures caused by upstream tool changes:

- mise v2026.6.10 started stripping mise-managed install dirs from
  inherited PATH, causing `uv` shims to fail inside bats tests that redirect
  `HOME` to a temp directory. Fixed by placing a minimal mise global config in
  `test/test_helper/xdg_config/mise/config.toml`.
- aube (mise's npm backend) now blocks packages with fewer than 1,000
  weekly downloads in CI. `@contextlint/cli` (~701/week) triggers this gate.
  Fixed by placing an aube user config in
  `test/test_helper/xdg_config/aube/config.toml` that exempts trusted
  low-download packages.

Both configs are placed under a new `test/test_helper/xdg_config/` directory
that mirrors the `$XDG_CONFIG_HOME` structure. `common_setup.bash` copies the
whole tree into the temp `HOME` in one step, and the project git repo is never
polluted with untracked config files.

## mise v2026.6.10 uv shim resolution failure

### Problem

Since mise v2026.6.10, `ci-nogit` fails with:

```
mise ERROR No version is set for shim: uv
Set a global default version with one of the following:
mise use -g uv@0.11.2
```

mise v2026.6.9 does not exhibit this failure.

### Root Cause

mise v2026.6.10 introduced [jdx/mise#10422](https://github.com/jdx/mise/pull/10422):

> `mise x` / `run` / `env` now strip mise-managed install directories from the
> inherited PATH when composing the child environment.

The intent is to prevent stale tool versions (carried in from IDE terminals or CI
wrappers) from shadowing the version mise was asked to use. After the change,
only the freshly resolved bin dir for the current toolset is injected.

This interacts with `test/test_helper/common_setup.bash` as follows:

1. `common_setup` changes `HOME` to a temp directory (`$TEST_TEMP_DIR`).
2. A builtin test invokes a tool stub, e.g. `test/builtin_tool_stubs/mypy`, which
   starts with `#!/usr/bin/env -S mise tool-stub`.
3. The nested `mise` invocation (v2026.6.10+) strips mise-managed install dirs
   from the inherited PATH and reinjects only the tools present in the current
   toolset config.
4. Because `HOME` is now the temp dir, mise's global config resolves to
   `$TEST_TEMP_DIR/.config/mise/config.toml`, which does not exist. The project's
   `mise.toml` (which declares `uv = "latest"`) is also unreachable because the
   test runs in `$TEST_TEMP_DIR/src/proj`, outside the project tree.
5. `uv` is therefore not in the resolved toolset. Its install dir is stripped from
   PATH and not re-added, so `uv` falls through to the mise shim.
6. The shim cannot resolve a version for `uv` in the temp context and exits with
   the error above.

The four tool stubs that use the `pipx` backend are affected:

- `test/builtin_tool_stubs/black` (`pipx:black`)
- `test/builtin_tool_stubs/isort` (`pipx:isort`)
- `test/builtin_tool_stubs/mypy` (`pipx:mypy`)
- `test/builtin_tool_stubs/yamllint` (`pipx:yamllint`)

Modern `pipx` uses `uv` internally for package operations, which triggers the
shim when `uv` is not directly resolvable.

### Fix

`common_setup` already preserves the real `MISE_INSTALLS_DIR`, `XDG_DATA_HOME`,
and `XDG_CACHE_HOME` before changing `HOME`, so installed tool binaries remain
accessible. The missing piece is a mise global config in the temp `HOME` that
tells the shim which version of `uv` to use.

`test/test_helper/xdg_config/mise/config.toml` declares the required tools:

```toml
[tools]
uv = "latest"
```

Because `MISE_INSTALLS_DIR` still points to the real installs directory, the
shim resolves `"latest"` from the already-installed `uv` without any network
access.

## aube low-download threshold blocks `@contextlint/cli`

### Problem

`ci-nogit` fails with:

```
mise npm:@contextlint/cli@0.7.0       [1/3] install
 WARN aube::commands::add_supply_chain: @contextlint/cli: 701 weekly downloads (threshold: 1000)
ERR_AUBE_LOW_DOWNLOAD_PACKAGE
  × refusing to add @contextlint/cli: only 701 weekly downloads (threshold:
  │ 1000). Pass --allow-low-downloads to bypass, or set `lowDownloadThreshold
  │ = 0`.
```

### Root Cause

[jdx/aube#656](https://github.com/jdx/aube/pull/656) introduced a supply-chain
security check that refuses to install npm packages with fewer than 1,000 weekly
downloads in non-interactive (CI) environments. The `@contextlint/cli` package
currently has ~701 weekly downloads, falling below the threshold.

`builtins_tests.bats` installs tools on demand via `mise tool-stub`. When the
contextlint stub triggers `mise install npm:@contextlint/cli`, aube rejects the
install and the job fails.

### Fix

`test/test_helper/xdg_config/aube/config.toml` sets the user-scope
`allowedUnpopularPackages` setting introduced in
[jdx/aube#673](https://github.com/jdx/aube/pull/673):

```toml
allowedUnpopularPackages = ["@contextlint/cli"]
```

This is aube's user config (`$XDG_CONFIG_HOME/aube/config.toml`), so it applies
in all test environments without creating any file inside the test git repo. All
other supply-chain checks remain intact.

## Unified xdg_config/ approach

Both fixes place their config files under `test/test_helper/xdg_config/`, which
mirrors the `$XDG_CONFIG_HOME` directory structure:

```
test/test_helper/xdg_config/
  mise/config.toml   ← uv = "latest"
  aube/config.toml   ← allowedUnpopularPackages = ["@contextlint/cli"]
```

`common_setup.bash` copies the whole tree in one step after setting `HOME`:

```diff
+    export XDG_CONFIG_HOME="$HOME/.config"
+    mkdir -p "$XDG_CONFIG_HOME"
+    cp -r "$PROJECT_ROOT/test/test_helper/xdg_config/." "$XDG_CONFIG_HOME/"
```

Adding config for a new tool in the future only requires dropping a file into the
appropriate subdirectory — no changes to `common_setup.bash` needed.

## Test Plan

- [x] `ci-nogit` passes on both `ubuntu-latest` and `macos-latest`
- [x] `ci-libgit2` and `ci-nolibgit2` are unaffected
- [x] `builtins_tests.bats` completes without `No version is set for shim: uv` errors
- [x] `contextlint :: check good file` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Improved test environment setup by initializing an XDG config directory under the temporary home for consistent config discovery.
  * Updated test configuration fixtures to better cover tool/package configuration, including allowed package settings and pinned `uv` tool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->