### PR TITLE
chore: release v1.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [1.51.0](https://github.com/jdx/hk/compare/v1.50.0..v1.51.0) - 2026-07-13
+
+### 🚀 Features
+
+- **(builtins)** add sherif linter by [@smasato](https://github.com/smasato) in [#1062](https://github.com/jdx/hk/pull/1062)
+- **(config)** add disjunctive file selectors by [@risu729](https://github.com/risu729) in [#1055](https://github.com/jdx/hk/pull/1055)
+- **(step)** add structured argv commands by [@jdx](https://github.com/jdx) in [#1067](https://github.com/jdx/hk/pull/1067)
+
+### 🐛 Bug Fixes
+
+- **(install)** avoid duplicating config hook arguments by [@jdx](https://github.com/jdx) in [#1065](https://github.com/jdx/hk/pull/1065)
+- **(stash)** wait for transient index locks by [@jdx](https://github.com/jdx) in [#1060](https://github.com/jdx/hk/pull/1060)
+- **(step)** respect linux argument size limit by [@jdx](https://github.com/jdx) in [#1066](https://github.com/jdx/hk/pull/1066)
+- make --quiet and --silent suppress progress output by [@smasato](https://github.com/smasato) in [#1058](https://github.com/jdx/hk/pull/1058)
+
+### 📚 Documentation
+
+- align social links icons vertically center by [@smasato](https://github.com/smasato) in [#1059](https://github.com/jdx/hk/pull/1059)
+
+### 🧪 Testing
+
+- **(step)** make check list failure test deterministic by [@jdx](https://github.com/jdx) in [#1068](https://github.com/jdx/hk/pull/1068)
+
+### 🛡️ Security
+
+- **(deps)** update namespacelabs/nscloud-cache-action action to v1.6.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1054](https://github.com/jdx/hk/pull/1054)
+
+### 🔍 Other Changes
+
+- **(release)** skip ai reviews for release prs by [@jdx](https://github.com/jdx) in [#1049](https://github.com/jdx/hk/pull/1049)
+- gate autorelease on fix and feat commits by [@jdx](https://github.com/jdx) in [#1046](https://github.com/jdx/hk/pull/1046)
+
+### 📦️ Dependency Updates
+
+- update anthropics/claude-code-action action to v1.0.163 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1051](https://github.com/jdx/hk/pull/1051)
+- update rust crate pklr to v1.1.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1053](https://github.com/jdx/hk/pull/1053)
+- update rust crate demand to v2.0.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1052](https://github.com/jdx/hk/pull/1052)
+- update anthropics/claude-code-action action to v1.0.165 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1057](https://github.com/jdx/hk/pull/1057)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1064](https://github.com/jdx/hk/pull/1064)
+
 ## [1.50.0](https://github.com/jdx/hk/compare/v1.49.0..v1.50.0) - 2026-07-06
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.50.0"
+version = "1.51.0"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "hk"
 repository = "https://github.com/jdx/hk"
 rust-version = "1.88.0"
-version = "1.50.0"
+version = "1.51.0"
 
 [[bin]]
 name = "generate-docs"

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 140+ pre-configured linters and formatters through the `Builtins` mo
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -4943,7 +4943,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.50.0",
+  "version": "1.51.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.50.0
+**Version**: 1.51.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined
@@ -261,8 +261,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -295,7 +295,7 @@ Add steps to your hkrc. hk merges them into every project's hooks — steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -388,7 +388,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,8 +105,8 @@ Separately from global *hooks*, you can also create a global *config* file that 
 `hk init` generates an `hk.pkl` file in the root of the repository. Here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -43,7 +43,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,8 +3,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,8 +3,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,8 +3,8 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,8 +4,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -6,8 +6,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -6,8 +6,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -13,8 +13,8 @@ Groups can set common step attributes such as `dir`, `workspace_indicator`, `pre
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -7,8 +7,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
 amends "pkl/Config.pkl"
 import "pkl/Builtins.pkl"
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.50.0"
+version "1.51.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)" hide=#true global=#true {


### PR DESCRIPTION
### 🚀 Features

- **(builtins)** add sherif linter by [@smasato](https://github.com/smasato) in [#1062](https://github.com/jdx/hk/pull/1062)
- **(config)** add disjunctive file selectors by [@risu729](https://github.com/risu729) in [#1055](https://github.com/jdx/hk/pull/1055)
- **(step)** add structured argv commands by [@jdx](https://github.com/jdx) in [#1067](https://github.com/jdx/hk/pull/1067)

### 🐛 Bug Fixes

- **(install)** avoid duplicating config hook arguments by [@jdx](https://github.com/jdx) in [#1065](https://github.com/jdx/hk/pull/1065)
- **(stash)** wait for transient index locks by [@jdx](https://github.com/jdx) in [#1060](https://github.com/jdx/hk/pull/1060)
- **(step)** respect linux argument size limit by [@jdx](https://github.com/jdx) in [#1066](https://github.com/jdx/hk/pull/1066)
- make --quiet and --silent suppress progress output by [@smasato](https://github.com/smasato) in [#1058](https://github.com/jdx/hk/pull/1058)

### 📚 Documentation

- align social links icons vertically center by [@smasato](https://github.com/smasato) in [#1059](https://github.com/jdx/hk/pull/1059)

### 🧪 Testing

- **(step)** make check list failure test deterministic by [@jdx](https://github.com/jdx) in [#1068](https://github.com/jdx/hk/pull/1068)

### 🛡️ Security

- **(deps)** update namespacelabs/nscloud-cache-action action to v1.6.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1054](https://github.com/jdx/hk/pull/1054)

### 🔍 Other Changes

- **(release)** skip ai reviews for release prs by [@jdx](https://github.com/jdx) in [#1049](https://github.com/jdx/hk/pull/1049)
- gate autorelease on fix and feat commits by [@jdx](https://github.com/jdx) in [#1046](https://github.com/jdx/hk/pull/1046)

### 📦️ Dependency Updates

- update anthropics/claude-code-action action to v1.0.163 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1051](https://github.com/jdx/hk/pull/1051)
- update rust crate pklr to v1.1.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1053](https://github.com/jdx/hk/pull/1053)
- update rust crate demand to v2.0.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1052](https://github.com/jdx/hk/pull/1052)
- update anthropics/claude-code-action action to v1.0.165 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1057](https://github.com/jdx/hk/pull/1057)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1064](https://github.com/jdx/hk/pull/1064)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and documentation sync only; no runtime code changes in the diff.
> 
> **Overview**
> **Release v1.51.0** — bumps the crate and CLI from `1.50.0` to `1.51.0` in `Cargo.toml`, `Cargo.lock`, and `hk.usage.kdl`, and adds a **CHANGELOG** section for this release.
> 
> Docs and examples are updated so Pkl `amends` / `import` URLs and generated CLI metadata (`docs/cli/*`) point at **v1.51.0** instead of v1.50.0. No Rust hook/runtime logic changes appear in this diff; shipped behavior is whatever landed in earlier PRs (sherif builtin, disjunctive file selectors, structured argv commands, stash/install/step fixes, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b127160aa9d1e4c9cc7f7316d0e48b9debb66f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->