### PR TITLE
fix(config): read string settings from live git config

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -435,13 +435,15 @@ impl Settings {
                         }
                     }
                     "string" | "enum" => {
-                        if let Ok(v) = cfg.get_str(key) {
-                            map.insert(setting_name, SettingValue::String(v.to_string()));
+                        // `get_str` requires a snapshot on a live Config. `get_string`
+                        // returns an owned String and works on configs from Repository::config().
+                        if let Ok(v) = cfg.get_string(key) {
+                            map.insert(setting_name, SettingValue::String(v));
                             break;
                         }
                     }
                     "path" => {
-                        if let Ok(v) = cfg.get_str(key) {
+                        if let Ok(v) = cfg.get_string(key) {
                             map.insert(setting_name, SettingValue::Path(PathBuf::from(v)));
                             break;
                         }
@@ -909,5 +911,29 @@ mod tests {
         let merged = Settings::merge_settings_generic(&defaults, &env, &git, &pkl, &cli);
         assert!(merged.warnings.contains("warning4"));
         assert_eq!(merged.warnings.len(), 1);
+    }
+
+    #[test]
+    fn test_git_map_reads_string_setting_from_live_config() {
+        use git2::Config;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg_path = tmp.path().join("gitconfig");
+        std::fs::write(&cfg_path, "[hk]\n\tstash = none\n").expect("write gitconfig");
+        let cfg = Config::open(&cfg_path).expect("open cfg");
+
+        let value = cfg
+            .get_string("hk.stash")
+            .expect("hk.stash must read on a live Config");
+        assert_eq!(value, "none");
+
+        let str_err = cfg
+            .get_str("hk.stash")
+            .expect_err("get_str must fail on a live config");
+        assert!(
+            str_err.message().contains("live config object"),
+            "unexpected libgit2 error message: {:?}",
+            str_err.message()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- read string, enum, and path git-config settings with `Config::get_string` so live configs returned by `Repository::config()` surface values correctly
- add a regression test covering live config reads for `hk.stash`

## Root cause

`collect_git_map` used `Config::get_str` for string-like settings. libgit2 rejects borrow-returning reads on live config objects, so settings such as `hk.stash` silently fell back to defaults even though `hk config explain` listed git config as a source.

Fixes discussion #1031.

## Validation

- `cargo test --bin hk`

Co-authored-by: distortedlogic <jermeek@gmail.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change in git config collection with a targeted test; no auth or data-path changes.
> 
> **Overview**
> **Git config merging** now loads `string`, `enum`, and `path` settings with `Config::get_string` instead of `get_str` in `collect_git_map`. Live configs from `Repository::config()` could not satisfy `get_str` (libgit2 requires a snapshot), so values like `hk.stash` were skipped during merge even when `hk config explain` showed git as a source.
> 
> A regression test documents that `get_string` works on a live config and that `get_str` fails with the expected libgit2 error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 290c31d341020e41e5928f4705e7a4b3fc22c2dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->