### PR TITLE
fix: include staged renames in staged files list

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -455,11 +455,22 @@ impl Git {
             let mut staged_renamed_files = BTreeSet::new();
             let staged_copied_files = BTreeSet::new();
             for s in staged_statuses.iter() {
-                if let Ok(path) = s.path().map(PathBuf::from) {
+                let st = s.status();
+                // For renamed entries, s.path() returns the old path which no longer
+                // exists in the worktree; use the new path from the head-to-index delta
+                let path = if st.is_index_renamed() {
+                    // INDEX_RENAMED implies a head-to-index rename delta, whose
+                    // new_file path is always present
+                    s.head_to_index()
+                        .and_then(|d| d.new_file().path())
+                        .map(PathBuf::from)
+                } else {
+                    s.path().map(PathBuf::from).ok()
+                };
+                if let Some(path) = path {
                     // Check if path exists (including broken symlinks)
                     // path.exists() returns false for broken symlinks, but symlink_metadata succeeds
                     let exists = path.exists() || std::fs::symlink_metadata(&path).is_ok();
-                    let st = s.status();
                     if st.is_index_new() {
                         staged_added_files.insert(path.clone());
                     }
@@ -507,6 +518,8 @@ impl Git {
                         unstaged_deleted_files.insert(path.clone());
                     }
                     if st == git2::Status::WT_RENAMED {
+                        // Note: s.path() would be the old path here, but WT_RENAMED
+                        // is unreachable while renames_index_to_workdir is not enabled
                         unstaged_renamed_files.insert(path.clone());
                     }
                     if exists && st != git2::Status::WT_NEW {
@@ -557,7 +570,8 @@ impl Git {
             let mut unstaged_modified_files = BTreeSet::new();
             let mut unstaged_deleted_files = BTreeSet::new();
             let mut unstaged_renamed_files = BTreeSet::new();
-            for file in output.split('\0') {
+            let mut entries = output.split('\0');
+            while let Some(file) = entries.next() {
                 if file.is_empty() {
                     continue;
                 }
@@ -565,6 +579,16 @@ impl Git {
                 let index_status = chars.next().unwrap_or_default();
                 let workdir_status = chars.next().unwrap_or_default();
                 let path = PathBuf::from(chars.skip(1).collect::<String>());
+                // Renamed/copied entries are followed by the original path as a
+                // separate NUL-terminated field; consume it so it is not parsed
+                // as another status entry
+                if index_status == 'R'
+                    || index_status == 'C'
+                    || workdir_status == 'R'
+                    || workdir_status == 'C'
+                {
+                    entries.next();
+                }
                 // Check if path exists (including broken symlinks)
                 // path.exists() returns false for broken symlinks, but symlink_metadata succeeds
                 let exists = path.exists() || std::fs::symlink_metadata(&path).is_ok();

--- a/test/staged_rename_pre_commit.bats
+++ b/test/staged_rename_pre_commit.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+_setup_repo() {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    steps {
+      ["list"] {
+        glob = "*.txt"
+        check = "printf '%s\n' {{files}} > files_list.txt"
+      }
+    }
+  }
+}
+EOF
+    git add hk.pkl
+    git commit -m "init"
+
+    seq 1 10 | sed 's/^/line /' > a.txt
+    git add a.txt
+    git commit -m "add a.txt"
+}
+
+_assert_step_ran_with_new_path() {
+    run hk run pre-commit
+    assert_success
+
+    # Before the fix, the staged rename was invisible and the step was
+    # silently skipped ("no files to run"), so files_list.txt never existed
+    assert_file_exists files_list.txt
+    assert_file_contains files_list.txt 'b\.txt'
+    assert_file_not_contains files_list.txt 'a\.txt'
+}
+
+@test "pre-commit runs steps on staged pure rename (libgit2)" {
+    export HK_LIBGIT2=1
+    _setup_repo
+
+    git mv a.txt b.txt
+
+    # Sanity: ensure git detects the rename
+    run bash -c "git status --porcelain"
+    assert_output --partial "R  a.txt -> b.txt"
+
+    _assert_step_ran_with_new_path
+}
+
+@test "pre-commit runs steps on staged pure rename (shell git)" {
+    export HK_LIBGIT2=0
+    _setup_repo
+
+    git mv a.txt b.txt
+
+    # Sanity: ensure git detects the rename
+    run bash -c "git status --porcelain"
+    assert_output --partial "R  a.txt -> b.txt"
+
+    _assert_step_ran_with_new_path
+}
+
+@test "pre-commit runs steps on staged rename with modification (libgit2)" {
+    export HK_LIBGIT2=1
+    _setup_repo
+
+    git mv a.txt b.txt
+    echo "line 11" >> b.txt
+    git add b.txt
+
+    # Sanity: ensure git still detects this as a rename, not delete+add
+    run bash -c "git status --porcelain"
+    assert_output --partial "R  a.txt -> b.txt"
+
+    _assert_step_ran_with_new_path
+}
+
+@test "pre-commit runs steps on staged rename with modification (shell git)" {
+    export HK_LIBGIT2=0
+    _setup_repo
+
+    git mv a.txt b.txt
+    echo "line 11" >> b.txt
+    git add b.txt
+
+    # Sanity: ensure git still detects this as a rename, not delete+add
+    run bash -c "git status --porcelain"
+    assert_output --partial "R  a.txt -> b.txt"
+
+    _assert_step_ran_with_new_path
+}


### PR DESCRIPTION
## Summary

Rename-only commits silently bypass all pre-commit steps when using libgit2 (`HK_LIBGIT2=1`, the default). `hk run pre-commit` reports "Fetching staged files (0 files)" and every step is skipped, so a `git mv` commit can land with lint violations — we hit this in practice when a rename commit passed hooks locally and then failed lint in CI. Affects both pure renames (R100) and rename+modify. Regressed when rename detection was enabled in #347.

## Reproduction

```sh
git init repo && cd repo
# hk.pkl with any pre-commit step, e.g. check = "echo {{files}}"
echo hello > a.txt
git add -A && git commit -m init
git mv a.txt b.txt
hk run pre-commit                 # BUG: 0 files, all steps skipped
HK_LIBGIT2=0 hk run pre-commit    # works: 1 file (b.txt)
```

## Root cause

With `renames_head_to_index(true)`, git2's `StatusEntry::path()` returns the **old** path for renamed entries (`path_bytes()` reads `head_to_index.old_file.path`). The old path no longer exists in the worktree, so the existence check in `Git::status()` filtered renamed files out of `staged_files`, and `Hook::file_list` saw an empty list. (Renames do land in `staged_renamed_files`, but that set is only used by expression conditions.)

## Fix

- **libgit2 path:** for `INDEX_RENAMED` entries, resolve the new path from the head-to-index delta instead of `s.path()`. This also makes `staged_renamed_files` consistent with the shell-git path, which already reported the new path.
- **shell-git fallback:** `git status --porcelain -z` emits the original path of renamed/copied entries as a separate NUL-terminated field. The parser treated that field as another status entry, which could insert bogus paths into the status sets (e.g. an old path starting with `MM ` would be parsed as a modified file). Consume the field instead. The workdir-side `R` check is reachable too: worktree renames of intent-to-add files show up as ` R new\0old\0` in porcelain v1.

## Tests

New `test/staged_rename_pre_commit.bats`: pure rename and rename+modify, each pinned to both `HK_LIBGIT2=1` and `HK_LIBGIT2=0`. Both libgit2 cases fail before the fix and pass after; shell-git cases pass before and after (regression guard). Also ran `mise run test:cargo`, `cargo fmt --check`, `cargo clippy`, and the related bats suites (`staged_renamed_files`, `untracked_not_processed_pre_commit`, `git_status_ad_deleted`, `expr_git_status`, `check`) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of renamed files in status checks, including staged renames and rename/copy records from different Git backends.
  * Ensured renamed files are recognized correctly even when paths are missing or symlinks are broken.

* **Tests**
  * Added coverage for pre-commit behavior with staged renames, both with and without content changes.
  * Verified consistent results across Git operation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->