### PR TITLE
ci: gate autorelease on fix and feat commits

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -2,8 +2,7 @@ name: auto-merge-release
 
 on:
   schedule:
-    # 10:00 UTC = 4am CST (winter) / 5am CDT (summer)
-    - cron: "0 10 * * 1"
+    - cron: "0 10 * * *"
   workflow_dispatch:
 
 permissions: {}
@@ -27,6 +26,14 @@ jobs:
           latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
           if [ -n "$latest_tag" ]; then
             range="${latest_tag}..HEAD"
+            tag_time=$(git log -1 --format=%ct "$latest_tag")
+            now=$(date +%s)
+            min_age=$((7 * 24 * 60 * 60))
+            age=$((now - tag_time))
+            if [ "$age" -lt "$min_age" ]; then
+              echo "Latest release ${latest_tag} is less than 7 days old; not auto-merging release PRs"
+              exit 0
+            fi
           else
             range="HEAD"
           fi
@@ -49,7 +56,7 @@ jobs:
             exit 0
           fi
 
-          echo "PR #$PR_NUMBER is ready for the Monday morning release window"
+          echo "PR #$PR_NUMBER is ready for the daily release window"
           gh pr merge "$PR_NUMBER" -R jdx/hk --squash --auto
         env:
           GH_TOKEN: ${{ secrets.HK_GH_TOKEN }}

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -21,28 +21,37 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # zizmor: ignore[artipacked] v6
         with:
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
       - name: Merge release into main
         run: |
           set -euo pipefail
 
-          latest_tag=$(git describe --tags --match 'v[0-9]*' --abbrev=0 || true)
-          if [ -n "$latest_tag" ]; then
-            range="${latest_tag}..HEAD"
-            tag_time=$(git for-each-ref --format='%(creatordate:unix)' "refs/tags/$latest_tag")
-            now=$(date +%s)
-            min_age=$((7 * 24 * 60 * 60))
-            age=$((now - tag_time))
-            if [ "$age" -lt "$min_age" ]; then
-              echo "Latest release ${latest_tag} is less than 7 days old; not auto-merging release PRs"
-              exit 0
+          if [ "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" ]; then
+            latest_tag=$(git describe --tags --match 'v[0-9]*' --abbrev=0 || true)
+            if [ -n "$latest_tag" ]; then
+              range="${latest_tag}..HEAD"
+              tag_time=$(git for-each-ref --format='%(creatordate:unix)' "refs/tags/$latest_tag")
+              now=$(date +%s)
+              min_age=$((7 * 24 * 60 * 60))
+              age=$((now - tag_time))
+              if [ "$age" -lt "$min_age" ]; then
+                echo "Latest release ${latest_tag} is less than 7 days old; not auto-merging release PRs"
+                exit 0
+              fi
+            else
+              echo "No v[0-9]* release tag found; allowing bootstrap release"
+              range=""
+            fi
+            if [ -n "$range" ]; then
+              commit_subjects=$(git log --format=%s "$range")
+              if ! grep -Eq '^(fix|feat)(\([^)]+\))?!?: ' <<<"$commit_subjects"; then
+                echo "No pending fix/feat commits since the latest release; not auto-merging release PRs"
+                exit 0
+              fi
             fi
           else
