### PR TITLE
perf(config): share resolved config cache by content

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -18,6 +18,13 @@ pub struct CacheManagerBuilder {
     cache_keys: Vec<String>,
     fresh_duration: Option<Duration>,
     fresh_files: Vec<PathBuf>,
+    fresh_file_key_mode: FreshFileKeyMode,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FreshFileKeyMode {
+    PathAndContent,
+    ContentOnly,
 }
 
 pub static BASE_CACHE_KEYS: Lazy<Vec<String>> = Lazy::new(|| {
@@ -35,6 +42,7 @@ impl CacheManagerBuilder {
             cache_keys: BASE_CACHE_KEYS.clone(),
             fresh_files: vec![],
             fresh_duration: None,
+            fresh_file_key_mode: FreshFileKeyMode::PathAndContent,
         }
     }
 
@@ -48,10 +56,16 @@ impl CacheManagerBuilder {
         self
     }
 
-    // pub fn with_cache_key(mut self, key: String) -> Self {
-    //     self.cache_keys.push(key);
-    //     self
-    // }
+    pub fn with_content_fresh_files(mut self, paths: impl IntoIterator<Item = PathBuf>) -> Self {
+        self.fresh_files.extend(paths);
+        self.fresh_file_key_mode = FreshFileKeyMode::ContentOnly;
+        self
+    }
+
+    pub fn with_cache_key(mut self, key: String) -> Self {
+        self.cache_keys.push(key);
+        self
+    }
 
     fn cache_key(&self) -> String {
         hash_to_str(&self.cache_keys).chars().take(5).collect()
@@ -61,12 +75,16 @@ impl CacheManagerBuilder {
     where
         T: Serialize + DeserializeOwned,
     {
-        self.cache_keys.extend(
-            self.fresh_files
-                .iter()
-                .unique()
-                .map(|path| fresh_file_cache_key(path)),
-        );
+        self.cache_keys
+            .extend(
+                self.fresh_files
+                    .iter()
+                    .unique()
+                    .map(|path| match self.fresh_file_key_mode {
+                        FreshFileKeyMode::PathAndContent => fresh_file_cache_key(path),
+                        FreshFileKeyMode::ContentOnly => fresh_file_content_cache_key(path),
+                    }),
+            );
         let key = self.cache_key();
         let (base, ext) = split_file_name(&self.cache_file_path);
         let mut cache_file_path = self.cache_file_path;
@@ -179,6 +197,13 @@ fn fresh_file_cache_key(path: &Path) -> String {
     match std::fs::read(path) {
         Ok(contents) => format!("{}:{}", path.display(), hash_to_str(&contents)),
         Err(_) => format!("{}:<missing>", path.display()),
+    }
+}
+
+fn fresh_file_content_cache_key(path: &Path) -> String {
+    match std::fs::read(path) {
+        Ok(contents) => hash_to_str(&contents),
+        Err(_) => "<missing>".to_string(),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,25 +47,71 @@ impl Config {
     }
 
     /// Analyze pkl imports to get all transitive dependencies.
-    /// Returns a set of local file paths that the config depends on.
-    fn analyze_imports(path: &Path) -> Result<IndexSet<PathBuf>> {
+    /// Returns local file paths that the config depends on and whether the
+    /// module graph contains imports whose bytes hk cannot hash.
+    fn analyze_imports(path: &Path) -> Result<ImportAnalysis> {
         if env::use_pklr_backend() {
-            return pklr::analyze_imports(path)
+            let local_paths: IndexSet<PathBuf> = pklr::analyze_imports(path)
                 .map(|v| v.into_iter().collect())
-                .map_err(|e| eyre::eyre!("{e}"));
+                .map_err(|e| eyre::eyre!("{e}"))?;
+            let has_untracked_imports =
+                Self::has_untracked_imports_in_pkl_sources(path, &local_paths)?;
+            return Ok(ImportAnalysis {
+                local_paths,
+                has_untracked_imports,
+            });
         }
         let imports: PklImports =
             run_pkl(&["analyze", "imports"], path).wrap_err("failed to analyze pkl")?;
 
         // Extract all local file paths from the imports map keys
-        let mut paths = IndexSet::new();
+        let mut local_paths = IndexSet::new();
+        let mut has_untracked_imports = false;
         for uri in imports.resolvedImports.keys() {
             if let Some(file_path) = uri.strip_prefix("file://") {
-                paths.insert(PathBuf::from(file_path));
+                local_paths.insert(PathBuf::from(file_path));
+            } else if Self::is_untracked_import_uri(uri) {
+                has_untracked_imports = true;
             }
         }
 
-        Ok(paths)
+        Ok(ImportAnalysis {
+            local_paths,
+            has_untracked_imports,
+        })
+    }
+
+    fn has_untracked_imports_in_pkl_sources(
+        path: &Path,
+        local_paths: &IndexSet<PathBuf>,
+    ) -> Result<bool> {
+        let mut paths = IndexSet::new();
+        paths.insert(path.to_path_buf());
+        paths.extend(local_paths.iter().cloned());
+        for path in paths {
+            let source = std::fs::read_to_string(&path)
+                .wrap_err_with(|| format!("failed to read pkl imports from {}", path.display()))?;
+            if Self::source_may_reference_untracked_import(&source) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn source_may_reference_untracked_import(source: &str) -> bool {
+        source.lines().map(str::trim_start).any(|line| {
+            !line.starts_with("//")
+                && ["amends", "extends", "import", "import*"]
+                    .iter()
+                    .any(|keyword| line.starts_with(keyword))
+                && ["\"http://", "\"https://", "\"package://"]
+                    .iter()
+                    .any(|scheme| line.contains(scheme))
+        })
+    }
+
+    fn is_untracked_import_uri(uri: &str) -> bool {
+        uri.starts_with("http://") || uri.starts_with("https://") || uri.starts_with("package://")
     }
 
     fn init(&mut self, path: &Path) -> Result<()> {
@@ -147,17 +193,19 @@ impl Config {
         // For pkl files, we need to track all transitive imports for cache invalidation
         let is_pkl = path.extension().is_some_and(|ext| ext == "pkl");
 
-        let fresh_files: Vec<PathBuf> = if is_pkl {
+        let (fresh_files, has_untracked_imports): (Vec<PathBuf>, bool) = if is_pkl {
             // First, get the imports (cached separately, invalidated only by the main config file)
             let imports_cache_path =
                 cache_dir.join(format!("{}-imports.json", hash::hash_to_str(&path)));
             let imports_cache_mgr = CacheManagerBuilder::new(imports_cache_path)
                 .with_fresh_files(vec![path.clone()])
-                .build::<IndexSet<PathBuf>>();
+                .build::<ImportAnalysis>();
 
-            let imports = imports_cache_mgr
+            let import_analysis = imports_cache_mgr
                 .get_or_try_init(|| Self::analyze_imports(&path))?
                 .clone();
+            let has_untracked_imports = import_analysis.has_untracked_imports
+                || Self::has_untracked_imports_in_pkl_sources(&path, &import_analysis.local_paths)?;
 
             // Always include the main config file. The pklr backend's
             // analyze_imports does not include the source file in its
@@ -165,18 +213,27 @@ impl Config {
             // the cache when using pklr. Using IndexSet avoids
             // double-listing the path on the pkl CLI backend, whose
             // resolvedImports already contains it.
-            let mut files: IndexSet<PathBuf> = imports;
+            let mut files: IndexSet<PathBuf> = import_analysis.local_paths;
             files.insert(path.clone());
-            files.into_iter().collect()
+            (files.into_iter().collect(), has_untracked_imports)
         } else {
-            vec![path.clone()]
+            (vec![path.clone()], false)
         };
 
         // Build the config cache with all fresh files (imports + main config)
-        let config_cache_path = cache_dir.join(hash_key);
-        let config_cache_mgr = CacheManagerBuilder::new(config_cache_path)
-            .with_fresh_files(fresh_files)
-            .build::<Config>();
+        let config_cache_path = if has_untracked_imports {
+            cache_dir.join(hash_key)
+        } else {
+            cache_dir.join("resolved-config.json")
+        };
+        let config_cache_builder = CacheManagerBuilder::new(config_cache_path)
+            .with_cache_key(format!("pkl-backend:{}", env::HK_PKL_BACKEND.as_str()));
+        let config_cache_mgr = if has_untracked_imports {
+            config_cache_builder.with_fresh_files(fresh_files)
+        } else {
+            config_cache_builder.with_content_fresh_files(fresh_files)
+        }
+        .build::<Config>();
 
         // Load from cache if fresh; otherwise read from disk. In both cases, run init
         // to apply side-effects (env vars, settings, warnings) that are not stored in cache.
@@ -772,4 +829,10 @@ impl IntoIterator for StringOrList {
 #[allow(non_snake_case)]
 struct PklImports {
     resolvedImports: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ImportAnalysis {
+    local_paths: IndexSet<PathBuf>,
+    has_untracked_imports: bool,
 }

--- a/test/cache_behavior.bats
+++ b/test/cache_behavior.bats
@@ -195,6 +195,36 @@ EOF
     assert_output --partial "config.load:config.load_project:cache.get_or_try_init: cache.miss"
 }
 
+@test "resolved config cache is shared across identical local configs" {
+    export HK_CACHE=1
+
+    mkdir repo1 repo2
+    for repo in repo1 repo2; do
+        cat <<EOF > "$repo/hk.pkl"
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["shared"] { check = "echo shared" }
+        }
+    }
+}
+EOF
+    done
+
+    run bash -c "cd repo1 && hk validate -vv"
+    assert_success
+    assert_output --partial "cache.miss"
+    resolved_count=$(find "$HK_CACHE_DIR/configs" -name "resolved-config-*.json" -type f | wc -l | tr -d ' ')
+    [ "$resolved_count" -eq 1 ]
+
+    run bash -c "cd repo2 && hk validate -vv"
+    assert_success
+    assert_output --partial "cache.hit"
+    resolved_count=$(find "$HK_CACHE_DIR/configs" -name "resolved-config-*.json" -type f | wc -l | tr -d ' ')
+    [ "$resolved_count" -eq 1 ]
+}
+
 @test "cache handles concurrent access safely" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"


### PR DESCRIPTION
## Summary

- content-address resolved config cache entries for configs whose dependencies are local files
- keep path-keyed cache behavior when Pkl imports include HTTP or package URIs that hk cannot hash
- add a bats regression covering reuse across two byte-identical configs in different directories

## Notes

The imports cache remains path-keyed because import discovery is location-sensitive. The resolved config cache switches to a stable base filename only when hk can key freshness from local file contents.

## Validation

- cargo test
- mise run test:bats test/cache_behavior.bats
- cargo fmt --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes config cache identity and invalidation rules; incorrect handling of remote/package imports could serve stale resolved config, though the PR explicitly falls back to path-keyed behavior in those cases.
> 
> **Overview**
> **Resolved Pkl config caching** now reuses entries across projects when dependency freshness can be keyed on **file contents** instead of absolute paths.
> 
> `CacheManagerBuilder` gains **`with_content_fresh_files`** (content-only freshness keys) and **`with_cache_key`** (e.g. Pkl backend id). Import analysis returns **`ImportAnalysis`** with **`has_untracked_imports`** for HTTP/`package://` URIs and a source scan on the pklr path. When no untracked imports exist, the resolved config uses a stable **`resolved-config.json`** basename plus content-based keys; otherwise it keeps the per-config-path cache file and path+content freshness.
> 
> A **bats** test asserts two byte-identical `hk.pkl` trees in different directories share one resolved-config cache file (miss then hit).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a806cc77b6c72312ee271c276b4fbe5d92d1401. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->