### PR TITLE
fix(builtins): use pinact v4 CLI flags in pinact builtins

### DIFF
--- a/pkl/builtins/pinact.pkl
+++ b/pkl/builtins/pinact.pkl
@@ -9,9 +9,9 @@ import "./test/helpers.pkl"
 const pinact = new Config.Step {
   glob = List(".github/workflows/*", "*/action.*")
   types = List("yaml")
-  // `verify` flag to verify pairs of commit CHA and version are correct
-  check_diff = "pinact run --verify --check {{ files }}"
-  fix = "pinact run --verify {{ files }}"
+  // pinact ≥ 4.0: --verify-comment verifies SHA/version comment pairs; --check is -fix=false
+  check_diff = "pinact run --verify-comment --check {{ files }}"
+  fix = "pinact run --verify-comment {{ files }}"
   tests {
     local const bad =
       """

--- a/pkl/builtins/pinact_update.pkl
+++ b/pkl/builtins/pinact_update.pkl
@@ -8,8 +8,8 @@ import "../Config.pkl"
 const pinact_update = new Config.Step {
   glob = List(".github/workflows/*", "*/action.*")
   types = List("yaml")
-  // `verify` flag to verify pairs of commit CHA and version are correct
-  check_diff = "pinact run --update --verify --check {{ files }}"
-  fix = "pinact run --update --verify {{ files }}"
+  // pinact ≥ 4.0: --verify-comment verifies SHA/version comment pairs; --check is -fix=false
+  check_diff = "pinact run --update --verify-comment --check {{ files }}"
+  fix = "pinact run --update --verify-comment {{ files }}"
   // Tests removed: they check against live GitHub Action versions, making them flaky
 }

--- a/test/builtin_tool_stubs/pinact
+++ b/test/builtin_tool_stubs/pinact
@@ -1,4 +1,4 @@
 #!/usr/bin/env -S mise tool-stub
 
-version = "3.8.0"
+version = "4.1.0"
 tool = "aqua:suzuki-shunsuke/pinact"


### PR DESCRIPTION
This breaks backward compatibility; I think it's safe to keep them for now, but please let me know if we should update this.

## Summary
- Update `pinact` and `pinact_update` builtins to use pinact v4 primary flags (`--verify-comment`, `--check`) instead of the v3-style `--verify` spelling.
- Bump the pinact test stub from 3.8.0 to 4.1.0 so builtin tests exercise the v4 CLI.

pinact v4 keeps backwards-compatible aliases for `--verify` and `--check`; this change adopts the v4-native flag names documented in `pinact run --help`.

pinact v4.0.0 was released on May 25, 2026—80 days (about 2 months and 19 days) ago as of August 13, 2026—so it has had sufficient time to settle.

## Test plan
- [x] `hk test pinact` (builtin step tests)
- [ ] `mise run test` (full suite)


Made with [Cursor](https://cursor.com)

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*