### PR TITLE
fix(release): add macos x86 target

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,3 +3,4 @@ self-hosted-runner:
     - namespace-profile-endev-linux-amd64
     - namespace-profile-endev-linux-arm64
     - namespace-profile-endev-macos-arm64
+    - namespace-profile-endev-macos-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
             os: macos-latest
             runner: namespace-profile-endev-macos-arm64
             build-tool: cargo
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            runner: namespace-profile-endev-macos-amd64
+            build-tool: cargo
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64


### PR DESCRIPTION
Some friends are still on Intel macs, would it be possible to support them? If not, no worries!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an additional macOS Intel (`x86_64`) build target for release binaries, expanding availability for more Mac users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->