### PR TITLE
feat(builtins): use types=shell for shfmt and shellcheck

### DIFF
--- a/pkl/builtins/shellcheck.pkl
+++ b/pkl/builtins/shellcheck.pkl
@@ -11,7 +11,7 @@ import "./test/helpers.pkl"
 }
 shellcheck = new Config.Step {
   batch = true
-  glob = List("**/*.sh", "**/*.bash")
+  types = List("shell")
   check = "shellcheck {{ files }}"
   tests {
     local const testMaker = new helpers.TestMaker {
@@ -19,5 +19,14 @@ shellcheck = new Config.Step {
     }
     ["check bad file"] = testMaker.checkFail("#!/usr/bin/bash\necho 'oops I'm escaped'", 1)
     ["check good file"] = testMaker.checkPass("#!/usr/bin/bash\necho 'oops I'\\''m escaped'\n")
+
+    local const extensionlessMaker = new helpers.TestMaker { filename = "deploy" }
+    ["check extensionless shebang bad file"] =
+      extensionlessMaker.checkFail(
+        "#!/usr/bin/bash\necho 'oops I'm escaped'",
+        1,
+      )
+    ["check extensionless shebang good file"] =
+      extensionlessMaker.checkPass("#!/usr/bin/bash\necho 'oops I'\\''m escaped'\n")
   }
 }

--- a/pkl/builtins/shfmt.pkl
+++ b/pkl/builtins/shfmt.pkl
@@ -11,7 +11,7 @@ import "./test/helpers.pkl"
 }
 shfmt = new Config.Step {
   batch = true
-  glob = List("**/*.sh", "**/*.bash", "**/*.mksh", "**/*.bats", "**/*.zsh")
+  types = List("shell")
   check_diff = "shfmt -d --apply-ignore {{ files }}"
   check_list_files =
     """
@@ -55,5 +55,23 @@ shfmt = new Config.Step {
     ["check ignored good file"] = ignoredTestMaker.checkPass(after)
     ["fix ignored bad file"] = ignoredTestMaker.fixPass(before, before)
     ["fix ignored good file"] = ignoredTestMaker.fixPass(after, after)
+
+    local const extensionlessMaker = new helpers.TestMaker { filename = "deploy" }
+    local const extensionlessBefore =
+      """
+      #!/bin/bash
+      foo() {
+        (( $bar ))
+      }
+      """
+    local const extensionlessAfter =
+      """
+      #!/bin/bash
+      foo() {
+      	(($bar))
+      }
+      """
+    ["check extensionless shebang bad file"] = extensionlessMaker.checkFail(extensionlessBefore, 1)
+    ["check extensionless shebang good file"] = extensionlessMaker.checkPass(extensionlessAfter)
   }
 }

--- a/src/step/filtering.rs
+++ b/src/step/filtering.rs
@@ -14,7 +14,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use std::collections::HashSet;
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 use super::types::Step;
@@ -171,6 +171,21 @@ impl Step {
     ///
     /// The filtered list of files that match all criteria
     pub fn filter_files(&self, files: &[PathBuf]) -> Result<Vec<PathBuf>> {
+        self.filter_files_with_base(files, None)
+    }
+
+    /// Filter files while resolving relative paths against `base_dir` for
+    /// filesystem-backed checks such as type, binary, and symlink detection.
+    pub fn filter_files_with_base(
+        &self,
+        files: &[PathBuf],
+        base_dir: Option<&Path>,
+    ) -> Result<Vec<PathBuf>> {
+        let resolve_path = |file: &PathBuf| match base_dir {
+            Some(base_dir) if !file.is_absolute() => base_dir.join(file),
+            _ => file.clone(),
+        };
+
         let mut files = files.to_vec();
         if let Some(dir) = &self.dir {
             files.retain(|f| f.starts_with(dir));
@@ -196,18 +211,20 @@ impl Step {
         // Filter out binary files unless allow_binary is true
         if !self.allow_binary {
             files.retain(|f| {
+                let path = resolve_path(f);
                 // Keep file if we can't determine if it's binary (might be deleted/renamed)
                 // or if it's definitely not binary
-                is_binary_file(f).map(|is_bin| !is_bin).unwrap_or(true)
+                is_binary_file(&path).map(|is_bin| !is_bin).unwrap_or(true)
             });
         }
 
         // Filter out symbolic links unless allow_symlinks is true
         if !self.allow_symlinks {
             files.retain(|f| {
+                let path = resolve_path(f);
                 // Keep file if we can't determine if it's a symlink (might be deleted/renamed)
                 // or if it's definitely not a symlink
-                is_symlink_file(f)
+                is_symlink_file(&path)
                     .map(|is_symlink| !is_symlink)
                     .unwrap_or(true)
             });
@@ -215,7 +232,7 @@ impl Step {
 
         // Filter by file types if specified
         if let Some(types) = &self.types {
-            files.retain(|f| crate::file_type::matches_types(f, types));
+            files.retain(|f| crate::file_type::matches_types(&resolve_path(f), types));
         }
 
         Ok(files)

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -165,10 +165,6 @@ pub async fn run_test_named(step: &Step, name: &str, test: &StepTest) -> Result<
         .tmpdir
         .unwrap_or_else(|| files.iter().any(|p| p.starts_with(&sandbox)));
 
-    if test.files.is_none() {
-        files = step.filter_files(&files)?;
-    }
-
     let base_dir = if uses_sandbox {
         sandbox.to_path_buf()
     } else {
@@ -187,6 +183,10 @@ pub async fn run_test_named(step: &Step, name: &str, test: &StepTest) -> Result<
             }
         };
         xx::file::write(&path, contents)?;
+    }
+
+    if test.files.is_none() {
+        files = step.filter_files_with_base(&files, Some(&base_dir))?;
     }
 
     tctx.with_files(step.shell_type(), &files);


### PR DESCRIPTION
## Summary

- Replace extension-only `glob` on `Builtins.shfmt` and `Builtins.shellcheck` with `types = List("shell")`
- Selects shell scripts by extension **or** shebang (e.g. extensionless `bin/deploy`)
- Aligns builtins with the shellcheck example in [hk configuration docs](https://hk.jdx.dev/configuration) and `test/types.bats`
- Add builtin tests for an extensionless `deploy` script

## Motivation

Glob-only builtins miss extensionless scripts with a shell shebang. Adding `types` on top of an inherited builtin `glob` in consumer configs is AND semantics and does not fix that.

Consumer repos can still add `glob` in `hk.pkl` for paths `types = shell` does not cover (e.g. `.bashrc` without a shebang).

## Test plan

- [x] `mise run pkl:gen`
- [x] `hk test --step shfmt`
- [x] `hk test --step shellcheck`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File filtering now evaluates paths against the resolved working directory, improving binary, symlink, and file-type checks.
  * Test file selection now uses the correct base directory when no explicit file list is provided, reducing mismatches in sandboxed or nested setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->