### PR TITLE
pkl: make Hook an open class

### DIFF
--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -178,7 +178,7 @@ walk_ignore: Boolean?
 /// Hooks define when and how linters are run. See [hooks](https://hk.jdx.dev/hooks) for more information.
 hooks: Mapping<String, Hook> = new Mapping<String, Hook> {}
 
-class Hook {
+open class Hook {
   /// Default: `false` (`true` for `fix` hook)
   ///
   /// If true, hk will run the fix command for each step (if it exists) to make modifications.


### PR DESCRIPTION
pkl: make Hook an open class

Allows downstream users to subclass Hook to enforce policy on fields
via pkl's `fixed` keyword, which cannot be overridden in an amend
block.

Motivating example (dx-hk-lang): the maintainer wants to publish a
strict Hook template that pins stash = "none" and cannot be reset by
consumer amend:

    import "modulepath:/pkl/Config.pkl" as hk

    class StrictPreCommitHook extends hk.Hook {
      fixed stash: hk.StashMethod = "none"
    }

    strictPreCommit = new StrictPreCommitHook {}

Consumer amend that tries `stash = "git"` now fails at pkl eval time
with "Cannot assign to fixed property `stash`", surfacing the policy
violation to `hk validate`, `hk run`, and `git commit` uniformly.

Currently `Hook` is a plain `class`, so pkl refuses:

    Cannot extend non-open class `hk.Config#Hook`

The workaround (which dx-hk-lang currently ships) is to embed the
policy check as a throw expression inside the `env` mapping - it
works but pollutes every step's process environment with a marker
variable and abuses `env` as a validation carrier. `fixed` on an
`open class` is the idiomatic pkl mechanism for exactly this
enforcement pattern.

Config.Step, Config.Group, and Config.Config all remain plain
classes; this PR narrows the change to `Hook` since Hook is the
only class end users routinely subclass for policy templates.