### PR TITLE
fix(install): run installed pre-commit hooks staged

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -325,7 +325,7 @@ fn warn_if_global_overlap(events: &[String]) {
 fn install_global(events: &[String], command: &OsStr) -> Result<()> {
     remove_config_entries("--global")?;
     for event in events {
-        write_config_hook("--global", command, event)?;
+        write_config_hook("--global", command, event, true)?;
     }
     println!(
         "Installed hk global hooks in ~/.gitconfig for: {}",
@@ -339,7 +339,7 @@ fn install_global(events: &[String], command: &OsStr) -> Result<()> {
 
 fn install_local_config(events: &[String], command: &OsStr) -> Result<()> {
     for event in events {
-        write_config_hook("--local", command, event)?;
+        write_config_hook("--local", command, event, false)?;
         println!("Installed hk hook via git config: hook.hk-{event}.command");
     }
     Ok(())
@@ -371,7 +371,12 @@ fn install_local_shims(events: &[String], command: &OsStr) -> Result<()> {
 
 /// Write both `hook.hk-<event>.command` and `hook.hk-<event>.event` at the
 /// given scope (`--local` or `--global`).
-fn write_config_hook(scope: &str, command: &OsStr, event: &str) -> Result<()> {
+fn write_config_hook(
+    scope: &str,
+    command: &OsStr,
+    event: &str,
+    staged_pre_commit: bool,
+) -> Result<()> {
     let name = format!("hk-{event}");
     let cmd_key = format!("hook.{name}.command");
     let event_key = format!("hook.{name}.event");
@@ -379,7 +384,7 @@ fn write_config_hook(scope: &str, command: &OsStr, event: &str) -> Result<()> {
     // with `HK=0 git commit` under config-based hooks.
     let mut cmd_value = OsString::from(r#"test "${HK:-1}" = "0" || "#);
     cmd_value.push(command);
-    cmd_value.push(format!(r#" run {event} --from-hook "$@""#));
+    cmd_value.push(hook_run_args(event, staged_pre_commit));
 
     run_git([
         OsString::from("config"),
@@ -501,8 +506,17 @@ fn git_hook_content(hk: &str, hook: &str) -> String {
     format!(
         r#"#!/bin/sh
 test "${{HK:-1}}" = "0" || exec {hk} run {hook} --from-hook "$@"
-"#
+"#,
     )
+}
+
+fn hook_run_args(event: &str, staged_pre_commit: bool) -> OsString {
+    let staged = if staged_pre_commit && event == "pre-commit" {
+        " --staged"
+    } else {
+        ""
+    };
+    OsString::from(format!(r#" run {event} --from-hook{staged} "$@""#))
 }
 
 fn check_hooks_path_config() -> Result<()> {
@@ -582,6 +596,22 @@ mod tests {
     fn local_mise_command_keeps_existing_behavior() {
         assert_eq!(local_hook_command(true), OsString::from("mise x -- hk"));
         assert_eq!(local_hook_command(false), OsString::from("hk"));
+    }
+
+    #[test]
+    fn hook_run_args_adds_staged_only_for_pre_commit() {
+        assert_eq!(
+            hook_run_args("pre-commit", true),
+            OsString::from(r#" run pre-commit --from-hook --staged "$@""#)
+        );
+        assert_eq!(
+            hook_run_args("pre-push", true),
+            OsString::from(r#" run pre-push --from-hook "$@""#)
+        );
+        assert_eq!(
+            hook_run_args("pre-commit", false),
+            OsString::from(r#" run pre-commit --from-hook "$@""#)
+        );
     }
 
     #[cfg(unix)]

--- a/test/install_creates_git_hooks.bats
+++ b/test/install_creates_git_hooks.bats
@@ -17,4 +17,9 @@ hooks { ["pre-commit"] { steps { ["prettier"] = Builtins.prettier } } }
 EOF
     hk install --legacy
     assert_file_exists ".git/hooks/pre-commit"
+
+    run cat ".git/hooks/pre-commit"
+    assert_success
+    assert_output --partial 'run pre-commit --from-hook "$@"'
+    refute_output --partial '--staged'
 }

--- a/test/install_global.bats
+++ b/test/install_global.bats
@@ -28,7 +28,7 @@ require_git_2_54() {
 
     run git config --global --get hook.hk-pre-commit.command
     assert_success
-    assert_output --partial 'run pre-commit --from-hook "$@"'
+    assert_output --partial 'run pre-commit --from-hook --staged "$@"'
     refute_output --partial '|| hk run'
 
     run git config --global --get hook.hk-pre-rebase.command
@@ -63,6 +63,7 @@ EOF
     run git config --global --get hook.hk-pre-rebase.command
     assert_success
     assert_output --partial 'run pre-rebase --from-hook "$@"'
+    refute_output --partial '--staged'
 
     run git config --global --get hook.hk-pre-commit.command
     assert_failure
@@ -84,7 +85,7 @@ EOF
 
     run git config --global --get hook.hk-pre-commit.command
     assert_success
-    assert_output --partial "~/bin/mise x hk -- hk run pre-commit --from-hook"
+    assert_output --partial '~/bin/mise x hk -- hk run pre-commit --from-hook --staged "$@"'
     refute_output --partial '|| mise x -- hk run'
 
     command="$(git config --global --get hook.hk-pre-commit.command)"


### PR DESCRIPTION
## Summary

- add `--staged` to generated global `pre-commit` hook commands
- centralize config-hook run argument generation for the global staged pre-commit case
- keep local config hooks, legacy shims, and non-`pre-commit` hook commands unchanged

## Why

`hk install --global` previously wrote pre-commit commands without `--staged`, so an environment override like `HK_STASH=git` could defeat a repo-level `stash = "none"` policy. Running global pre-commit hooks in staged mode makes the generated global hook enforce staged-only behavior by default without changing established local-install stash behavior.

Fixes discussion #1030.

## Validation

- `cargo test --bin hk cli::install::tests`
- `mise run test:bats test/install_global.bats`
- `mise run test:bats test/install_creates_git_hooks.bats`
- `mise run test:bats test/stash_untracked_with_partial_stash.bats`
- `mise run test:bats test/pre_commit_restores_unstaged_over_fixer_regression.bats`
- commit hook checks: prelint, cargo fmt, dbg, newlines, trailing-whitespace, cargo check

Reported-by: Distortedlogic <jermeek@gmail.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to install-time hook command strings; local and legacy installs keep prior behavior, with only global pre-commit gaining `--staged`.
> 
> **Overview**
> **Global** `hk install` now generates `pre-commit` git config hook commands that invoke `hk run pre-commit --from-hook --staged`, so installed hooks default to staged-only behavior and are less affected by env overrides like `HK_STASH=git` against repo `stash = "none"`.
> 
> Hook command suffixes are built through a shared `hook_run_args` helper used by config-based installs; **local** config hooks and **legacy** `.git/hooks/` shims still omit `--staged` on `pre-commit`. Other events (e.g. `pre-push`, `pre-rebase`) are unchanged.
> 
> Unit and Bats tests assert the staged flag only on global `pre-commit` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6f1920cdbb0e193c2a8d93b4b907453074013d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->