### PR TITLE
fix(builtins): update betterleaks tests for aws composite rule

### DIFF
--- a/pkl/builtins/betterleaks.pkl
+++ b/pkl/builtins/betterleaks.pkl
@@ -12,12 +12,14 @@ import "./test/helpers.pkl"
 }
 betterleaks = new Config.Step {
   types = List("text")
-  // Reference: https://github.com/betterleaks/betterleaks/blob/v1.1.1/.pre-commit-hooks.yaml#L4
+  // Reference: https://github.com/betterleaks/betterleaks/blob/v1.5.0/.pre-commit-hooks.yaml#L4
   check = "betterleaks dir --redact --verbose --no-banner {{ files }}"
   tests {
     local const testMaker = new helpers.TestMaker { filename = "foo.txt" }
-    // Reference: https://github.com/betterleaks/betterleaks/blob/v1.1.1/testdata/repos/nogit/api.go#L20
-    ["check bad file"] = testMaker.checkFail("awsToken = AKIALALEMEL33243OLIA", 1)
+    // aws-access-token alone is not reported since betterleaks 1.2.0 (composite rule); use github-pat instead.
+    // Reference: https://github.com/betterleaks/betterleaks/blob/v1.5.0/cmd/generate/config/rules/github.go
+    ["check bad file"] =
+      testMaker.checkFail("token = \"ghp_qOomCIZBWchHR4v5FPp9UiQRS9CyigrCkXXuIJQPfe63f12a\"", 1)
     ["check good file"] = testMaker.checkPass("message = foobar")
   }
 }

--- a/test/builtin_tool_stubs/betterleaks
+++ b/test/builtin_tool_stubs/betterleaks
@@ -1,4 +1,4 @@
 #!/usr/bin/env -S mise tool-stub
 
-version = "1.1.1"
+version = "1.5.0"
 tool = "aqua:betterleaks/betterleaks"


### PR DESCRIPTION
## Summary

- Replace the `aws-access-token` builtin test fixture (`AKIALALEMEL33243OLIA`) with a `github-pat` sample that still fails on betterleaks ≥1.2.0
- Bump the betterleaks test stub from v1.1.1 to v1.5.0

Since [betterleaks#53](https://github.com/betterleaks/betterleaks/pull/53) (betterleaks 1.2.0), `aws-access-token` is a composite rule: a standalone access-key-shaped string is intentionally not reported without a nearby `aws-secret-access-key`. The old gitleaks test fixture therefore passes the scanner on current betterleaks, making the builtin `check bad file` test a false negative.

## Test plan

- [ ] CI `builtins_tests` job passes on macOS and Ubuntu

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the betterleaks tool to version 1.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->