### PR TITLE
schedule releases for Monday morning

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -10,6 +10,7 @@ jobs:
   merge:
     if: github.repository == 'jdx/hk'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Merge release into main
         run: |
@@ -22,7 +23,7 @@ jobs:
           BODY=$(gh pr view "$PR_NUMBER" -R jdx/hk --json body --jq '.body // ""')
           TRIMMED_BODY=$(echo "$BODY" | tr -d '[:space:]')
           if [ -z "$TRIMMED_BODY" ]; then
-            echo "PR #$PR_NUMBER has no description, never merging"
+            echo "Skipping merge: PR #$PR_NUMBER has an empty body; will retry on the next scheduled run"
             exit 0
           fi
 

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -6,11 +6,16 @@ on:
     - cron: "0 10 * * 1"
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: auto-merge-release
+  cancel-in-progress: false
+
 jobs:
   merge:
     if: github.repository == 'jdx/hk'
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Merge release into main
         run: |
@@ -28,10 +33,6 @@ jobs:
           fi
 
           echo "PR #$PR_NUMBER is ready for the Monday morning release window"
-
-          gh pr merge "$PR_NUMBER" -R jdx/hk --squash --auto || {
-            echo "Merge failed or PR not ready, will retry on the next run"
-            exit 0
-          }
+          gh pr merge "$PR_NUMBER" -R jdx/hk --squash --auto
         env:
           GH_TOKEN: ${{ secrets.HK_GH_TOKEN }}

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -19,7 +19,10 @@ jobs:
     steps:
       - name: Merge release into main
         run: |
-          PR_NUMBER=$(gh pr list -R jdx/hk --base main --head release --state open --json number --jq '.[0].number // empty')
+          set -euo pipefail
+
+          PR_NUMBER=$(gh pr list -R jdx/hk --base main --head release --state open --limit 100 --json number,headRefName,headRepositoryOwner \
+            --jq '[.[] | select(.headRefName == "release") | select(.headRepositoryOwner.login == "jdx")][0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
             echo "No open PR from release to main"
             exit 0

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,36 @@
+name: auto-merge-release
+
+on:
+  schedule:
+    # 10:00 UTC = 4am CST (winter) / 5am CDT (summer)
+    - cron: "0 10 * * 1"
+  workflow_dispatch:
+
+jobs:
+  merge:
+    if: github.repository == 'jdx/hk'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge release into main
+        run: |
+          PR_NUMBER=$(gh pr list -R jdx/hk --base main --head release --state open --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR from release to main"
+            exit 0
+          fi
+
+          BODY=$(gh pr view "$PR_NUMBER" -R jdx/hk --json body --jq '.body // ""')
+          TRIMMED_BODY=$(echo "$BODY" | tr -d '[:space:]')
+          if [ -z "$TRIMMED_BODY" ]; then
+            echo "PR #$PR_NUMBER has no description, never merging"
+            exit 0
+          fi
+
+          echo "PR #$PR_NUMBER is ready for the Monday morning release window"
+
+          gh pr merge "$PR_NUMBER" -R jdx/hk --squash --auto || {
+            echo "Merge failed or PR not ready, will retry on the next run"
+            exit 0
+          }
+        env:
+          GH_TOKEN: ${{ secrets.HK_GH_TOKEN }}


### PR DESCRIPTION
## Summary

- Add an auto-merge workflow for release PRs.
- Run it Monday morning only at `0 10 * * 1` UTC.
- Target the existing `release` branch PR created by the release-plz task.

## Validation

- `actionlint -stdin-filename .github/workflows/auto-merge-release.yml -`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automated merges to `main` depend on correct PR selection and token permissions; a misconfigured or overly broad merge could ship release changes without the usual manual gate.
> 
> **Overview**
> Adds **`auto-merge-release`**, a GitHub Actions workflow that **squash auto-merges** the open **`release` → `main`** PR (from release-plz) on a **Monday 10:00 UTC** cron, with **`workflow_dispatch`** for manual runs.
> 
> The job is limited to **`jdx/hk`**, uses a **concurrency group** so overlapping runs don’t cancel each other, and **no default workflow permissions** (merge is done via **`GH_TOKEN`** / `HK_GH_TOKEN`). It **no-ops** if there is no matching PR, and **skips merge** when the PR body is empty (whitespace-only) so a later run can retry once release notes are filled in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d751eb8056dc7dbcddc7cafba806ff7719f9e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->