### PR TITLE
chore(deps): exempt pklr from release age

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>jdx/renovate-config"]
+  "extends": ["local>jdx/renovate-config"],
+  "packageRules": [
+    {
+      "description": "Disable minimum release age checks for pklr updates",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["pklr"],
+      "minimumReleaseAge": null
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- add a Renovate package rule for the Cargo `pklr` dependency
- set `minimumReleaseAge` to `null` for `pklr` only, leaving the shared default intact for other updates

## Testing
- `jq . .github/renovate.json`
- `git diff --check`
- `npx --yes --package renovate renovate-config-validator .github/renovate.json`

_This PR description was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/tooling-only Renovate config with no runtime or application code impact.
> 
> **Overview**
> Adds a **Renovate `packageRules`** entry so **Cargo** updates for **`pklr`** set **`minimumReleaseAge` to `null`**, skipping the shared config’s release-age wait for that crate only.
> 
> Other dependencies keep the inherited **`local>jdx/renovate-config`** behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a033f03ae4efd974b5e4fa5e84d665b87b5176fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to better align with existing project rules.
  * Allowed a specific Rust package update path to proceed without the usual release-age delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->