-            range="HEAD"
-          fi
-          if ! git log --format=%s "$range" | grep -Eq '^(fix|feat)(\([^)]+\))?!?: '; then
-            echo "No pending fix/feat commits since the latest release; not auto-merging release PRs"
-            exit 0
+            echo "Manual dispatch; skipping release cadence guards"
           fi
 
           PR_NUMBER=$(gh pr list -R jdx/hk --base main --head release --state open --limit 100 --json number,headRefName,headRepositoryOwner \

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -15,18 +15,21 @@ jobs:
   merge:
     if: github.repository == 'jdx/hk'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # zizmor: ignore[artipacked] v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Merge release into main
         run: |
           set -euo pipefail
 
-          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
+          latest_tag=$(git describe --tags --match 'v[0-9]*' --abbrev=0 || true)
           if [ -n "$latest_tag" ]; then
             range="${latest_tag}..HEAD"
-            tag_time=$(git log -1 --format=%ct "$latest_tag")
+            tag_time=$(git for-each-ref --format='%(creatordate:unix)' "refs/tags/$latest_tag")
             now=$(date +%s)
             min_age=$((7 * 24 * 60 * 60))
             age=$((now - tag_time))

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -17,9 +17,23 @@ jobs:
     if: github.repository == 'jdx/hk'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # zizmor: ignore[artipacked] v6
+        with:
+          fetch-depth: 0
       - name: Merge release into main
         run: |
           set -euo pipefail
+
+          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
+          if [ -n "$latest_tag" ]; then
+            range="${latest_tag}..HEAD"
+          else
+            range="HEAD"
+          fi
+          if ! git log --format=%s "$range" | grep -Eq '^(fix|feat)(\([^)]+\))?!?: '; then
+            echo "No pending fix/feat commits since the latest release; not auto-merging release PRs"
+            exit 0
+          fi
 
           PR_NUMBER=$(gh pr list -R jdx/hk --base main --head release --state open --limit 100 --json number,headRefName,headRepositoryOwner \
             --jq '[.[] | select(.headRefName == "release") | select(.headRepositoryOwner.login == "jdx")][0].number // empty')

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - release-plz
+  schedule:
+    - cron: "0 0 * * *"
 
 concurrency:
   group: release-plz
@@ -25,7 +27,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # zizmor: ignore[artipacked] v6
         with:
           fetch-depth: 0
-      - name: Check for fix/feat commits since the latest release
+      - name: Check release age and fix/feat commits
         id: commits
         run: |
           set -euo pipefail
@@ -34,6 +36,15 @@ jobs:
           if [ -n "$latest_tag" ]; then
             range="${latest_tag}..HEAD"
             echo "Checking pending commits since ${latest_tag}"
+            tag_time=$(git log -1 --format=%ct "$latest_tag")
+            now=$(date +%s)
+            min_age=$((7 * 24 * 60 * 60))
+            age=$((now - tag_time))
+            if [ "$age" -lt "$min_age" ]; then
+              echo "Latest release ${latest_tag} is less than 7 days old; skipping autorelease."
+              echo "has_release_commits=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           else
             range="HEAD"
             echo "No v* release tag found; checking all commits"

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - main
       - release-plz
-  schedule:
-    - cron: "0 0 * * *"
 
 concurrency:
   group: release-plz
@@ -18,48 +16,8 @@ env:
   DRY_RUN: 0
 
 jobs:
-  pending-release:
-    if: github.repository == 'jdx/hk'
-    runs-on: ubuntu-latest
-    outputs:
-      has_release_commits: ${{ steps.commits.outputs.has_release_commits }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # zizmor: ignore[artipacked] v6
-        with:
-          fetch-depth: 0
-      - name: Check release age and fix/feat commits
-        id: commits
-        run: |
-          set -euo pipefail
-
-          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
-          if [ -n "$latest_tag" ]; then
-            range="${latest_tag}..HEAD"
-            echo "Checking pending commits since ${latest_tag}"
-            tag_time=$(git log -1 --format=%ct "$latest_tag")
-            now=$(date +%s)
-            min_age=$((7 * 24 * 60 * 60))
-            age=$((now - tag_time))
-            if [ "$age" -lt "$min_age" ]; then
-              echo "Latest release ${latest_tag} is less than 7 days old; skipping autorelease."
-              echo "has_release_commits=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          else
-            range="HEAD"
-            echo "No v* release tag found; checking all commits"
-          fi
-
-          if git log --format=%s "$range" | grep -Eq '^(fix|feat)(\([^)]+\))?!?: '; then
-            echo "has_release_commits=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No pending fix/feat commits; skipping autorelease."
-            echo "has_release_commits=false" >> "$GITHUB_OUTPUT"
-          fi
-
   release-plz:
-    needs: pending-release
-    if: github.repository == 'jdx/hk' && needs.pending-release.outputs.has_release_commits == 'true'
+    if: github.repository == 'jdx/hk'
     runs-on: namespace-profile-endev-linux-amd64
     permissions:
       contents: write

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -16,8 +16,39 @@ env:
   DRY_RUN: 0
 
 jobs:
-  release-plz:
+  pending-release:
     if: github.repository == 'jdx/hk'
+    runs-on: ubuntu-latest
+    outputs:
+      has_release_commits: ${{ steps.commits.outputs.has_release_commits }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # zizmor: ignore[artipacked] v6
+        with:
+          fetch-depth: 0
+      - name: Check for fix/feat commits since the latest release
+        id: commits
+        run: |
+          set -euo pipefail
+
+          latest_tag=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -1 || true)
+          if [ -n "$latest_tag" ]; then
+            range="${latest_tag}..HEAD"
+            echo "Checking pending commits since ${latest_tag}"
+          else
+            range="HEAD"
+            echo "No v* release tag found; checking all commits"
+          fi
+
+          if git log --format=%s "$range" | grep -Eq '^(fix|feat)(\([^)]+\))?!?: '; then
+            echo "has_release_commits=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No pending fix/feat commits; skipping autorelease."
+            echo "has_release_commits=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  release-plz:
+    needs: pending-release
+    if: github.repository == 'jdx/hk' && needs.pending-release.outputs.has_release_commits == 'true'
     runs-on: namespace-profile-endev-linux-amd64
     permissions:
       contents: write


### PR DESCRIPTION
## What changed

- Adds a preflight check to the release-plz workflow that looks for pending `fix` or `feat` conventional commits since the latest `v[0-9]*` release tag.
- Skips the automatic release-plz job when no release-worthy commits are pending.
- Adds the same guard before the scheduled release PR auto-merge.

## Why

This keeps automatic releases from running for maintenance-only commit ranges, while still allowing real fix/feature changes to publish automatically.

## Validation

- `actionlint .github/workflows/release-plz.yml .github/workflows/auto-merge-release.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect CI scheduling and merge preconditions; manual dispatch bypasses the new guards and no application or auth code is touched.
> 
> **Overview**
> **Tightens when the `release` → `main` PR is auto-merged** by adding scheduled-run guards and switching from a weekly Monday window to a **daily** 10:00 UTC cron.
> 
> On non-manual runs, the job now checks out full history/tags, then exits early unless the latest `v[0-9]*` tag is at least **7 days old** and there is at least one **`fix`/`feat` conventional commit** since that tag (bootstrap allowed when no tag exists). **`workflow_dispatch` skips these guards.** The merge step still requires a non-empty PR body and uses the same `gh pr merge --squash --auto` flow; logging now refers to a **daily** release window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6b576e149a561f6a43e3dde6eb7bd9f4018dc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->