### PR TITLE
chore(release): enable hardened runtime for macos binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
           profile: serious
           codesign: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
           codesign_prefix: dev.jdx.
+          codesign-options: runtime
           dry-run: true # Always dry-run to just build without uploading
       - name: Upload binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/test/test_helper/common_setup.bash
+++ b/test/test_helper/common_setup.bash
@@ -23,6 +23,11 @@ _common_setup() {
     export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
     export HOME="$TEST_TEMP_DIR"
 
+    # Install tool user configs into the temp HOME so tools behave correctly in tests.
+    export XDG_CONFIG_HOME="$HOME/.config"
+    mkdir -p "$XDG_CONFIG_HOME"
+    cp -r "$PROJECT_ROOT/test/test_helper/xdg_config/." "$XDG_CONFIG_HOME/"
+
     git config --global init.defaultBranch main
 
     # Only set user config if not already set (to avoid overriding existing config)

--- a/test/test_helper/xdg_config/aube/config.toml
+++ b/test/test_helper/xdg_config/aube/config.toml
@@ -1,0 +1,1 @@
+allowedUnpopularPackages = ["@contextlint/cli"]

--- a/test/test_helper/xdg_config/mise/config.toml
+++ b/test/test_helper/xdg_config/mise/config.toml
@@ -1,0 +1,2 @@
+[tools]
+uv = "latest"


### PR DESCRIPTION
_Human note: normally I rewrite my ai-generated pr descriptions to make them less verbose, but this time I've left it as-is because the problem was described well._

_I will just add that I tried to create a regression test for this bug, but it wasn't very easy to do. We would need a test path that runs a hardened binary to have the test assert success. Happy to add that if you would like but it would be a novel test pattern for this project._

## Summary

Enable macOS Hardened Runtime for release binaries by passing `codesign-options: runtime` to `taiki-e/upload-rust-binary-action`.

## Why

`hk` vendors libgit2, but libgit2-sys still links Apple targets against `libiconv`. If `hk` is launched from an environment that sets `DYLD_LIBRARY_PATH` to a project dependency directory containing another `libiconv.2.dylib`, dyld can load that library instead of the system one.

One concrete failure mode is a mise-managed project with Pixi/conda dependencies. mise shims load the project environment before execing `hk`; the project can set `DYLD_LIBRARY_PATH` to `.pixi/envs/default/lib`, which contains `libiconv.2.dylib`. On macOS repositories with `core.precomposeunicode=true`, libgit2's status path enters its macOS precompose/iconv code and can segfault before checks run.

Signing release binaries with Hardened Runtime prevents this kind of DYLD-based library interposition for `hk`, while still allowing libgit2 to be used normally.

## Validation

- Confirmed `taiki-e/upload-rust-binary-action@v1` supports the `codesign-options` input.
- Locally verified an ad-hoc signed copy of `target/debug/hk` with `codesign --options runtime` succeeds under a Pixi `DYLD_LIBRARY_PATH` that otherwise reproduces the libgit2/iconv segfault.

*This PR description was generated by Codex.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the release build workflow’s binary signing options to include runtime behavior.
  * Improved test environment setup by installing XDG-based configuration into a temporary HOME.
  * Updated test fixtures for allowed tooling packages and added a pinned tool configuration block.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->