### PR TITLE
fix(step): prefer check_list_files in check-first

### DIFF
--- a/src/step/batching.rs
+++ b/src/step/batching.rs
@@ -52,7 +52,7 @@ impl Step {
         base_tctx: &tera::Context,
     ) -> Option<usize> {
         let run_cmd = if original_job.check_first {
-            self.check_first_cmd()
+            self.check_first_cmd().map(|cmd| cmd.script())
         } else {
             self.run_cmd(original_job.run_type)
         }?;

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -23,7 +23,7 @@ use std::sync::{Arc, LazyLock};
 use tokio::sync::OwnedSemaphorePermit;
 
 use super::expr_env::EXPR_ENV;
-use super::types::{RunType, Step};
+use super::types::{CheckFirstCmd, RunType, Step};
 
 /// Default stage pattern for steps with fix commands when staging is enabled.
 static DEFAULT_STAGE: LazyLock<Vec<String>> = LazyLock::new(|| vec!["<JOB_FILES>".to_string()]);
@@ -115,18 +115,7 @@ impl Step {
                 if job.check_first {
                     let prev_run_type = job.run_type;
                     job.run_type = RunType::Check;
-                    let (ran_check_diff, ran_check_list_files) =
-                        match step.check_first_cmd() {
-                            Some(cmd) => (
-                                step.check_diff
-                                    .as_ref()
-                                    .is_some_and(|check_diff| std::ptr::eq(cmd, check_diff)),
-                                step.check_list_files
-                                    .as_ref()
-                                    .is_some_and(|check_list_files| std::ptr::eq(cmd, check_list_files)),
-                            ),
-                            None => (false, false),
-                        };
+                    let check_first_cmd = step.check_first_cmd();
                     // Stash check output in case the second run is cancelled by fail_fast
                     let mut check_first_output: Option<(String, String, String)> = None;
                     match step.run(&ctx, &mut job).await {
@@ -148,9 +137,15 @@ impl Step {
                                 // Parse according to the check-first command that actually ran.
                                 // Platform-specific Script values can be empty, in which case
                                 // check_first_cmd falls back to the next available command.
-                                let (files, extras) = if ran_check_diff {
+                                let (files, extras) = if matches!(
+                                    check_first_cmd,
+                                    Some(CheckFirstCmd::Diff(_))
+                                ) {
                                     step.filter_files_from_check_diff(&job.files, stdout)
-                                } else if ran_check_list_files {
+                                } else if matches!(
+                                    check_first_cmd,
+                                    Some(CheckFirstCmd::ListFiles(_))
+                                ) {
                                     step.filter_files_from_check_list(&job.files, stdout)
                                 } else {
                                     (job.files.clone(), Vec::new())
@@ -163,10 +158,14 @@ impl Step {
                                 }
 
                                 // For check_diff: if no parseable files, keep all original files
-                                if files.is_empty() && ran_check_diff {
+                                if files.is_empty()
+                                    && matches!(check_first_cmd, Some(CheckFirstCmd::Diff(_)))
+                                {
                                     debug!("{step}: check_diff returned no parseable files, will run fixer on all original files");
                                     // Keep all original files for check_diff when diff parsing fails
-                                } else if files.is_empty() && ran_check_list_files {
+                                } else if files.is_empty()
+                                    && matches!(check_first_cmd, Some(CheckFirstCmd::ListFiles(_)))
+                                {
                                     // For check_list_files: non-zero exit with no files is an error
                                     // (Tool failed, not "files need fixing")
                                     error!("{step}: check_list_files failed with no files in output");
@@ -177,7 +176,9 @@ impl Step {
 
                                 // Try to apply diff directly when check_diff is defined and we're in Fix mode
                                 // (prev_run_type is the original mode; job.run_type was temporarily changed to Check)
-                                if ran_check_diff && prev_run_type == RunType::Fix {
+                                if matches!(check_first_cmd, Some(CheckFirstCmd::Diff(_)))
+                                    && prev_run_type == RunType::Fix
+                                {
                                     match step.apply_diff_output(stdout) {
                                         Ok(true) => {
                                             // Diff applied successfully - no need to run fixer

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -115,6 +115,18 @@ impl Step {
                 if job.check_first {
                     let prev_run_type = job.run_type;
                     job.run_type = RunType::Check;
+                    let (ran_check_diff, ran_check_list_files) =
+                        match step.check_first_cmd() {
+                            Some(cmd) => (
+                                step.check_diff
+                                    .as_ref()
+                                    .is_some_and(|check_diff| std::ptr::eq(cmd, check_diff)),
+                                step.check_list_files
+                                    .as_ref()
+                                    .is_some_and(|check_list_files| std::ptr::eq(cmd, check_list_files)),
+                            ),
+                            None => (false, false),
+                        };
                     // Stash check output in case the second run is cancelled by fail_fast
                     let mut check_first_output: Option<(String, String, String)> = None;
                     match step.run(&ctx, &mut job).await {
@@ -133,12 +145,15 @@ impl Step {
                                     debug!("{step}: check stderr output:\n{}", stderr);
                                 }
                                 check_first_output = Some((stdout.clone(), stderr.clone(), combined.clone()));
-                                // Use check_diff parser if check_diff is defined, otherwise check_list_files
-                                let is_check_diff = step.check_diff.is_some();
-                                let (files, extras) = if is_check_diff {
+                                // Parse according to the check-first command that actually ran.
+                                // Platform-specific Script values can be empty, in which case
+                                // check_first_cmd falls back to the next available command.
+                                let (files, extras) = if ran_check_diff {
                                     step.filter_files_from_check_diff(&job.files, stdout)
-                                } else {
+                                } else if ran_check_list_files {
                                     step.filter_files_from_check_list(&job.files, stdout)
+                                } else {
+                                    (job.files.clone(), Vec::new())
                                 };
                                 for f in extras {
                                     warn!(
@@ -148,10 +163,10 @@ impl Step {
                                 }
 
                                 // For check_diff: if no parseable files, keep all original files
-                                if files.is_empty() && is_check_diff {
+                                if files.is_empty() && ran_check_diff {
                                     debug!("{step}: check_diff returned no parseable files, will run fixer on all original files");
                                     // Keep all original files for check_diff when diff parsing fails
-                                } else if files.is_empty() {
+                                } else if files.is_empty() && ran_check_list_files {
                                     // For check_list_files: non-zero exit with no files is an error
                                     // (Tool failed, not "files need fixing")
                                     error!("{step}: check_list_files failed with no files in output");
@@ -162,7 +177,7 @@ impl Step {
 
                                 // Try to apply diff directly when check_diff is defined and we're in Fix mode
                                 // (prev_run_type is the original mode; job.run_type was temporarily changed to Check)
-                                if is_check_diff && prev_run_type == RunType::Fix {
+                                if ran_check_diff && prev_run_type == RunType::Fix {
                                     match step.apply_diff_output(stdout) {
                                         Ok(true) => {
                                             // Diff applied successfully - no need to run fixer

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -24,7 +24,7 @@ use std::process::Stdio;
 
 use super::expr_env::EXPR_ENV;
 use super::shell::ShellType;
-use super::types::{Pattern, RunType, Script, Step};
+use super::types::{CheckFirstCmd, Pattern, RunType, Script, Step};
 use crate::error::Error;
 
 /// Cap on the per-job progress message in printable characters. The
@@ -132,8 +132,13 @@ impl Step {
                 if files.len() == 1 { "" } else { "s" }
             )
         };
-        let run_cmd = if job.check_first {
+        let check_first_cmd = if job.check_first {
             self.check_first_cmd()
+        } else {
+            None
+        };
+        let run_cmd = if let Some(check_first_cmd) = check_first_cmd {
+            Some(check_first_cmd.script())
         } else {
             self.run_cmd(job.run_type)
         };
@@ -370,13 +375,24 @@ impl Step {
     /// Get the command to run in "check first" mode.
     ///
     /// Prefers check_diff, then check_list_files, then check.
-    pub fn check_first_cmd(&self) -> Option<&Script> {
+    pub fn check_first_cmd(&self) -> Option<CheckFirstCmd<'_>> {
         let is_present = |s: &&Script| !s.to_string().trim().is_empty();
         self.check_diff
             .as_ref()
             .filter(is_present)
-            .or_else(|| self.check_list_files.as_ref().filter(is_present))
-            .or_else(|| self.check.as_ref().filter(is_present))
+            .map(CheckFirstCmd::Diff)
+            .or_else(|| {
+                self.check_list_files
+                    .as_ref()
+                    .filter(is_present)
+                    .map(CheckFirstCmd::ListFiles)
+            })
+            .or_else(|| {
+                self.check
+                    .as_ref()
+                    .filter(is_present)
+                    .map(CheckFirstCmd::Check)
+            })
     }
 
     /// Check if this step has a command for the given run type.

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -142,6 +142,10 @@ impl Step {
         } else {
             self.run_cmd(job.run_type)
         };
+        let ran_check_list_files = matches!(check_first_cmd, Some(CheckFirstCmd::ListFiles(_)))
+            || (check_first_cmd.is_none() && run_cmd == self.check_list_files.as_ref());
+        let ran_check_diff = matches!(check_first_cmd, Some(CheckFirstCmd::Diff(_)))
+            || (check_first_cmd.is_none() && run_cmd == self.check_diff.as_ref());
         let Some(mut run) = run_cmd
             .map(|s| s.to_string())
             .filter(|s| !s.trim().is_empty())
@@ -251,7 +255,7 @@ impl Step {
             Ok(result) => {
                 // For both check_list_files and check_diff: stderr is informational only
                 // Files are read from stdout; stderr may contain warnings, debug info, etc.
-                if run_cmd == self.check_list_files.as_ref() {
+                if ran_check_list_files {
                     debug!(
                         "{self}: check_list_files succeeded (exit 0), stdout len={}, stderr len={}",
                         result.stdout.len(),
@@ -266,7 +270,7 @@ impl Step {
                             "{self}: check_list_files exited 0 (success) but returned files in stdout. This may indicate misconfiguration - the tool should exit non-zero when files need fixing."
                         );
                     }
-                } else if run_cmd == self.check_diff.as_ref() {
+                } else if ran_check_diff {
                     // For check_diff, stderr with exit 0 is just informational (e.g., "N files already formatted")
                     debug!(
                         "{self}: check_diff succeeded (exit 0), stdout len={}, stderr len={}",
@@ -287,8 +291,10 @@ impl Step {
             Err(err) => {
                 if let ensembler::Error::ScriptFailed(e) = &err {
                     if job.check_first
-                        && (run_cmd == self.check_list_files.as_ref()
-                            || run_cmd == self.check_diff.as_ref())
+                        && matches!(
+                            check_first_cmd,
+                            Some(CheckFirstCmd::ListFiles(_) | CheckFirstCmd::Diff(_))
+                        )
                     {
                         return Err(Error::CheckListFailed {
                             source: eyre::eyre!("{}", err),

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -369,12 +369,14 @@ impl Step {
 
     /// Get the command to run in "check first" mode.
     ///
-    /// Prefers check_diff, then check, then check_list_files.
+    /// Prefers check_diff, then check_list_files, then check.
     pub fn check_first_cmd(&self) -> Option<&Script> {
+        let is_present = |s: &&Script| !s.to_string().trim().is_empty();
         self.check_diff
             .as_ref()
-            .or(self.check.as_ref())
-            .or(self.check_list_files.as_ref())
+            .filter(is_present)
+            .or_else(|| self.check_list_files.as_ref().filter(is_present))
+            .or_else(|| self.check.as_ref().filter(is_present))
     }
 
     /// Check if this step has a command for the given run type.

--- a/src/step/types.rs
+++ b/src/step/types.rs
@@ -346,6 +346,21 @@ impl Display for Script {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CheckFirstCmd<'a> {
+    Diff(&'a Script),
+    ListFiles(&'a Script),
+    Check(&'a Script),
+}
+
+impl<'a> CheckFirstCmd<'a> {
+    pub(crate) fn script(self) -> &'a Script {
+        match self {
+            Self::Diff(script) | Self::ListFiles(script) | Self::Check(script) => script,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/test/check_list_files_empty_with_stderr.bats
+++ b/test/check_list_files_empty_with_stderr.bats
@@ -115,6 +115,66 @@ EOF
     assert_output --partial "formatted test.txt"
 }
 
+@test "check_first prefers check_list_files over check" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    steps {
+      ["format"] {
+        check_first = true
+        glob = List("*.txt")
+        stage = List("<JOB_FILES>")
+        check = "sh -c 'echo generic-check; exit 1'"
+        check_list_files = "sh -c 'echo needs-format.txt; exit 1'"
+        fix = "echo 'formatted' {{files}}"
+      }
+    }
+  }
+}
+EOF
+    echo 'needs formatting' > needs-format.txt
+    echo 'already formatted' > already-format.txt
+    git add needs-format.txt already-format.txt
+
+    run hk fix
+    assert_success
+    assert_output --partial "formatted needs-format.txt"
+    refute_output --partial "formatted already-format.txt"
+    refute_output --partial "generic-check"
+}
+
+@test "check_first falls back when check_list_files is empty on this platform" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    steps {
+      ["format"] {
+        check_first = true
+        glob = List("*.txt")
+        stage = List("<JOB_FILES>")
+        check = "sh -c 'echo generic-check; exit 1'"
+        check_list_files = new Script {
+          linux = ""
+          other = "sh -c 'echo needs-format.txt; exit 1'"
+        }
+        fix = "echo 'formatted' {{files}}"
+      }
+    }
+  }
+}
+EOF
+    echo 'needs formatting' > needs-format.txt
+    echo 'already formatted' > already-format.txt
+    git add needs-format.txt already-format.txt
+
+    run hk fix
+    assert_success
+    assert_output --partial "generic-check"
+    assert_output --partial "formatted already-format.txt needs-format.txt"
+}
+
 @test "check_list_files with non-zero exit should be an error" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"

--- a/test/check_list_files_empty_with_stderr.bats
+++ b/test/check_list_files_empty_with_stderr.bats
@@ -157,6 +157,8 @@ hooks {
         check = "sh -c 'echo generic-check; exit 1'"
         check_list_files = new Script {
           linux = ""
+          macos = ""
+          windows = ""
           other = "sh -c 'echo needs-format.txt; exit 1'"
         }
         fix = "echo 'formatted' {{files}}"


### PR DESCRIPTION
## Summary

Restore the check-first command preference to use `check_list_files` before the generic `check` command, while keeping `check_diff` as the highest-priority option. This follows up on the same oddity raised in https://github.com/jdx/hk/pull/952, but keeps the change focused on the runner behavior and regression coverage.

## Background

There are two different command-selection paths here:

- normal check mode should prefer `check`, because that is the broad, human-facing validation command
- fix-mode `check_first` should prefer commands that can identify the exact files to fix, because the prepass is used to avoid unnecessary fixer work and write locks

Historically, before the `RunType` / `CheckType` simplification, the check-first path selected `check_diff`, then `check_list_files`, then `check`. That made sense: `check_diff` can sometimes be applied directly, and `check_list_files` can narrow the subsequent `fix` command to only files that need writes.

The ordering appears to have changed in #547 (`refactor: Simplify RunType/CheckType`). That refactor removed the explicit `CheckType` selection and introduced `check_first_cmd()`, where the fallback order became `check_diff -> check -> check_list_files`. The commit message only calls out `hk test` preferring `check` over `check_diff` as an intended behavior change, so this looks like a collateral change from the refactor rather than a deliberate semantic change for fix-mode check-first.

## Why fix it

When a step defines both `check` and `check_list_files`, the current check-first prepass runs the generic `check`. If that fails, hk falls through to `fix` with the whole job file set, because the generic check output does not provide a file list to filter on.

Using `check_list_files` first makes the check-first path useful again for those steps: hk can run the fixer on fewer files, take fewer write locks, and keep `<JOB_FILES>` staging scoped to the files that were actually processed. This is mostly an efficiency/concurrency improvement, but it also better matches the purpose of `check_list_files` in fix mode.

`check_diff` remains first because it is the stronger optimization: hk may be able to apply the emitted diff directly and skip the fixer entirely.

The implementation keeps the selected check-first command tagged as `Diff`, `ListFiles`, or `Check`. Normal `hk check` can simply run the first available command, but the fix-mode `check_first` prepass uses the selected command's failure output to decide what happens next: parse a diff, parse a file list, or fall through to the fixer with the original files. Carrying the tag makes that distinction explicit instead of re-inferring it from the script text.

## Compatibility note

This changes behavior for steps that define both `check` and `check_list_files` and run through fix-mode `check_first`. Those steps will now run `check_list_files` for the check-first prepass instead of `check`.

That should be the desired behavior for formatters and file-listing tools, but it may affect edge cases where a user intentionally relied on the generic `check` command running first despite also defining `check_list_files`, or where `check_list_files` has narrower validation than `check`. Normal `hk check` command selection still prefers `check` first; this change is scoped to the check-first prepass used before fixing.

The implementation also skips empty platform-specific scripts while choosing the check-first command, so configurations can disable a list-files or diff command on a platform and fall back to the next available command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined check-first behavior to use the specific check-first command that actually ran, improving handling for empty/whitespace-configured scripts.
  * Aligned file parsing/filtering and “no parseable files” handling with the executed check-first mode, including Fix mode application of diff output only when in diff mode.
  * Ensured list-files checks take precedence over generic checks, with correct fallback when list-files is unavailable on the current platform.
* **Tests**
  * Added Bats coverage for list-files precedence and platform-dependent fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

