### PR TITLE
chore: stop running cargo update in release task

### DIFF
--- a/mise-tasks/release-plz
+++ b/mise-tasks/release-plz
@@ -43,7 +43,6 @@ cargo set-version --package hk "${version#v}"
 
 git config user.name mise-en-dev
 git config user.email 123107610+mise-en-dev@users.noreply.github.com
-cargo update
 
 # Regenerate rendered artifacts (CLI docs, usage, etc.) for the release
 # This must run BEFORE update-version since update-version needs the generated docs


### PR DESCRIPTION
## Summary
- remove `cargo update` from `mise-tasks/release-plz`
- keep release PRs from introducing unrelated `Cargo.lock` dependency churn

## Tests
- `bash -n mise-tasks/release-plz`
- `rg -n "cargo update" mise-tasks/release-plz mise-tasks .github Cargo.toml`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to release scripting only; no runtime auth, security, or application logic affected.
> 
> **Overview**
> The **`mise-tasks/release-plz`** release automation no longer runs **`cargo update`** after bumping the crate version and configuring the release git identity.
> 
> Release PRs will keep **`Cargo.lock`** as-is (aside from whatever **`cargo set-version`**, **`mise run render`**, and **`update-version`** already change), so unrelated dependency resolution churn should not land in version-bump PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a669e8fa3fc93081fcd18e2543ccab46c2eff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->