### PR TITLE
chore(deps): bump pklr to 1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,9 +1977,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pklr"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1bc1df527363cc0a371dc866bd2c0aa0fea5a34aac91c3a7fc5a7521ac79a9"
+checksum = "267f0200de87abde8c08de2a49dc86c666c5799ddacd67fc4504f0887f7e88d0"
 dependencies = [
  "async-recursion",
  "indexmap 2.14.0",


### PR DESCRIPTION
## Summary
- update the locked `pklr` crate from 1.1.0 to 1.1.1

## Testing
- `mise run test:cargo`
- `git diff --check`

_This PR description was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no direct code changes; risk is limited to upstream `pklr` behavior in Pkl config loading.
> 
> **Overview**
> Updates the locked **`pklr`** crate in **`Cargo.lock`** from **1.1.0** to **1.1.2** (registry checksum only). No **`Cargo.toml`** or Rust source changes in this diff.
> 
> This pulls in whatever fixes and behavior changes ship in **`pklr`** 1.1.x for hk’s default Pkl config evaluation path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad8bb2934a5f22b0d507d60ae532bc34e44ea074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->