### PR TITLE
docs: fix stale defaults, broken links, and invalid examples

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -8,15 +8,15 @@ git hooks need to be fast above all else or else developers won't use them. Para
 is the best (and likely only) way to achieve acceptable performance at the git hook manager level.
 
 Existing alternatives to hk such as [lefthook](https://github.com/evilmartians/lefthook) support
-very basic parallel execution of shell script however because linters may edit files—this naive approach
+very basic parallel execution of shell scripts—however, because linters may edit files, this naive approach
 can break down if multiple linters affect the same file.
 
 I felt that a git hook manager that had tighter integration with the linters would be able to leverage
 read/write file locks to enable more aggressive parallelism while preventing race conditions. This read/write locking is the primary reason
-I built hk, however there are other design decisions worth noting that I think makes hk a better experience than its peers:
+I built hk, however there are other design decisions worth noting that I think make hk a better experience than its peers:
 
 - hk has a bunch of [builtins](https://github.com/jdx/hk/tree/main/pkl/builtins) you can use for common linters like `prettier` or `black`.
-- hk stashes unstaged changes before running "fix" hooks. This prevents a common issue with pre-commit hooks where files containing both staged and
+- hk can stash unstaged changes before running "fix" hooks (see the `stash` setting). This prevents a common issue with pre-commit hooks where files containing both staged and
   unstaged changes get modified and the unstaged changes end up being staged erroneously.
 - By default, hk uses libgit2 to directly interact with git instead of shelling out many times to `git`.
   (This generally makes hk much faster but there are situations like `fsmonitor` where it may perform worse)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -104,7 +104,7 @@ uv tool install pre-commit prek black ruff
 ### Generate and run
 
 ```bash
-# Generate a synthetic project (~700 files)
+# Generate a synthetic project (~6,000 files by default)
 benchmark/generate-project.sh /tmp/hk-bench
 
 # Run benchmarks

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -4,7 +4,7 @@ outline: "deep"
 
 # Built-in Linters Reference
 
-hk provides 90+ pre-configured linters and formatters through the `Builtins` module. These are production-ready configurations that work out of the box.
+hk provides 140+ pre-configured linters and formatters through the `Builtins` module. These are production-ready configurations that work out of the box.
 
 ## Usage
 
@@ -101,5 +101,5 @@ If a builtin doesn't exist for your tool:
 
 ## See Also
 
-- [Configuration Guide](configuration.md)
-- [Getting Started](getting_started.md)
+- [Configuration Guide](/configuration)
+- [Getting Started](/getting_started)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ hk builds its effective configuration by layering sources from lowest to highest
 | 5 | [Environment variables](#settings-reference) (`HK_*`) | Per-invocation |
 | 6 (highest) | [CLI flags](#settings-reference) | Per-invocation |
 
-Higher layers override lower. For hooks and steps, layers are **additive** — hkrc can define hooks the project doesn't have, but the project's definition wins on collision. See [hkrc merge semantics](#hkrc) for details.
+Higher layers override lower. For hooks and steps, layers are **additive** — hkrc can define hooks the project doesn't have, but the project's definition wins on collision. See the [hkrc](#hkrc) section for merge semantics.
 
 ## `hk.pkl`
 
@@ -48,7 +48,7 @@ amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.
 import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
-    // linters can be manually defined
+    // steps can be manually defined
     ["eslint"] {
         // the files to run the linter on, if no files are matched, the linter will be skipped
         // this will filter the staged files and return the subset matching these globs
@@ -61,7 +61,7 @@ local linters = new Mapping<String, Step> {
         // defaults to the step's glob when staging is enabled, so usually not needed
         // stage = List("*.js", "*.ts")
     }
-    // linters can also be specified with the Builtins pkl library
+    // steps can also be pulled from the Builtins pkl library
     ["prettier"] = Builtins.prettier
 }
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -6,12 +6,31 @@ outline: "deep"
 
 Environment variables can be used to configure hk.
 
+Most of these map to settings that can also be configured via CLI flags, git config, `hk.pkl`, or user config—see the
+[Settings Reference](/configuration#settings-reference) for every setting's available sources and precedence. Variables are listed here in alphabetical order.
+
+## `HK_CACHE`
+
+Type: `bool`
+Default: `true` (release builds), `false` (debug builds)
+
+Controls whether hk caches data such as parsed configuration files. Set to `0` or `false` to disable caching.
+
 ## `HK_CACHE_DIR`
 
 Type: `path`
 Default: `~/.cache/hk`
 
 The cache directory to use.
+
+## `HK_CHECK`
+
+Type: `bool`
+Default: `false`
+
+Forces hk to run only check commands (read-only) instead of fix commands. This is the opposite of `HK_FIX` and is equivalent to passing `--check`.
+
+Useful for CI environments where you want to verify code quality without making changes.
 
 ## `HK_CHECK_FIRST`
 
@@ -24,6 +43,29 @@ The reason for this is to make hk able to parallelize as much as possible. We ca
 the same file as we want without them interfering with each other—however we can't have 2 fix commands potentially writing to the same file. So we optimistically run the check commands in parallel, then if any fail we run their fix commands potentially in series.
 
 If this is disabled hk will have simpler logic that just uses fix commands in series in this situation.
+
+## `HK_CONFIG_DIR`
+
+Type: `path`
+Default: `$XDG_CONFIG_HOME/hk` (usually `~/.config/hk`)
+
+The directory hk uses for user configuration such as `~/.config/hk/config.pkl`.
+
+## `HK_DISPLAY_SKIP_REASONS`
+
+Type: `string[]` (comma-separated list)
+Default: `profile-not-enabled`
+
+Controls which skip reasons are displayed when steps are skipped.
+
+Available options:
+
+- `all`: Show all skip reasons
+- `none`: Hide all skip reasons
+- `disabled-by-config`: Show when steps are skipped due to configuration
+- `profile-not-enabled`: Show when steps are skipped due to missing profiles (default)
+
+Example: `HK_DISPLAY_SKIP_REASONS=all` to see all skip reasons.
 
 ## `HK_EXCLUDE`
 
@@ -41,11 +83,12 @@ HK_EXCLUDE=node_modules,dist
 HK_EXCLUDE="**/*.min.js,**/*.map"
 ```
 
-## `HK_PROFILE`
+## `HK_FAIL_FAST`
 
-Type: `string[]` (comma-separated list)
+Type: `bool`
+Default: `true`
 
-The profile(s) to use.
+If `true`, hk will abort running steps after the first one fails.
 
 ## `HK_FILE`
 
@@ -60,106 +103,6 @@ Type: `bool`
 Default: `true`
 
 If set to `false`, hk will not run fix steps.
-
-## `HK_JOBS`
-
-Type: `usize`
-Default: `(number of cores)`
-
-The number of jobs to run in parallel.
-
-## `HK_LOG`
-
-Type: `trace` | `debug` | `info` | `warn` | `error`
-Default: `info`
-
-The log level to use.
-
-## `HK_LOG_FILE`
-
-Type: `path`
-Default: `~/.local/state/hk/hk.log`
-
-The log file to use.
-
-## `HK_LOG_FILE_LEVEL`
-
-Type: `trace` | `debug` | `info` | `warn` | `error`
-Default: `HK_LOG`
-
-The log level to use for the log file.
-
-## `HK_MISE`
-
-Type: `bool`
-Default: `false`
-
-If set to `true`:
-
-- When installing hooks with `hk install`, hk will use `mise x` to execute hooks which won't require activating mise to use mise tools
-- When generating files with `hk init`, hk will create a `mise.toml` file with hk configured
-
-## `HK_SKIP_STEPS`
-
-Type: `string[]` (comma-separated list)
-
-A comma-separated list of step names to skip when running pre-commit and pre-push hooks.
-For example: `HK_SKIP_STEPS=lint,test` would skip any steps named "lint" or "test".
-
-This setting can also be configured via:
-- Git config: `git config hk.skipSteps "step1,step2"`
-- User config (`.hkrc.pkl`): `skip_steps = List("step1", "step2")`
-
-All skip configurations from different sources are unioned together.
-
-## `HK_SKIP_HOOK`
-
-Type: `string[]` (comma-separated list)
-Default: `(empty)`
-
-A comma-separated list of hook names to skip entirely. This allows you to disable specific git hooks from running.
-For example: `HK_SKIP_HOOK=pre-commit,pre-push` would skip running those hooks completely.
-
-This is useful when you want to temporarily disable certain hooks while still keeping them configured in your `hk.pkl` file.
-Unlike `HK_SKIP_STEPS` which skips individual steps, this skips the entire hook and all its steps.
-
-This setting can also be configured via:
-- Git config: `git config hk.skipHook "pre-commit"`
-- User config (`.hkrc.pkl`): `skip_hooks = List("pre-commit")`
-
-All skip configurations from different sources are unioned together.
-
-## `HK_STASH`
-
-Type: `git` | `patch-file` | `none`
-Default: `git`
-
-- `git`: Use `git stash` to stash unstaged changes before running hooks.
-- `patch-file`: Use an hk generated patch file to stash unstaged changes before running hooks (typically faster and avoids `index is locked` errors).
-- `none`: Do not stash unstaged changes before running hooks. Much faster but will stage unstaged changes if they are in the same file as staged changes with fix modifications.
-
-## `HK_STASH_UNTRACKED`
-
-Type: `bool`
-Default: `true`
-
-If set to `true`, hk will stash untracked files when stashing before running hooks.
-
-When set to `false`, hk also skips the untracked-file scan entirely (`git status --untracked-files=no`). This is the recommended setting when `GIT_WORK_TREE` points at a very large directory such as `$HOME` (e.g. a YADM dotfiles repo), where scanning for untracked files can take tens of seconds. Untracked files will not appear in reports or `hk check --all` results in this mode.
-
-## `HK_FAIL_FAST`
-
-Type: `bool`
-Default: `true`
-
-If `true`, hk will abort running steps after the first one fails.
-
-## `HK_STATE_DIR`
-
-Type: `path`
-Default: `~/.local/state/hk`
-
-The state directory to use.
 
 ## `HK_HIDE_WARNINGS`
 
@@ -178,22 +121,28 @@ Example usage:
 HK_HIDE_WARNINGS=missing-profiles hk check
 ```
 
-## Config warnings list
-
-You can opt-in to specific warning categories in `hk.pkl` or `.hkrc.pkl`. By default this is empty.
-
-Example:
-
-```pkl
-warnings = List("missing-profiles")
-```
-
 ## `HK_HIDE_WHEN_DONE`
 
 Type: `bool`
 Default: `false`
 
 If set to `true`, hk will hide the progress output when the hook finishes if there are no errors.
+
+## `HK_JOBS`
+
+Type: `usize`
+Default: `(number of cores)`
+
+The number of jobs to run in parallel. `HK_JOB` is accepted as an alias.
+
+## `HK_JSON`
+
+Type: `bool`
+Default: `false`
+
+Enables JSON output format for structured data, equivalent to passing `--json`. Useful for integration with other tools or for programmatic processing of results.
+
+Example: `hk check --json | jq '.steps[] | select(.failed)'`
 
 ## `HK_LIBGIT2`
 
@@ -202,6 +151,169 @@ Default: `true`
 
 If set to `false`, hk will not use libgit2 to interact with git and instead use shelling out to git commands. This may provide better performance
 in some cases such as when using `fsmonitor` to watch for changes.
+
+## `HK_LOG`
+
+Type: `off` | `error` | `warn` | `info` | `debug` | `trace`
+Default: `info`
+
+The log level to use. `HK_LOG_LEVEL` is accepted as an alias.
+
+## `HK_LOG_FILE`
+
+Type: `path`
+Default: `~/.local/state/hk/hk.log`
+
+The log file to use.
+
+## `HK_LOG_FILE_LEVEL`
+
+Type: `off` | `error` | `warn` | `info` | `debug` | `trace`
+Default: `HK_LOG`
+
+The log level to use for the log file.
+
+## `HK_MISE`
+
+Type: `bool`
+Default: `false`
+
+If set to `true`:
+
+- When installing hooks with `hk install`, hk will use `mise x` to execute hooks which won't require activating mise to use mise tools
+- When generating files with `hk init`, hk will create a `mise.toml` file with hk configured
+
+## `HK_PKL_BACKEND`
+
+Type: `pkl` | `pklr`
+Default: `pklr`
+
+Selects the evaluator used to read `hk.pkl`. Set to `pkl` to use the pkl CLI instead of the built-in pklr evaluator.
+
+## `HK_PKL_CA_CERTIFICATES`
+
+Type: `path`
+
+A path to a CA certificates file to provide `pkl`'s `--ca-certificates` flag when invoking `pkl`.
+
+This is useful in corporate environments with SSL-intercepting proxies where pkl needs to trust custom CA certificates to download packages.
+
+This variable is read directly from the environment before pkl is invoked, so it cannot be configured in `hk.pkl`.
+
+## `HK_PKL_HTTP_REWRITE`
+
+Type: `string`
+
+A value to provide `pkl`'s `--http-rewrite` flag when invoking `pkl`, in the form `http(s)://<FROM>/=http(s)://<TO>/`.
+
+This variable is read directly from the environment before pkl is invoked, so it cannot be configured in `hk.pkl`.
+
+## `HK_PROFILE`
+
+Type: `string[]` (comma-separated list)
+
+The profile(s) to enable. Prefix a profile with `!` to explicitly disable it. `HK_PROFILES` is accepted as an alias.
+
+Example usage:
+
+- `HK_PROFILE=ci` - Enable the CI profile
+- `HK_PROFILE=slow,ci` - Enable multiple profiles
+
+## `HK_SKIP_HOOK`
+
+Type: `string[]` (comma-separated list)
+Default: `(empty)`
+
+A comma-separated list of hook names to skip entirely. This allows you to disable specific git hooks from running.
+For example: `HK_SKIP_HOOK=pre-commit,pre-push` would skip running those hooks completely. `HK_SKIP_HOOKS` is accepted as an alias.
+
+This is useful when you want to temporarily disable certain hooks while still keeping them configured in your `hk.pkl` file.
+Unlike `HK_SKIP_STEPS` which skips individual steps, this skips the entire hook and all its steps.
+
+This setting can also be configured via:
+- Git config: `git config hk.skipHook "pre-commit"`
+- User config (`~/.config/hk/config.pkl`): `skip_hooks = List("pre-commit")`
+
+All skip configurations from different sources are unioned together.
+
+## `HK_SKIP_STEPS`
+
+Type: `string[]` (comma-separated list)
+
+A comma-separated list of step names to skip when running pre-commit and pre-push hooks.
+For example: `HK_SKIP_STEPS=lint,test` would skip any steps named "lint" or "test". `HK_SKIP_STEP` is accepted as an alias.
+
+This setting can also be configured via:
+- Git config: `git config hk.skipSteps "step1,step2"`
+- User config (`~/.config/hk/config.pkl`): `skip_steps = List("step1", "step2")`
+
+All skip configurations from different sources are unioned together.
+
+## `HK_STAGE`
+
+Type: `bool`
+
+When set, overrides the [hook's `stage` key](/configuration#hooks-hook-stage-boolean), which controls whether hk automatically stages files modified by fix commands.
+
+This is useful when you want to manually review changes made by auto-fixers before including them in your commit.
+
+## `HK_STASH`
+
+Type: `git` | `patch-file` | `none`
+Default: `none`
+
+Overrides the [hook-level `stash` setting](/configuration), which defaults to `none`.
+
+- `git`: Use `git stash` to stash unstaged changes before running hooks.
+- `patch-file`: Currently an alias of the `git` behavior.
+- `none`: Do not stash unstaged changes before running hooks. Fastest option, but fix steps may modify unstaged changes if they are in the same file as staged changes.
+
+In `hk.pkl`, the hook-level `stash` key also accepts booleans: `true` is an alias of `"git"` and `false` is an alias of `"none"`.
+
+## `HK_STASH_BACKUP_COUNT`
+
+Type: `usize`
+Default: `20`
+
+Number of backup patch files to keep per repository when using git stash. Each time git stash is used, hk creates a backup patch file in `$HK_STATE_DIR/patches/`; the oldest backups beyond this count are automatically deleted.
+
+Set to `0` to disable patch backup creation entirely.
+
+## `HK_STASH_UNTRACKED`
+
+Type: `bool`
+Default: `true`
+
+If set to `true`, hk will stash untracked files when stashing before running hooks.
+
+When set to `false`, hk also skips the untracked-file scan entirely (`git status --untracked-files=no`). This is the recommended setting when `GIT_WORK_TREE` points at a very large directory such as `$HOME` (e.g. a YADM dotfiles repo), where scanning for untracked files can take tens of seconds. Untracked files will not appear in reports or `hk check --all` results in this mode.
+
+## `HK_STATE_DIR`
+
+Type: `path`
+Default: `~/.local/state/hk`
+
+The state directory to use.
+
+## `HK_SUMMARY_TEXT`
+
+Type: `bool`
+Default: `false`
+
+Controls whether per-step output summaries are printed in plain text mode. In text mode, hk only emits summaries for **failed** steps by default (so CI logs always include the full diagnostic for a failure). Successful steps stream their output during execution, so a trailing summary would just duplicate it. Set this to `true` to force summaries to appear for every step in text mode.
+
+Example:
+
+```bash
+HK_SUMMARY_TEXT=1 hk check
+```
+
+## `HK_TERMINAL_PROGRESS`
+
+Type: `bool`
+Default: `true`
+
+Enables or disables reporting progress via OSC sequences to compatible terminals.
 
 ## `HK_TIMING_JSON`
 
@@ -234,15 +346,39 @@ Example output shape:
 }
 ```
 
-## `HK_SUMMARY_TEXT`
+## `HK_TRACE`
+
+Type: `off` | `text` | `json` | `1` | `true`
+Default: `off`
+
+Enables tracing spans and performance diagnostics for detailed execution analysis.
+
+- `off`: No tracing (default)
+- `text` (or the aliases `1` / `true`): Human-readable trace output
+- `json`: Machine-readable JSON trace output
+
+Example: `HK_TRACE=text hk check` to see detailed execution traces.
+
+## `HK_WALK_IGNORE`
 
 Type: `bool`
-Default: `false`
+Default: `true`
 
-Controls whether per-step output summaries are printed in plain text mode. In text mode, hk only emits summaries for **failed** steps by default (so CI logs always include the full diagnostic for a failure). Successful steps stream their output during execution, so a trailing summary would just duplicate it. Set this to `true` to force summaries to appear for every step in text mode.
+Controls whether hk respects `.gitignore` and other ignore files when walking directories.
 
-Example:
+When enabled (default), hk will skip files matching patterns in `.gitignore`, `.ignore`, and other standard ignore files when discovering files for linting. This improves performance by not processing generated files, build artifacts, or vendored dependencies.
 
-```bash
-HK_SUMMARY_TEXT=1 hk check
+When disabled, all files are included regardless of ignore patterns.
+
+Example: `HK_WALK_IGNORE=0 hk check --all` to include all files.
+
+## `HK_WARNINGS`
+
+Type: `string[]` (comma-separated list)
+Default: `(empty)`
+
+Warning tags to enable. This can also be configured in `hk.pkl` or user config:
+
+```pkl
+warnings = List("missing-profiles")
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -102,21 +102,21 @@ Separately from global *hooks*, you can also create a global *config* file that 
 
 ## `hk.pkl`
 
-This will generate a `hk.pkl` file in the root of the repository, here's an example `hk.pkl` with eslint and prettier linters:
+`hk init` generates an `hk.pkl` file in the root of the repository. Here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
 amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
 import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
-    // linters can be manually defined
+    // steps can be manually defined
     ["eslint"] {
         // the files to run the linter on, if no files are matched, the linter will be skipped
         glob = List("*.js", "*.ts")
         // a command that returns non-zero to fail the check
         check = "eslint {{files}}"
     }
-    // linters can also be specified with the builtins pkl library
+    // steps can also be pulled from the builtins pkl library
     ["prettier"] = Builtins.prettier
     // with pkl, builtins can also be extended:
     ["prettier-yaml"] = (Builtins.prettier) {

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -20,7 +20,7 @@ steps {
 }
 ```
 
-See: [Step Dependencies](/configuration.md#step-depends-list-string)
+See: [Step Dependencies](/configuration#step-depends-list-string)
 
 ## Group
 
@@ -38,7 +38,7 @@ steps {
 }
 ```
 
-See: [Group Configuration](/configuration.md#group)
+See: [Group Configuration](/configuration#group)
 
 ## Hook
 
@@ -55,7 +55,7 @@ hooks {
 }
 ```
 
-See: [Hooks](/hooks.md)
+See: [Hooks](/hooks)
 
 ## Job
 
@@ -70,7 +70,7 @@ hk check --jobs 4
 HK_JOBS=8 hk fix
 ```
 
-See: [HK_JOBS](/environment_variables.md#hk_jobs)
+See: [HK_JOBS](/environment_variables#hk-jobs)
 
 ## Skip
 
@@ -85,7 +85,7 @@ HK_SKIP_STEPS=lint,test hk run pre-commit
 HK_SKIP_HOOK=pre-commit,pre-push git commit
 ```
 
-See: [HK_SKIP_STEPS](/environment_variables.md#hk_skip_steps), [HK_SKIP_HOOK](/environment_variables.md#hk_skip_hook)
+See: [HK_SKIP_STEPS](/environment_variables#hk-skip-steps), [HK_SKIP_HOOK](/environment_variables#hk-skip-hook)
 
 ## Stash
 
@@ -93,8 +93,8 @@ A strategy for temporarily saving unstaged changes before running hooks that mig
 
 Stash strategies:
 - `git`: Uses `git stash`
-- `patch-file`: Uses hk-generated patch files (faster, avoids lock conflicts)
-- `none`: No stashing (fastest, but may cause staging conflicts)
+- `patch-file`: Currently an alias of the `git` strategy
+- `none`: No stashing (fastest, but may cause staging conflicts; the default)
 
 Example:
 ```pkl
@@ -106,7 +106,7 @@ hooks {
 }
 ```
 
-See: [HK_STASH](/environment_variables.md#hk_stash)
+See: [HK_STASH](/environment_variables#hk-stash)
 
 ## Step
 
@@ -124,4 +124,4 @@ steps {
 }
 ```
 
-See: [Step Configuration](/configuration.md#hooks-hook-steps-step-group)
+See: [Step Configuration](/configuration#hooks-hook-steps-step-group)

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hooks
 
-The following describes the behavior of git hooks that hk supports. Each linter provides a "check" and "fix" commands. "check" commands are read-only and can be run in parallel. "fix" commands can edit files and will block other "fix" or "check" commands from running at the same time. Note that hk does not enforce that "check" commands do not write to files for performance reasons however you still should try to follow this convention in order for hk to behave as expected.
+The following describes the behavior of git hooks that hk supports. Each step provides a "check" and a "fix" command. "check" commands are read-only and can be run in parallel. "fix" commands can edit files and will block other "fix" or "check" commands from running at the same time. Note that hk does not enforce that "check" commands do not write to files for performance reasons however you still should try to follow this convention in order for hk to behave as expected.
 
 It's the read/write locking behavior that hk makes use of in order to run hooks as fast as possible while still being safe.
 
@@ -8,16 +8,16 @@ It's the read/write locking behavior that hk makes use of in order to run hooks 
 
 hk hooks perform the following assuming `fix = true`:
 
-* Stashes any untracked/unstaged changes (disable with [`HK_STASH=none`](/configuration#hk-stash))
+* Stashes any untracked/unstaged changes if stashing is enabled—it is off by default, see [`HK_STASH`](/environment_variables#hk-stash)
 * Gathers list of files with staged changes (or all files if running `hk run pre-commit --all`)
-* Runs linters and hook steps in parallel up to [`HK_JOBS`](/configuration#hk-jobs) at a time, with caveats:
+* Runs linters and hook steps in parallel up to [`HK_JOBS`](/environment_variables#hk-jobs) at a time, with caveats:
   * `exclusive = true` hook steps will wait until all previous steps finished and block later steps from starting
   * if any hook step has any dependencies, hk will wait for them to complete before starting
   * hk will create read/write locks for each file (according to the linter's glob patterns) to check/fix in the linters unless `stomp = true`
   * if `check_first = true` on the linter, hk will run the "check" command first with read locks, if that fails, it will run the "fix" command with write locks on all the files
   * if a `check_list_files` command is available on the linter, hk will use the output of that command to filter the list of files to get write locks for and call "fix" on.
   * if `check_first = false` on the linter, hk will run the "fix" command after fetching write locks, blocking other linters from running. You
-    should avoid this performance.
+    should avoid this configuration for performance reasons.
   * if any of the files have been modified and match the `stage` globs, they will be added to the git index (defaults to the step's `glob` for steps with a `fix` command)
 * untracked/unstaged changes are unstashed
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -11,8 +11,8 @@ hk provides several ways to control logging output for debugging issues and unde
 hk supports standard log levels that control the amount of information displayed:
 
 - **error**: Only show error messages
-- **warn**: Show warnings and errors (default)
-- **info**: Show informational messages, warnings, and errors
+- **warn**: Show warnings and errors
+- **info**: Show informational messages, warnings, and errors (default)
 - **debug**: Show debug information including file operations and step execution details
 - **trace**: Show detailed trace information including all internal operations
 
@@ -181,8 +181,8 @@ To see how configuration is being loaded and processed:
 # Validate configuration with verbose output
 hk validate -v
 
-# Check which steps would run
-HK_LOG=debug hk check --dry-run
+# Check which steps would run without running them
+hk check --plan
 ```
 
 ### Debugging Git Hook Issues

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -45,12 +45,16 @@ Just run mise in `hk.pkl` like any other command:
 ```pkl
 amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
 
-`pre-commit` {
-    ["prelint"] {
-        check = "mise run prelint"
-        exclusive = true // ensures this completes before the next steps
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["prelint"] {
+                check = "mise run prelint"
+                exclusive = true // ensures this completes before the next steps
+            }
+            // ... more steps ...
+        }
     }
-    // ... more steps ...
 }
 ```
 

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -52,8 +52,8 @@ hooks {
     fix = true
     steps {
       ["prelint"] {
-        command = "lint"
-        args = ["--fix"]
+        check = "mise run prelint"
+        exclusive = true
       }
     }
   }
@@ -98,10 +98,10 @@ Listings are for more complex ordered collections:
 
 ```pkl
 my_listing = new Listing<Step> {
-  new LinterStep {
+  new Step {
     check = "make lint"
   }
-  new LinterStep {
+  new Step {
     check = "make format"
   }
 }
@@ -112,7 +112,7 @@ my_listing = new Listing<Step> {
 hk will complain if you attempt to export variables that it doesn't expect, so you'll likely need to use the `local` keyword to create local variables:
 
 ```pkl
-local my_step = new LinterStep {
+local my_step = new Step {
   check = "make lint"
 }
 ```
@@ -122,7 +122,7 @@ local my_step = new LinterStep {
 You typically won't define your own class with an hk config, but you will instantiate the ones provided by [Config.pkl](https://github.com/jdx/hk/blob/main/pkl/Config.pkl):
 
 ```pkl
-local my_step = new LinterStep {
+local my_step = new Step {
   check = "make lint"
 }
 ```
@@ -132,14 +132,14 @@ local my_step = new LinterStep {
 If you want to use shared object but amend it with modifications, you do that with this syntax:
 
 ```pkl
-local make_lint = new LinterStep {
+local make_lint = new Step {
   check = "make lint"
 }
 local linters = new Mapping<String, Step> {
-  ["make-lint"] = (make_lint) {
+  ["make-lint-a"] = (make_lint) {
     dir = "proj_a"
   }
-  ["make-lint"] = (make_lint) {
+  ["make-lint-b"] = (make_lint) {
     dir = "proj_b"
   }
 }
@@ -149,11 +149,11 @@ Essentially this is the same as:
 
 ```pkl
 local linters = new Mapping<String, Step> {
-  ["make-lint"] = new LinterStep {
+  ["make-lint-a"] = new Step {
     check = "make lint"
     dir = "proj_a"
   }
-  ["make-lint"] = new LinterStep {
+  ["make-lint-b"] = new Step {
     check = "make lint"
     dir = "proj_b"
   }
@@ -184,12 +184,12 @@ Share code between files by importing:
 
 ```pkl
 import "./extra.pkl"
-# do something with `extra`
+// do something with `extra`
 
 import "https://example.com/remote.pkl"
-# do something with `remote`
+// do something with `remote`
 ```
 
 ## Caching
 
-hk will cache the output of parsing each `hk.pkl` file until it is modified. For now, I would discouraging using features like env vars inside of `hk.pkl` files as the cache will not be invalidated if the env vars change. Perhaps this could be fixed somehow.
+hk will cache the output of parsing each `hk.pkl` file until it is modified. For now, I would discourage using features like env vars inside of `hk.pkl` files as the cache will not be invalidated if the env vars change. Perhaps this could be fixed somehow.

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -6,7 +6,6 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-
 amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
 import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
@@ -95,25 +94,27 @@ local all_linters = new Mapping<String, Step> {
 hooks {
   ["pre-commit"] {
     fix = true
-    stash = "patch-file"  // Use patch file instead of git stash
+    stash = "patch-file" // Use patch file instead of git stash
     steps = all_linters
   }
   ["check"] {
     steps = all_linters
     // Generate a report after checking
-    report = #"""
-      echo "Check completed at $(date)"
-      echo "Results: $HK_REPORT_JSON" | jq '.'
-    """#
+    report =
+      #"""
+        echo "Check completed at $(date)"
+        echo "Results: $HK_REPORT_JSON" | jq '.'
+      """#
   }
 }
 
 // Show additional skip reasons for debugging
-display_skip_reasons = List(
-  "profile-not-enabled",
-  "no-files-to-process",
-  "condition-false"
-)
+display_skip_reasons =
+  List(
+    "profile-not-enabled",
+    "no-files-to-process",
+    "condition-false",
+  )
 
 // Environment variables for all steps
 env {
@@ -129,7 +130,3 @@ Example configuration with custom linters and platform-specific commands
 * Demonstrates platform-specific commands
 * Uses conditions and workspace indicators
 * Shows test configuration
-
-## Key Features
-
-- Standard configuration

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -6,7 +6,6 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-
 amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
 import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
@@ -61,7 +60,3 @@ Example configuration for a JavaScript/TypeScript project
 * Uses eslint for linting
 * Runs type checking with tsc
 * Enables automatic fixes in pre-commit
-
-## Key Features
-
-- Standard configuration

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -7,7 +7,6 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-
 amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
 import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
 
@@ -19,15 +18,15 @@ local python_linters = new Mapping<String, Step> {
   }
   // Ruff formatter for code formatting
   ["ruff_format"] = (Builtins.ruff_format) {
-    depends = "ruff"  // Run after ruff
+    depends = "ruff" // Run after ruff
   }
   // Black for consistent formatting (alternative to ruff_format)
   ["black"] = (Builtins.black) {
-    depends = "ruff_format"  // Run after ruff_format
+    depends = "ruff_format" // Run after ruff_format
   }
   // isort for import sorting
   ["isort"] = (Builtins.isort) {
-    depends = "black"  // Run after black
+    depends = "black" // Run after black
   }
   // Type checking with mypy
   ["mypy"] = (Builtins.mypy) {
@@ -77,7 +76,3 @@ Example configuration for a Python project
 * Uses mypy for type checking
 * Sorts imports with isort
 * Validates with flake8
-
-## Key Features
-
-- Standard configuration

--- a/docs/why-hk.md
+++ b/docs/why-hk.md
@@ -110,7 +110,7 @@ Both require Node.js. If your project isn't a JS project, you're adding a runtim
 | Language | Rust | Python | Go | Rust |
 | Requires Python | No | Yes | No | Often* |
 | Config format | Pkl | YAML | YAML | YAML |
-| Built-in linter configs | [120+](/builtins) | — | — | — |
+| Built-in linter configs | [140+](/builtins) | — | — | — |
 | Plugin model | Pkl config (local) | Git repos (remote) | Shell commands | Git repos (remote) |
 | check_diff support | Yes | No | No | No |
 | check_list_files support | Yes | No | No | No |

--- a/scripts/generate-examples.sh
+++ b/scripts/generate-examples.sh
@@ -37,11 +37,6 @@ $(cat "$pkl_file")
 ## Description
 
 $(grep -E "^///" "$pkl_file" 2>/dev/null | sed 's|^///[ ]*||' || echo "No description available.")
-
-## Key Features
-
-$(grep -E "^//\s+\*" "$pkl_file" 2>/dev/null | sed 's|^//[ ]*||' || echo "- Standard configuration")
-
 EOF
 done
 

--- a/settings.toml
+++ b/settings.toml
@@ -437,8 +437,10 @@ Strategy for temporarily saving unstaged changes before running hooks that might
 
 Available strategies:
 - `git`: Use `git stash` to stash changes
-- `patch-file`: Use hk-generated patch files (typically faster, avoids "index is locked" errors)
+- `patch-file`: Currently an alias of the `git` behavior
 - `none`: No stashing (fastest, but may cause staging conflicts if fixes modify unstaged changes in the same file)
+
+If not set, the hook-level `stash` setting applies (default: `none`).
 """
 
 [stash_untracked]


### PR DESCRIPTION
## Summary

Documentation accuracy pass: audited the docs against `src/env.rs`, `settings.toml`, and `pkl/Config.pkl` and fixed everything that had drifted from the code.

### Factual fixes
- **`HK_STASH` default corrected**: docs claimed `git`; the actual default is `none` (`pkl/Config.pkl` `Hook.stash`). Also corrected the `patch-file` description everywhere (env var docs, `settings.toml` doc string, glossary) — it is currently an alias of the `git` behavior, not a faster separate implementation.
- **`environment_variables.md` rewritten** (alphabetical): adds previously undocumented vars — `HK_CACHE`, `HK_CHECK`, `HK_CONFIG_DIR`, `HK_DISPLAY_SKIP_REASONS`, `HK_JSON`, `HK_PKL_BACKEND`, `HK_PKL_CA_CERTIFICATES`, `HK_PKL_HTTP_REWRITE`, `HK_STASH_BACKUP_COUNT`, `HK_TERMINAL_PROGRESS`, `HK_TRACE`, `HK_WALK_IGNORE`, `HK_WARNINGS` — and documents the env var aliases (`HK_LOG_LEVEL`, `HK_JOB`, `HK_PROFILES`, `HK_SKIP_STEP`, `HK_SKIP_HOOKS`) from `settings.toml`.
- **`pkl_introduction.md`**: examples referenced a nonexistent `LinterStep` class (it's `Step`), used duplicate mapping keys (invalid pkl), `#` as a pkl comment, and `command`/`args` fields that don't exist on `Step`.
- **`logging.md`**: default log level is `info`, not `warn`; `hk check --dry-run` doesn't exist — replaced with `--plan`.
- **`mise_integration.md`**: the task example wasn't valid hk.pkl (missing `hooks`/`steps` structure).
- **Builtin count**: 141 builtins exist; updated "90+" (builtins.md) and "120+" (why-hk.md) to 140+.
- **`hooks.md`**: stashing described as on-by-default (it defaults to `none` now); grammar fixes.

### Link fixes
- `hooks.md` linked `HK_STASH`/`HK_JOBS` to `/configuration#hk-stash`/`#hk-jobs` — those anchors don't exist; now point at `/environment_variables`.
- `glossary.md` anchors used underscore form (`#hk_stash`) which VitePress never generates (its slugifier turns `_` into `-`); normalized `.md`-suffixed links too.

### Generated example pages
- `scripts/generate-examples.sh` always emitted a "Key Features — Standard configuration" filler section (its grep pattern never matches); removed the section and regenerated the pages from the current `docs/public/*.pkl` sources. `monorepo.md` was left untouched since it has diverged from the generator with hand-written content.

## Verification
- `mise run docs:gen` regenerates includes cleanly
- VitePress build passes (`aube run docs:build`), which validates internal page links
- `hk check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and example-generation script only; no runtime or config semantics changed in code.
> 
> **Overview**
> **Documentation accuracy and navigation** — the PR brings user-facing docs in line with `pkl/Config.pkl`, `settings.toml`, and runtime behavior, without changing application code.
> 
> **Defaults and behavior** — **`HK_STASH` / hook `stash`** are documented as defaulting to **`none`** (not `git`), with **`patch-file`** described as an alias of **`git`** everywhere that mattered (`environment_variables.md`, `glossary.md`, `hooks.md`, `settings.toml`). Builtin counts move to **140+**; benchmark repro notes **~6,000** synthetic files.
> 
> **`environment_variables.md`** is reorganized **alphabetically** and substantially expanded: new sections for vars like **`HK_CACHE`**, **`HK_CHECK`**, **`HK_CONFIG_DIR`**, **`HK_JSON`**, **`HK_PKL_*`**, **`HK_TRACE`**, **`HK_WALK_IGNORE`**, **`HK_WARNINGS`**, plus **env aliases** (`HK_LOG_LEVEL`, `HK_JOB`, etc.) and cross-links to the settings reference.
> 
> **Examples and copy** — **`pkl_introduction.md`** fixes invalid examples (`Step` not `LinterStep`, duplicate keys, comment syntax). **`mise_integration.md`** uses proper `hooks` / `steps` structure. **`logging.md`** sets default log level to **`info`** and replaces nonexistent **`--dry-run`** with **`--plan`**. Terminology shifts from “linters” to **steps** in several guides; prose and link targets are normalized for VitePress (`/configuration`, hyphenated anchors).
> 
> **Generator** — **`scripts/generate-examples.sh`** drops the unused “Key Features” block; example markdown under **`docs/reference/examples/`** is regenerated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19add5678fa42dc6842a8cc40dad84db365f8c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->