### PR TITLE
feat(config): add disjunctive file selectors

### DIFF
--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -261,6 +261,16 @@ class Hook {
   steps: Mapping<String, Step | Group> = new Mapping<String, Step> {}
 }
 
+/// A positive file-selection clause used by `Step.match_any`.
+/// Within a selector, `glob` and `types` compose with AND semantics.
+class FileSelector {
+  /// Glob or regex patterns to match.
+  glob: (String | List<String> | Regex)?
+
+  /// File types to match. A file may match any listed type.
+  types: List<String>?
+}
+
 class Step {
   /// List of environment variables that must be set for this step to run.
   /// A variable is considered satisfied if it is present in the process environment,
@@ -343,6 +353,24 @@ class Step {
   /// 3. Special filenames (e.g., `Dockerfile` → `dockerfile`)
   /// 4. Content/magic number detection for binary files
   types: List<String>?
+
+  /// Match files using any of the supplied selector clauses.
+  /// Selectors compose with OR semantics, while `glob` and `types` within
+  /// each selector compose with AND semantics.
+  ///
+  /// `match_any` cannot be combined with the top-level `glob` or `types`
+  /// fields. Each selector must contain a non-empty `glob` or `types` value.
+  ///
+  /// ```pkl
+  /// ["shellcheck"] {
+  ///   match_any = List(
+  ///     new { glob = List("**/*.sh", "**/*.bash") },
+  ///     new { types = List("shell") }
+  ///   )
+  ///   check = "shellcheck {{files}}"
+  /// }
+  /// ```
+  match_any: List<FileSelector>?
 
   /// Whether to include symbolic links (default: false)
   allow_symlinks: Boolean = false

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -365,7 +365,7 @@ class Step {
   /// ["shellcheck"] {
   ///   match_any = List(
   ///     new { glob = List("**/*.sh", "**/*.bash") },
-  ///     new { types = List("shell") }
+  ///     new { types = List("sh", "bash") }
   ///   )
   ///   check = "shellcheck {{files}}"
   /// }

--- a/pkl/builtins/shellcheck.pkl
+++ b/pkl/builtins/shellcheck.pkl
@@ -14,7 +14,7 @@ shellcheck = new Config.Step {
   match_any =
     List(
       new Config.FileSelector { glob = List("**/*.sh", "**/*.bash") },
-      new Config.FileSelector { types = List("shell") },
+      new Config.FileSelector { types = List("sh", "bash") },
     )
   check = "shellcheck {{ files }}"
   tests {
@@ -23,7 +23,11 @@ shellcheck = new Config.Step {
     }
     ["check bad file"] = testMaker.checkFail("#!/usr/bin/bash\necho 'oops I'm escaped'", 1)
     ["check good file"] = testMaker.checkPass("#!/usr/bin/bash\necho 'oops I'\\''m escaped'\n")
+    local const extensionlessTestMaker = new helpers.TestMaker {
+      filename = "script"
+      files = List("script")
+    }
     ["check extensionless shell script"] =
-      testMaker.withFilename("script").checkFail("#!/bin/sh\necho 'oops I'm escaped'", 1)
+      extensionlessTestMaker.checkFail("#!/bin/sh\necho 'oops I'm escaped'", 1)
   }
 }

--- a/pkl/builtins/shellcheck.pkl
+++ b/pkl/builtins/shellcheck.pkl
@@ -11,7 +11,11 @@ import "./test/helpers.pkl"
 }
 shellcheck = new Config.Step {
   batch = true
-  glob = List("**/*.sh", "**/*.bash")
+  match_any =
+    List(
+      new Config.FileSelector { glob = List("**/*.sh", "**/*.bash") },
+      new Config.FileSelector { types = List("shell") },
+    )
   check = "shellcheck {{ files }}"
   tests {
     local const testMaker = new helpers.TestMaker {
@@ -19,5 +23,7 @@ shellcheck = new Config.Step {
     }
     ["check bad file"] = testMaker.checkFail("#!/usr/bin/bash\necho 'oops I'm escaped'", 1)
     ["check good file"] = testMaker.checkPass("#!/usr/bin/bash\necho 'oops I'\\''m escaped'\n")
+    ["check extensionless shell script"] =
+      testMaker.withFilename("script").checkFail("#!/bin/sh\necho 'oops I'm escaped'", 1)
   }
 }

--- a/pkl/builtins/shfmt.pkl
+++ b/pkl/builtins/shfmt.pkl
@@ -16,7 +16,7 @@ shfmt = new Config.Step {
       new Config.FileSelector {
         glob = List("**/*.sh", "**/*.bash", "**/*.mksh", "**/*.bats", "**/*.zsh")
       },
-      new Config.FileSelector { types = List("shell") },
+      new Config.FileSelector { types = List("sh", "bash") },
     )
   check_diff = "shfmt -d --apply-ignore {{ files }}"
   check_list_files =
@@ -47,7 +47,10 @@ shfmt = new Config.Step {
     ["fix bad file"] = testMaker.fixPass(before, after)
     ["fix good file"] = testMaker.fixPass(after, after)
 
-    local const extensionlessTestMaker = testMaker.withFilename("script")
+    local const extensionlessTestMaker = new helpers.TestMaker {
+      filename = "script"
+      files = List("script")
+    }
     ["check extensionless shell script"] =
       extensionlessTestMaker.checkFail(
         "#!/bin/sh\n" + before,

--- a/pkl/builtins/shfmt.pkl
+++ b/pkl/builtins/shfmt.pkl
@@ -11,7 +11,13 @@ import "./test/helpers.pkl"
 }
 shfmt = new Config.Step {
   batch = true
-  glob = List("**/*.sh", "**/*.bash", "**/*.mksh", "**/*.bats", "**/*.zsh")
+  match_any =
+    List(
+      new Config.FileSelector {
+        glob = List("**/*.sh", "**/*.bash", "**/*.mksh", "**/*.bats", "**/*.zsh")
+      },
+      new Config.FileSelector { types = List("shell") },
+    )
   check_diff = "shfmt -d --apply-ignore {{ files }}"
   check_list_files =
     """
@@ -40,6 +46,13 @@ shfmt = new Config.Step {
     ["check good file"] = testMaker.checkPass(after)
     ["fix bad file"] = testMaker.fixPass(before, after)
     ["fix good file"] = testMaker.fixPass(after, after)
+
+    local const extensionlessTestMaker = testMaker.withFilename("script")
+    ["check extensionless shell script"] =
+      extensionlessTestMaker.checkFail(
+        "#!/bin/sh\n" + before,
+        1,
+      )
 
     local const ignoredTestMaker = new helpers.TestMaker {
       filename = "test.sh"

--- a/pkl/builtins/test/helpers.pkl
+++ b/pkl/builtins/test/helpers.pkl
@@ -6,6 +6,9 @@ class TestMaker {
   /// The name of the file to run the command on.
   filename: String = "file.txt"
 
+  /// Explicit files to pass to the command. Defaults to the written file keys.
+  files: List<String>?
+
   /// Extra files to include in the sandbox, useful for config files.
   extra_files: Mapping<String, String> = new Mapping {}
 
@@ -20,6 +23,7 @@ class TestMaker {
     expectedCode: Int,
   ): Config.StepTest = new Config.StepTest {
     run = runType
+    files = outer.files
     before = outer.before
     tmpdir = true
     write = new Mapping<String, String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -316,6 +316,7 @@ impl Config {
             }
 
             if let Some(glob) = &step_config.glob {
+                step.match_any = None;
                 step.glob = Some(glob.clone());
             }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -710,31 +710,19 @@ impl std::fmt::Display for Config {
 
 impl Config {
     pub fn validate(&self) -> Result<()> {
-        // Validate that steps with 'stage' attribute also have a 'fix' command
         for (hook_name, hook) in &self.hooks {
             for (step_name, step_or_group) in &hook.steps {
                 match step_or_group {
                     crate::hook::StepOrGroup::Step(step) => {
-                        if step.stage.is_some() && step.fix.is_none() {
-                            bail!(
-                                "Step '{}' in hook '{}' has 'stage' attribute but no 'fix' command. \
-                                Steps that stage files must have a fix command.",
-                                step_name,
-                                hook_name
-                            );
-                        }
+                        validate_step(step, step_name, &format!("in hook '{hook_name}'"))?;
                     }
                     crate::hook::StepOrGroup::Group(group) => {
                         for (group_step_name, group_step) in &group.steps {
-                            if group_step.stage.is_some() && group_step.fix.is_none() {
-                                bail!(
-                                    "Step '{}' in group '{}' of hook '{}' has 'stage' attribute but no 'fix' command. \
-                                    Steps that stage files must have a fix command.",
-                                    group_step_name,
-                                    step_name,
-                                    hook_name
-                                );
-                            }
+                            validate_step(
+                                group_step,
+                                group_step_name,
+                                &format!("in group '{step_name}' of hook '{hook_name}'"),
+                            )?;
                         }
                     }
                 }
@@ -742,6 +730,69 @@ impl Config {
         }
         Ok(())
     }
+}
+
+fn validate_step(step: &crate::step::Step, step_name: &str, location: &str) -> Result<()> {
+    if step.stage.is_some() && step.fix.is_none() {
+        bail!(
+            "Step '{}' {} has 'stage' attribute but no 'fix' command. \
+            Steps that stage files must have a fix command.",
+            step_name,
+            location
+        );
+    }
+
+    let Some(selectors) = &step.match_any else {
+        return Ok(());
+    };
+
+    if step.glob.is_some() || step.types.is_some() {
+        bail!(
+            "Step '{}' {} cannot combine 'match_any' with top-level 'glob' or 'types'.",
+            step_name,
+            location
+        );
+    }
+    if selectors.is_empty() {
+        bail!(
+            "Step '{}' {} has an empty 'match_any'; add at least one selector.",
+            step_name,
+            location
+        );
+    }
+    for (index, selector) in selectors.iter().enumerate() {
+        if selector
+            .glob
+            .as_ref()
+            .is_some_and(crate::step::Pattern::is_empty)
+        {
+            bail!(
+                "Step '{}' {} has an empty 'glob' in 'match_any' selector {}.",
+                step_name,
+                location,
+                index + 1
+            );
+        }
+        if selector.types.as_ref().is_some_and(Vec::is_empty) {
+            bail!(
+                "Step '{}' {} has an empty 'types' in 'match_any' selector {}.",
+                step_name,
+                location,
+                index + 1
+            );
+        }
+        if selector.is_empty() {
+            bail!(
+                "Step '{}' {} has an empty 'match_any' selector {}. \
+                Each selector must define a non-empty 'glob' or 'types'.",
+                step_name,
+                location,
+                index + 1
+            );
+        }
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/src/step/batching.rs
+++ b/src/step/batching.rs
@@ -219,6 +219,7 @@ impl Step {
     /// versus "run on all files".
     pub(crate) fn has_filters(&self) -> bool {
         self.glob.is_some()
+            || self.match_any.is_some()
             || self.dir.is_some()
             || self
                 .exclude

--- a/src/step/filtering.rs
+++ b/src/step/filtering.rs
@@ -17,7 +17,7 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::sync::LazyLock;
 
-use super::types::Step;
+use super::{FileSelector, Pattern, Step};
 
 /// Check if a file is binary by reading the first 8KB and looking for null bytes.
 ///
@@ -90,6 +90,30 @@ pub fn is_symlink_file(path: &PathBuf) -> Option<bool> {
 }
 
 impl Step {
+    fn filter_match_any_selector(
+        &self,
+        files: &[PathBuf],
+        selector: &FileSelector,
+    ) -> Result<Vec<PathBuf>> {
+        self.filter_selector(files, selector.glob.as_ref(), selector.types.as_deref())
+    }
+
+    fn filter_selector(
+        &self,
+        files: &[PathBuf],
+        pattern: Option<&Pattern>,
+        types: Option<&[String]>,
+    ) -> Result<Vec<PathBuf>> {
+        let mut files = files.to_vec();
+        if let Some(pattern) = pattern {
+            files = glob::get_pattern_matches(pattern, &files, self.dir.as_deref())?;
+        }
+        if let Some(types) = types {
+            files.retain(|f| crate::file_type::matches_types(f, types));
+        }
+        Ok(files)
+    }
+
     /// Get the profiles that enable this step.
     ///
     /// Returns profiles from the `profiles` field that don't start with `!`.
@@ -157,11 +181,10 @@ impl Step {
     ///
     /// Applies the following filters in order:
     /// 1. Directory filter (`dir`) - only files under this directory
-    /// 2. Glob/regex pattern (`glob`) - must match pattern
+    /// 2. Positive selectors (`glob` + `types`, or `match_any` clauses)
     /// 3. Exclusion pattern (`exclude`) - must not match
     /// 4. Binary filter (`allow_binary`) - skip binary files unless allowed
     /// 5. Symlink filter (`allow_symlinks`) - skip symlinks unless allowed
-    /// 6. Type filter (`types`) - must match file type
     ///
     /// # Arguments
     ///
@@ -180,10 +203,15 @@ impl Step {
             // Don't strip the dir prefix here - it causes issues when steps have different working directories
             // The path stripping should only happen in the command execution context via tera templates
         }
-        if let Some(pattern) = &self.glob {
-            // Use get_pattern_matches consistently for both globs and regex
-            files = glob::get_pattern_matches(pattern, &files, self.dir.as_deref())?;
-        }
+        files = if let Some(selectors) = &self.match_any {
+            let mut matched = IndexSet::new();
+            for selector in selectors {
+                matched.extend(self.filter_match_any_selector(&files, selector)?);
+            }
+            matched.into_iter().collect()
+        } else {
+            self.filter_selector(&files, self.glob.as_ref(), self.types.as_deref())?
+        };
         if let Some(pattern) = self.exclude.as_ref().filter(|pattern| !pattern.is_empty()) {
             // Use get_pattern_matches consistently for excludes too
             let excluded: HashSet<_> =
@@ -211,11 +239,6 @@ impl Step {
                     .map(|is_symlink| !is_symlink)
                     .unwrap_or(true)
             });
-        }
-
-        // Filter by file types if specified
-        if let Some(types) = &self.types {
-            files.retain(|f| crate::file_type::matches_types(f, types));
         }
 
         Ok(files)

--- a/src/step/filtering.rs
+++ b/src/step/filtering.rs
@@ -204,11 +204,14 @@ impl Step {
             // The path stripping should only happen in the command execution context via tera templates
         }
         files = if let Some(selectors) = &self.match_any {
-            let mut matched = IndexSet::new();
+            let mut matched = HashSet::new();
             for selector in selectors {
                 matched.extend(self.filter_match_any_selector(&files, selector)?);
             }
-            matched.into_iter().collect()
+            files
+                .into_iter()
+                .filter(|file| matched.contains(file))
+                .collect()
         } else {
             self.filter_selector(&files, self.glob.as_ref(), self.types.as_deref())?
         };
@@ -279,5 +282,30 @@ impl Step {
             }
         }
         Ok(Some(workspaces))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn match_any_preserves_input_order() {
+        let step = Step {
+            match_any: Some(vec![
+                FileSelector {
+                    glob: Some(Pattern::Globs(vec!["**/*.bats".to_string()])),
+                    types: None,
+                },
+                FileSelector {
+                    glob: Some(Pattern::Globs(vec!["**/*.sh".to_string()])),
+                    types: None,
+                },
+            ]),
+            ..Default::default()
+        };
+        let files = vec![PathBuf::from("first.sh"), PathBuf::from("second.bats")];
+
+        assert_eq!(step.filter_files(&files).unwrap(), files);
     }
 }

--- a/src/step/mod.rs
+++ b/src/step/mod.rs
@@ -47,7 +47,7 @@ mod types;
 // Re-export public API
 pub use expr_env::{EXPR_CTX, EXPR_ENV};
 pub use shell::ShellType;
-pub use types::{OutputSummary, Pattern, RunType, Script, Step};
+pub use types::{FileSelector, OutputSummary, Pattern, RunType, Script, Step};
 
 // Re-export for potential external use (currently only used internally)
 #[allow(unused_imports)]

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -114,17 +114,16 @@ impl Step {
         let mut tctx = job.tctx(&ctx.hook_ctx.tctx);
         // `{{globs}}` contains every positive glob/regex pattern. Type-only
         // selectors are represented by the already-filtered `{{files}}` list.
-        let globs = self
-            .match_any
-            .as_ref()
-            .map(|selectors| {
-                selectors
-                    .iter()
-                    .filter_map(|selector| selector.glob.as_ref())
-            })
+        let patterns = if let Some(selectors) = &self.match_any {
+            selectors
+                .iter()
+                .filter_map(|selector| selector.glob.as_ref())
+                .collect::<Vec<_>>()
+        } else {
+            self.glob.iter().collect()
+        };
+        let globs = patterns
             .into_iter()
-            .flatten()
-            .chain(self.glob.iter())
             .flat_map(|pattern| match pattern {
                 Pattern::Globs(globs) => globs.clone(),
                 Pattern::Regex { pattern, .. } => vec![pattern.clone()],

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -112,19 +112,25 @@ impl Step {
             return Ok(());
         }
         let mut tctx = job.tctx(&ctx.hook_ctx.tctx);
-        // Set {{globs}} template variable based on pattern type
-        match self.glob.as_ref() {
-            Some(Pattern::Globs(g)) => {
-                tctx.with_globs(g.as_slice());
-            }
-            Some(Pattern::Regex { pattern, .. }) => {
-                // For regex patterns, provide the pattern string so templates can use it
-                tctx.insert("globs", pattern);
-            }
-            None => {
-                tctx.with_globs(&[] as &[&str]);
-            }
-        }
+        // `{{globs}}` contains every positive glob/regex pattern. Type-only
+        // selectors are represented by the already-filtered `{{files}}` list.
+        let globs = self
+            .match_any
+            .as_ref()
+            .map(|selectors| {
+                selectors
+                    .iter()
+                    .filter_map(|selector| selector.glob.as_ref())
+            })
+            .into_iter()
+            .flatten()
+            .chain(self.glob.iter())
+            .flat_map(|pattern| match pattern {
+                Pattern::Globs(globs) => globs.clone(),
+                Pattern::Regex { pattern, .. } => vec![pattern.clone()],
+            })
+            .collect::<Vec<_>>();
+        tctx.with_globs(&globs);
         let file_msg = |files: &[PathBuf]| {
             format!(
                 "{} file{}",
@@ -165,10 +171,26 @@ impl Step {
             tera::render(&run, &tctx.for_display()).unwrap_or_else(|_| run.clone());
         let run = tera::render(&run, &tctx)
             .wrap_err_with(|| format!("{self}: failed to render command template"))?;
-        let pattern_display = match &self.glob {
-            Some(Pattern::Globs(g)) => g.join(" "),
-            Some(Pattern::Regex { pattern, .. }) => format!("regex: {}", pattern),
-            None => String::new(),
+        let display_pattern = |pattern: &Pattern| match pattern {
+            Pattern::Globs(globs) => globs.join(" "),
+            Pattern::Regex { pattern, .. } => format!("regex: {pattern}"),
+        };
+        let pattern_display = if let Some(selectors) = &self.match_any {
+            selectors
+                .iter()
+                .map(|selector| {
+                    let mut parts = Vec::new();
+                    if let Some(pattern) = &selector.glob {
+                        parts.push(display_pattern(pattern));
+                    }
+                    if let Some(types) = &selector.types {
+                        parts.push(format!("types: {}", types.join(", ")));
+                    }
+                    format!("({})", parts.join(" AND "))
+                })
+                .join(" OR ")
+        } else {
+            self.glob.as_ref().map(display_pattern).unwrap_or_default()
         };
         // Cap the full progress message: a `check =` value can be a
         // multi-line shell script or an inline-generated command, and

--- a/src/step/types.rs
+++ b/src/step/types.rs
@@ -2,6 +2,7 @@
 //!
 //! This module contains the fundamental types used to define and configure steps:
 //! - [`Step`] - The main configuration struct for a linting/formatting step
+//! - [`FileSelector`] - A positive file selector used by `match_any`
 //! - [`Pattern`] - File matching patterns (globs or regex)
 //! - [`Script`] - Platform-specific command scripts
 //! - [`RunType`] - Whether to run in check or fix mode
@@ -91,6 +92,30 @@ impl<'de> Deserialize<'de> for Pattern {
     }
 }
 
+/// A positive file-selection clause.
+///
+/// Glob and type filters within one selector use AND semantics. Multiple
+/// selectors in [`Step::match_any`] use OR semantics.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(debug_assertions, serde(deny_unknown_fields))]
+pub struct FileSelector {
+    /// File matching pattern (globs or regex)
+    #[serde(default)]
+    pub glob: Option<Pattern>,
+
+    /// File types to match
+    #[serde(default)]
+    pub types: Option<Vec<String>>,
+}
+
+impl FileSelector {
+    pub fn is_empty(&self) -> bool {
+        self.glob.as_ref().is_none_or(Pattern::is_empty)
+            && self.types.as_ref().is_none_or(Vec::is_empty)
+    }
+}
+
 /// A step configuration that defines a linting or formatting task.
 ///
 /// Steps are the core building blocks of hk. Each step defines:
@@ -139,6 +164,10 @@ pub struct Step {
     /// File types to match (e.g., `["rust", "toml"]`)
     #[serde(default)]
     pub types: Option<Vec<String>>,
+
+    /// Alternative positive file selectors, combined with OR semantics
+    #[serde(default)]
+    pub match_any: Option<Vec<FileSelector>>,
 
     /// Whether this step requires interactive terminal input
     #[serde(default)]

--- a/src/step_group.rs
+++ b/src/step_group.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, PickFirst, serde_as};
 
 use crate::{
-    Result, glob,
+    Result,
     hook::{HookContext, StepOrGroup},
     step::{Pattern, RunType, Script, Step},
     step_context::StepContext,
@@ -236,20 +236,7 @@ impl StepGroup {
             .steps
             .values()
             .map(|step| {
-                let step_files = if let Some(pattern) = &step.glob {
-                    // Use get_pattern_matches which handles dir filtering internally
-                    glob::get_pattern_matches(pattern, &files, step.dir.as_deref())?
-                } else if let Some(dir) = &step.dir {
-                    // If dir is set without glob, filter files to that directory
-                    files
-                        .iter()
-                        .filter(|f| f.starts_with(dir))
-                        .cloned()
-                        .collect()
-                } else {
-                    // No dir and no glob, use all files
-                    files.clone()
-                };
+                let step_files = step.filter_files(&files)?;
 
                 Ok((step.name.as_str(), step_files))
             })

--- a/test/builtins_tests.bats
+++ b/test/builtins_tests.bats
@@ -27,3 +27,37 @@ PKL
     # At least the newlines builtin has a test
     assert_output --partial "ok - newlines :: fix bad file"
 }
+
+@test "shell builtins select extensionless sh scripts but not fish" {
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl" as Builtins
+hooks {
+  ["check"] {
+    steps {
+      ["shellcheck"] = (Builtins.shellcheck) {
+        check = "echo shellcheck {{ files }}"
+      }
+      ["shfmt"] = (Builtins.shfmt) {
+        check = "echo shfmt {{ files }}"
+      }
+    }
+  }
+}
+PKL
+
+    cat <<'SCRIPT' > script
+#!/bin/sh
+echo shell
+SCRIPT
+    cat <<'SCRIPT' > fish-script
+#!/usr/bin/env fish
+echo fish
+SCRIPT
+
+    run hk check --all
+    assert_success
+    assert_output --partial "shellcheck script"
+    assert_output --partial "shfmt script"
+    refute_output --partial "fish-script"
+}

--- a/test/check_first_waits.bats
+++ b/test/check_first_waits.bats
@@ -19,7 +19,7 @@ hooks {
         fix = true
         steps {
             ["a"] {
-                glob = List("*.sh")
+                match_any = List(new { types = List("bash") })
                 stage = "*"
                 check_first = true
                 check = "echo 'start a' && sleep 0.1 && echo 'exit a' && exit 1"

--- a/test/hkrc.bats
+++ b/test/hkrc.bats
@@ -157,7 +157,7 @@ EOF
     assert_output --partial "Hook var not found (correct)"
 }
 
-@test "hkrc: per-step configuration overrides" {
+@test "hkrc: per-step glob overrides match_any" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
 import "$PKL_PATH/Builtins.pkl"
@@ -165,7 +165,7 @@ hooks {
     ["pre-commit"] {
         steps {
             ["test_glob"] {
-                glob = "*.txt"
+                match_any = List(new { glob = "*.txt" })
                 check = "echo 'Found files:' && echo {{ files }}"
             }
         }

--- a/test/types.bats
+++ b/test/types.bats
@@ -205,3 +205,77 @@ EOF
     assert_output --partial "test.ts"
     refute_output --partial "test.py"
 }
+
+@test "match_any: ORs glob and type selectors" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+  ["check"] {
+    steps {
+      ["shell"] {
+        match_any = List(
+          new { glob = List("**/*.bats") },
+          new { types = List("shell") }
+        )
+        check = "echo {{ files }}"
+      }
+    }
+  }
+}
+EOF
+    git init
+    git add -A
+    git commit -m "init"
+
+    echo "echo bats" > extension-only.bats
+    cat > extensionless <<'SCRIPT'
+#!/bin/sh
+echo shell
+SCRIPT
+    echo "print('not shell')" > test.py
+    git add extension-only.bats extensionless test.py
+
+    run hk check
+    assert_success
+    assert_output --partial "extension-only.bats"
+    assert_output --partial "extensionless"
+    refute_output --partial "test.py"
+}
+
+@test "match_any: ANDs glob and types within each selector" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+  ["check"] {
+    steps {
+      ["python-in-src"] {
+        match_any = List(
+          new {
+            glob = "src/**/*"
+            types = List("python")
+          }
+        )
+        check = "echo {{ files }}"
+      }
+    }
+  }
+}
+EOF
+    git init
+    git add -A
+    git commit -m "init"
+
+    mkdir -p src lib
+    echo "print('hello')" > src/test.py
+    echo "console.log('hello')" > src/test.js
+    echo "print('hello')" > lib/test.py
+    git add src lib
+
+    run hk check
+    assert_success
+    assert_output --partial "src/test.py"
+    refute_output --partial "src/test.js"
+    refute_output --partial "lib/test.py"
+}

--- a/test/types.bats
+++ b/test/types.bats
@@ -216,7 +216,7 @@ hooks {
       ["shell"] {
         match_any = List(
           new { glob = List("**/*.bats") },
-          new { types = List("shell") }
+          new { types = List("sh", "bash") }
         )
         check = "echo {{ files }}"
       }
@@ -234,12 +234,17 @@ EOF
 echo shell
 SCRIPT
     echo "print('not shell')" > test.py
-    git add extension-only.bats extensionless test.py
+    cat > fish-script <<'SCRIPT'
+#!/usr/bin/env fish
+echo fish
+SCRIPT
+    git add extension-only.bats extensionless fish-script test.py
 
     run hk check
     assert_success
     assert_output --partial "extension-only.bats"
     assert_output --partial "extensionless"
+    refute_output --partial "fish-script"
     refute_output --partial "test.py"
 }
 

--- a/test/validation_errors.bats
+++ b/test/validation_errors.bats
@@ -154,3 +154,92 @@ EOF
     assert_failure
     assert_output --partial "Step 'test-step' in hook 'pre-push' has 'stage' attribute but no 'fix' command"
 }
+
+@test "validation rejects match_any combined with top-level selectors" {
+    cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["check"] {
+        steps {
+            ["test-step"] {
+                glob = "*.sh"
+                match_any = List(new { types = List("shell") })
+                check = "echo {{ files }}"
+            }
+        }
+    }
+}
+EOF
+
+    run hk validate
+    assert_failure
+    assert_output --partial "cannot combine 'match_any' with top-level 'glob' or 'types'"
+}
+
+@test "validation rejects empty match_any" {
+    cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["check"] {
+        steps {
+            ["test-step"] {
+                match_any = List()
+                check = "echo {{ files }}"
+            }
+        }
+    }
+}
+EOF
+
+    run hk validate
+    assert_failure
+    assert_output --partial "has an empty 'match_any'; add at least one selector"
+}
+
+@test "validation rejects empty match_any selector" {
+    cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["check"] {
+        steps {
+            ["test-step"] {
+                match_any = List(new {})
+                check = "echo {{ files }}"
+            }
+        }
+    }
+}
+EOF
+
+    run hk validate
+    assert_failure
+    assert_output --partial "has an empty 'match_any' selector 1"
+}
+
+@test "validation rejects empty selector fields in groups" {
+    cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["check"] {
+        steps {
+            ["test-group"] = new Group {
+                steps {
+                    ["test-step"] {
+                        match_any = List(new { glob = List() })
+                        check = "echo {{ files }}"
+                    }
+                }
+            }
+        }
+    }
+}
+EOF
+
+    run hk validate
+    assert_failure
+    assert_output --partial "Step 'test-step' in group 'test-group' of hook 'check' has an empty 'glob' in 'match_any' selector 1"
+}


### PR DESCRIPTION
## Summary

- add `match_any` selectors with OR semantics across clauses and existing AND semantics within each clause
- reject empty selectors and configurations that mix `match_any` with top-level `glob` or `types`
- share filtering with contention detection and expose combined patterns through `{{globs}}`
- update `shfmt` and `shellcheck` to include extensionless shell scripts detected by shebang while preserving extension globs

Implements the selector design discussed in #1037.

## Validation

- `cargo test` — 177 passed
- `mise run test:bats test/types.bats`
- `mise run test:bats test/validation_errors.bats`
- `hk test --step shfmt`
- `hk test --step shellcheck`
- `hk check --all`

The broad `mise run test` Bats phase was stopped after unrelated Git LFS tests failed because `git-lfs` is unavailable in the local environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `match_any` as alternative file selectors, enabling OR-style matching across multiple glob/type clauses.
  * Updated templating and progress/pattern display to reflect `match_any`-driven selection logic.
* **Bug Fixes**
  * Ensured `match_any` is treated as a configured file filter and applied consistently during file selection.
  * Improved `match_any` validation, including clearer error locations for hook and group steps.
* **Tests**
  * Added tests covering `match_any` OR/AND semantics, preserved file ordering, and invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->