### PR TITLE
Update sponsor references for jdx.dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
             TAG_NAME="${GITHUB_REF_NAME}"
           fi
           communique generate "$TAG_NAME" --github-release
-      - name: Append en.dev sponsor blurb
+      - name: Append jdx.dev sponsor blurb
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUTS_VERSION: ${{ inputs.version }}
@@ -226,9 +226,9 @@ jobs:
           cat <<'EOF' >> /tmp/release-notes.md
           ## 💚 Sponsor hk
 
-          hk is developed by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev) — a small independent studio behind developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Work on hk is funded by sponsorships.
+          hk is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), and more. Work on hk is funded by sponsorships.
 
-          If hk has sped up your pre-commit loop or made linting feel less painful, please consider [sponsoring at en.dev](https://en.dev). Sponsorships are what keep hk moving and the project independent.
+          If hk has sped up your pre-commit loop or made linting feel less painful, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Sponsorships are what keep hk moving and the project independent.
           EOF
 
           gh release edit "$TAG_NAME" --notes-file /tmp/release-notes.md

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See docs: https://hk.jdx.dev/
 
 ## Sponsors
 
-hk is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), and [CodeRabbit](https://coderabbit.link/mise).
+hk is sponsored by [entire.io](https://entire.io) and [37signals](https://37signals.com).
 
 [View all sponsors](https://jdx.dev/sponsors.html).
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See docs: https://hk.jdx.dev/
 
 ## Sponsors
 
-hk is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), [CodeRabbit](https://coderabbit.link/mise), and [Supabase](https://supabase.com).
+hk is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), and [CodeRabbit](https://coderabbit.link/mise).
 
 [View all sponsors](https://jdx.dev/sponsors.html).
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ See docs: https://hk.jdx.dev/
 
 ## Sponsors
 
-hk is sponsored by [37signals](https://37signals.com).
+hk is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), [CodeRabbit](https://coderabbit.link/mise), and [Supabase](https://supabase.com).
 
-[View all sponsors](https://en.dev/sponsors.html).
+[View all sponsors](https://jdx.dev/sponsors.html).
 
 ## Demo
 

--- a/docs/.vitepress/theme/EndevFooter.vue
+++ b/docs/.vitepress/theme/EndevFooter.vue
@@ -4,15 +4,15 @@
     <span aria-hidden="true">·</span>
     <span>Copyright © {{ year }}</span>
     <span aria-hidden="true">·</span>
-    <a class="EndevFooterLink" href="https://en.dev">
+    <a class="EndevFooterLink" href="https://jdx.dev">
       <img
         alt=""
         class="EndevFooterLogo"
         height="28"
-        src="https://github.com/endevco.png?size=96"
+        src="https://github.com/jdx.png?size=96"
         width="28"
       />
-      <span>en.dev</span>
+      <span>jdx.dev</span>
     </a>
   </footer>
 </template>

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -35,7 +35,7 @@ import { onMounted, ref } from "vue";
 
 const sponsors = ref([]);
 const error = ref(false);
-const footerTiers = new Set(["anchor", "premier", "partner"]);
+const footerTiers = new Set(["title", "premier", "partner"]);
 const sponsorFeedTimeoutMs = 5000;
 
 const sponsorItems = (items) => (Array.isArray(items) ? items : []);

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -23,7 +23,7 @@
           <img :alt="sponsor.name" :src="sponsor.logo" loading="lazy" decoding="async" />
         </a>
       </div>
-      <a class="EndevSponsorsCta" href="https://en.dev/sponsors.html">
+      <a class="EndevSponsorsCta" href="https://jdx.dev/sponsors.html">
         View all sponsors
       </a>
     </div>
@@ -61,7 +61,7 @@ onMounted(async () => {
   const timeout = window.setTimeout(() => controller.abort(), sponsorFeedTimeoutMs);
 
   try {
-    const res = await fetch("https://en.dev/sponsors.json", {
+    const res = await fetch("https://jdx.dev/sponsors.json", {
       headers: { Accept: "application/json" },
       signal: controller.signal,
     });

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -4102,7 +4102,7 @@
         "flags": [],
         "mounts": [],
         "hide": false,
-        "help": "Show the companies sponsoring hk and the en.dev project family",
+        "help": "Show the companies sponsoring hk and the jdx.dev open source tools",
         "name": "sponsors",
         "aliases": [],
         "hidden_aliases": [],

--- a/docs/cli/sponsors.md
+++ b/docs/cli/sponsors.md
@@ -4,4 +4,4 @@
 
 - **Usage**: `hk sponsors`
 
-Show the companies sponsoring hk and the en.dev project family
+Show the companies sponsoring hk and the jdx.dev open source tools

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -606,7 +606,7 @@ cmd run help="Run a hook" {
         arg "[FILES]…" help="Run on specific files" required=#false var=#true
     }
 }
-cmd sponsors help="Show the companies sponsoring hk and the en.dev project family"
+cmd sponsors help="Show the companies sponsoring hk and the jdx.dev open source tools"
 cmd test help="Run step-defined tests" {
     flag --list help="List tests without running"
     flag --name help="Filter by test name (repeatable)" var=#true {

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -1,13 +1,13 @@
 use crate::Result;
 
-/// Show the companies sponsoring hk and the en.dev project family
+/// Show the companies sponsoring hk and the jdx.dev open source tools
 #[derive(Debug, clap::Args)]
 pub struct Sponsors {}
 
 impl Sponsors {
     pub async fn run(&self) -> Result<()> {
         println!(
-            "hk and the en.dev project family are sponsored by:\n\n  37signals - https://37signals.com\n\nView all sponsors: https://en.dev/sponsors.html"
+            "hk and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n  Supabase - https://supabase.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -7,7 +7,7 @@ pub struct Sponsors {}
 impl Sponsors {
     pub async fn run(&self) -> Result<()> {
         println!(
-            "hk and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n  Supabase - https://supabase.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+            "hk and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -7,7 +7,7 @@ pub struct Sponsors {}
 impl Sponsors {
     pub async fn run(&self) -> Result<()> {
         println!(
-            "hk and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n\nView all sponsors: https://jdx.dev/sponsors.html"
+            "hk and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- list Entire first in the README and sponsors command
- point sponsor feed/page links at jdx.dev
- update docs sponsor/footer copy and generated CLI docs

## Tests
- git diff --check
- npm run docs:build from docs/
- mise exec -- cargo run -q -p hk --bin hk -- sponsors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and URL updates only; no runtime or security-sensitive logic changes beyond relying on the jdx.dev sponsor feed tier name `title`.
> 
> **Overview**
> Repoints **sponsor branding** from **en.dev** to **jdx.dev** and highlights **entire.io** as title sponsor across README, docs, CLI, and release automation.
> 
> The **README** and **`hk sponsors`** output now list **entire.io** first alongside 37signals, and sponsor links use **jdx.dev/sponsors.html**. Docs footer and sponsor widgets fetch **jdx.dev/sponsors.json**, link to **jdx.dev**, and filter footer tiers with **`title`** instead of **`anchor`**.
> 
> Generated CLI docs (**`hk.usage.kdl`**, **`commands.json`**, **`sponsors.md`**) and the **release workflow** sponsor blurb match the new copy and URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1f6864f6a7203631f5fccdaed1bc338e8bc24c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->