### PR TITLE
chore: release v1.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [1.50.0](https://github.com/jdx/hk/compare/v1.49.0..v1.50.0) - 2026-07-06
+
+### 🚀 Features
+
+- **(builtins)** add textlint linter by [@smasato](https://github.com/smasato) in [#1036](https://github.com/jdx/hk/pull/1036)
+
+### 🐛 Bug Fixes
+
+- **(config)** read string settings from live git config by [@jdx](https://github.com/jdx) in [#1042](https://github.com/jdx/hk/pull/1042)
+- **(hook)** scope pre-commit files to staged changes by [@jdx](https://github.com/jdx) in [#1023](https://github.com/jdx/hk/pull/1023)
+- **(install)** run installed pre-commit hooks staged by [@jdx](https://github.com/jdx) in [#1043](https://github.com/jdx/hk/pull/1043)
+- **(step)** prefer check_list_files in check-first by [@risu729](https://github.com/risu729) in [#1038](https://github.com/jdx/hk/pull/1038)
+- include staged renames in staged files list by [@smasato](https://github.com/smasato) in [#1035](https://github.com/jdx/hk/pull/1035)
+
+### 📚 Documentation
+
+- fix stale defaults, broken links, and invalid examples by [@jdx](https://github.com/jdx) in [#1022](https://github.com/jdx/hk/pull/1022)
+- redesign logo as vector hook wordmark by [@jdx](https://github.com/jdx) in [#1041](https://github.com/jdx/hk/pull/1041)
+
+### ⚡ Performance
+
+- **(config)** share resolved config cache by content by [@jdx](https://github.com/jdx) in [#1044](https://github.com/jdx/hk/pull/1044)
+
+### 🔍 Other Changes
+
+- stop running cargo update in release task by [@jdx](https://github.com/jdx) in [#1020](https://github.com/jdx/hk/pull/1020)
+- Update sponsor references for jdx.dev by [@jdx](https://github.com/jdx) in [#1024](https://github.com/jdx/hk/pull/1024)
+- use release backends for cargo tools by [@jdx](https://github.com/jdx) in [#1040](https://github.com/jdx/hk/pull/1040)
+- schedule releases for Monday morning by [@jdx](https://github.com/jdx) in [#1045](https://github.com/jdx/hk/pull/1045)
+
+### 📦️ Dependency Updates
+
+- update anthropics/claude-code-action action to v1.0.158 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1026](https://github.com/jdx/hk/pull/1026)
+- update zizmorcore/zizmor-action action to v0.5.7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1027](https://github.com/jdx/hk/pull/1027)
+- update rust crate tera to v2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1028](https://github.com/jdx/hk/pull/1028)
+- update anthropics/claude-code-action action to v1.0.159 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1029](https://github.com/jdx/hk/pull/1029)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1039](https://github.com/jdx/hk/pull/1039)
+
 ## [1.49.0](https://github.com/jdx/hk/compare/v1.48.0..v1.49.0) - 2026-07-01
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.49.0"
+version = "1.50.0"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "hk"
 repository = "https://github.com/jdx/hk"
 rust-version = "1.88.0"
-version = "1.49.0"
+version = "1.50.0"
 
 [[bin]]
 name = "generate-docs"

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 140+ pre-configured linters and formatters through the `Builtins` mo
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -4943,7 +4943,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.49.0",
+  "version": "1.50.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.49.0
+**Version**: 1.50.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined
@@ -239,8 +239,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -273,7 +273,7 @@ Add steps to your hkrc. hk merges them into every project's hooks — steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -366,7 +366,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,8 +105,8 @@ Separately from global *hooks*, you can also create a global *config* file that 
 `hk init` generates an `hk.pkl` file in the root of the repository. Here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -43,7 +43,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,8 +3,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,8 +3,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,8 +3,8 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,8 +4,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -6,8 +6,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -6,8 +6,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -13,8 +13,8 @@ Groups can set common step attributes such as `dir`, `workspace_indicator`, `pre
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -7,8 +7,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
 amends "pkl/Config.pkl"
 import "pkl/Builtins.pkl"
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.49.0"
+version "1.50.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)" hide=#true global=#true {


### PR DESCRIPTION
### 🚀 Features

- **(builtins)** add textlint linter by [@smasato](https://github.com/smasato) in [#1036](https://github.com/jdx/hk/pull/1036)

### 🐛 Bug Fixes

- **(config)** read string settings from live git config by [@jdx](https://github.com/jdx) in [#1042](https://github.com/jdx/hk/pull/1042)
- **(hook)** scope pre-commit files to staged changes by [@jdx](https://github.com/jdx) in [#1023](https://github.com/jdx/hk/pull/1023)
- **(install)** run installed pre-commit hooks staged by [@jdx](https://github.com/jdx) in [#1043](https://github.com/jdx/hk/pull/1043)
- **(step)** prefer check_list_files in check-first by [@risu729](https://github.com/risu729) in [#1038](https://github.com/jdx/hk/pull/1038)
- include staged renames in staged files list by [@smasato](https://github.com/smasato) in [#1035](https://github.com/jdx/hk/pull/1035)

### 📚 Documentation

- fix stale defaults, broken links, and invalid examples by [@jdx](https://github.com/jdx) in [#1022](https://github.com/jdx/hk/pull/1022)
- redesign logo as vector hook wordmark by [@jdx](https://github.com/jdx) in [#1041](https://github.com/jdx/hk/pull/1041)

### ⚡ Performance

- **(config)** share resolved config cache by content by [@jdx](https://github.com/jdx) in [#1044](https://github.com/jdx/hk/pull/1044)

### 🔍 Other Changes

- stop running cargo update in release task by [@jdx](https://github.com/jdx) in [#1020](https://github.com/jdx/hk/pull/1020)
- Update sponsor references for jdx.dev by [@jdx](https://github.com/jdx) in [#1024](https://github.com/jdx/hk/pull/1024)
- use release backends for cargo tools by [@jdx](https://github.com/jdx) in [#1040](https://github.com/jdx/hk/pull/1040)
- schedule releases for Monday morning by [@jdx](https://github.com/jdx) in [#1045](https://github.com/jdx/hk/pull/1045)

### 📦️ Dependency Updates

- update anthropics/claude-code-action action to v1.0.158 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1026](https://github.com/jdx/hk/pull/1026)
- update zizmorcore/zizmor-action action to v0.5.7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1027](https://github.com/jdx/hk/pull/1027)
- update rust crate tera to v2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1028](https://github.com/jdx/hk/pull/1028)
- update anthropics/claude-code-action action to v1.0.159 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1029](https://github.com/jdx/hk/pull/1029)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1039](https://github.com/jdx/hk/pull/1039)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release housekeeping only; behavioral changes are already merged and listed in the changelog, not introduced in this diff.
> 
> **Overview**
> **Release v1.50.0** bumps the crate and CLI metadata from `1.49.0` to `1.50.0` in `Cargo.toml`, `Cargo.lock`, `hk.usage.kdl`, and generated CLI docs.
> 
> The new **1.50.0** section in `CHANGELOG.md` documents what ships in this tag (textlint builtin, pre-commit staged-file fixes, config/git-config and cache improvements, docs/logo updates, release tooling, and dependency bumps). Example and doc `hk.pkl` snippets are updated to the `v1.50.0` Pkl package URLs.
> 
> This PR does not change application logic—only version strings, changelog, and documentation references for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b565ed84146a06239f8bbf9e6fca436685e23fc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->