### PR TITLE
install: append --staged to pre-commit hook command by default

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -379,7 +379,12 @@ fn write_config_hook(scope: &str, command: &OsStr, event: &str) -> Result<()> {
     // with `HK=0 git commit` under config-based hooks.
     let mut cmd_value = OsString::from(r#"test "${HK:-1}" = "0" || "#);
     cmd_value.push(command);
-    cmd_value.push(format!(r#" run {event} --from-hook "$@""#));
+    // `--staged` on pre-commit restricts the run to staged files only and
+    // suppresses hk's internal `git stash`. It's the safe default for a
+    // pre-commit hook: an unstaged file cannot be silently drifted or lost
+    // by a failed stash/unstash cycle.
+    let staged_suffix = if event == "pre-commit" { " --staged" } else { "" };
+    cmd_value.push(format!(r#" run {event} --from-hook{staged_suffix} "$@""#));
 
     run_git([
         OsString::from("config"),
@@ -498,9 +503,12 @@ where
 }
 
 fn git_hook_content(hk: &str, hook: &str) -> String {
+    // `--staged` on pre-commit restricts the run to staged files only and
+    // suppresses hk's internal `git stash`. Safe default; see write_config_hook.
+    let staged_suffix = if hook == "pre-commit" { " --staged" } else { "" };
     format!(
         r#"#!/bin/sh
-test "${{HK:-1}}" = "0" || exec {hk} run {hook} --from-hook "$@"
+test "${{HK:-1}}" = "0" || exec {hk} run {hook} --from-hook{staged_suffix} "$@"
 "#
     )
 }
@@ -594,5 +602,29 @@ mod tests {
         let quoted = shell_quote_path(path);
 
         assert!(quoted.into_vec().contains(&0xFF));
+    }
+
+    #[test]
+    fn git_hook_content_appends_staged_for_pre_commit() {
+        let out = git_hook_content("hk", "pre-commit");
+        assert!(
+            out.contains("--from-hook --staged"),
+            "pre-commit hook script must include --staged: {out}",
+        );
+    }
+
+    #[test]
+    fn git_hook_content_omits_staged_for_non_pre_commit() {
+        for event in ["commit-msg", "pre-push", "prepare-commit-msg", "post-commit"] {
+            let out = git_hook_content("hk", event);
+            assert!(
+                out.contains("--from-hook \"$@\""),
+                "{event} hook script must not append --staged: {out}",
+            );
+            assert!(
+                !out.contains("--staged"),
+                "{event} hook script must not include --staged: {out}",
+            );
+        }
     }
 }


### PR DESCRIPTION
install: append --staged to pre-commit hook command by default

hk install (both --global config-based hooks and per-repo shim hooks) now appends --staged to the pre-commit command:

    test "${HK:-1}" = "0" || hk run pre-commit --from-hook --staged "$@"

The --staged flag restricts the run to staged files only and suppresses hk's internal call to the git-stash subcommand. Without it, HK_STASH=git (env) or --stash=git (CLI) can override an hk.pkl-level pre-commit stash = "none" and cause hk to stash/unstash unstaged files during the commit.

The staged-only default matches the semantics users most commonly expect from pre-commit hooks: format/lint what's staged, don't touch what isn't. Non-pre-commit events (commit-msg, pre-push, prepare-commit-msg, post-commit, ...) are unchanged since --staged isn't meaningful for them.

Users who want the pre-hooks-can-stash behavior back can override locally:

    git config --global hook.hk-pre-commit.command \
        'test "${HK:-1}" = "0" || hk run pre-commit --from-hook "$@"'

Adds two unit tests covering git_hook_content:
- git_hook_content_appends_staged_for_pre_commit
- git_hook_content_omits_staged_for_non_pre_commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated hook installation so `pre-commit` runs with staged-only behavior, while other hook events continue using the existing command flow.
  * Improved generated hook scripts and configuration to handle `pre-commit` differently from other events.
  
* **Tests**
  * Added coverage to verify `pre-commit` includes the staged flag and that non-`pre-commit` hooks keep the previous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->