### PR TITLE
fix: make --quiet and --silent suppress progress output

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -4895,8 +4895,8 @@
       {
         "name": "quiet",
         "usage": "-q --quiet",
-        "help": "Suppresses non-essential output (info messages, progress indicators)",
-        "help_first_line": "Suppresses non-essential output (info messages, progress indicators)",
+        "help": "Suppresses non-essential output (info messages, progress indicators). Failed-step diagnostics are still shown",
+        "help_first_line": "Suppresses non-essential output (info messages, progress indicators). Failed-step diagnostics are still shown",
         "short": ["q"],
         "long": ["quiet"],
         "hide": false,

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -4895,8 +4895,8 @@
       {
         "name": "quiet",
         "usage": "-q --quiet",
-        "help": "Suppresses output",
-        "help_first_line": "Suppresses output",
+        "help": "Suppresses non-essential output (info messages, progress indicators)",
+        "help_first_line": "Suppresses non-essential output (info messages, progress indicators)",
         "short": ["q"],
         "long": ["quiet"],
         "hide": false,
@@ -4905,8 +4905,8 @@
       {
         "name": "silent",
         "usage": "--silent",
-        "help": "Suppresses all output",
-        "help_first_line": "Suppresses all output",
+        "help": "Suppresses all output including warnings. Only errors are shown",
+        "help_first_line": "Suppresses all output including warnings. Only errors are shown",
         "short": [],
         "long": ["silent"],
         "hide": false,

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -32,11 +32,11 @@ Disables progress output
 
 ### `-q --quiet`
 
-Suppresses output
+Suppresses non-essential output (info messages, progress indicators)
 
 ### `--silent`
 
-Suppresses all output
+Suppresses all output including warnings. Only errors are shown
 
 ### `--trace`
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -32,7 +32,7 @@ Disables progress output
 
 ### `-q --quiet`
 
-Suppresses non-essential output (info messages, progress indicators)
+Suppresses non-essential output (info messages, progress indicators). Failed-step diagnostics are still shown
 
 ### `--silent`
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -138,11 +138,11 @@ Example timing report:
 To reduce output:
 
 ```bash
-# Suppress non-error output
+# Suppress non-essential output (info messages, progress indicators)
 hk check --quiet
 hk check -q
 
-# Suppress all output (only exit codes)
+# Suppress all output including warnings (only errors are shown)
 hk check --silent
 ```
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -139,6 +139,7 @@ To reduce output:
 
 ```bash
 # Suppress non-essential output (info messages, progress indicators)
+# Failed-step diagnostics are still shown
 hk check --quiet
 hk check -q
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -15,8 +15,8 @@ flag "-p --profile" help="Profiles to enable/disable prefix with ! to disable e.
 flag "-s --slow" help="Shorthand for --profile=slow" global=#true
 flag "-v --verbose" help="Enables verbose output" var=#true global=#true count=#true
 flag "-n --no-progress" help="Disables progress output" global=#true
-flag "-q --quiet" help="Suppresses output" global=#true
-flag --silent help="Suppresses all output" global=#true
+flag "-q --quiet" help="Suppresses non-essential output (info messages, progress indicators)" global=#true
+flag --silent help="Suppresses all output including warnings. Only errors are shown" global=#true
 flag --trace help="Enable tracing spans and performance diagnostics" global=#true
 flag --json help="Output in JSON format" global=#true
 cmd builtins help="Lists all available builtin linters"

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -15,7 +15,7 @@ flag "-p --profile" help="Profiles to enable/disable prefix with ! to disable e.
 flag "-s --slow" help="Shorthand for --profile=slow" global=#true
 flag "-v --verbose" help="Enables verbose output" var=#true global=#true count=#true
 flag "-n --no-progress" help="Disables progress output" global=#true
-flag "-q --quiet" help="Suppresses non-essential output (info messages, progress indicators)" global=#true
+flag "-q --quiet" help="Suppresses non-essential output (info messages, progress indicators). Failed-step diagnostics are still shown" global=#true
 flag --silent help="Suppresses all output including warnings. Only errors are shown" global=#true
 flag --trace help="Enable tracing spans and performance diagnostics" global=#true
 flag --json help="Output in JSON format" global=#true

--- a/settings.toml
+++ b/settings.toml
@@ -345,9 +345,9 @@ type = "bool"
 default = false
 sources.cli = ["--quiet", "-q"]
 docs = """
-Suppresses non-essential output.
+Suppresses non-essential output (info messages, progress indicators).
 
-When enabled, only errors and critical information will be displayed.
+When enabled, only warnings and errors will be displayed.
 Useful for scripting or when you only care about the exit code.
 """
 
@@ -356,10 +356,10 @@ type = "bool"
 default = false
 sources.cli = ["--silent"]
 docs = """
-Completely suppresses all output, including errors.
+Suppresses all output including warnings. Only errors are shown.
 
-More extreme than `quiet` - absolutely no output will be displayed.
-Useful when only the exit code matters.
+More extreme than `quiet` - progress indicators, info messages, and
+warnings are all hidden. Useful when only the exit code matters.
 """
 
 [skip_hooks]

--- a/src/cli/init/mod.rs
+++ b/src/cli/init/mod.rs
@@ -64,9 +64,9 @@ impl Init {
                 .map(|d| format!("{} ({})", d.builtin.name, d.reason))
                 .collect::<Vec<_>>()
                 .join(", ");
-            println!("Detected: {}", summary);
+            info!("Detected: {}", summary);
         }
-        println!("Created hk.pkl");
+        info!("Created hk.pkl");
 
         Ok(())
     }
@@ -74,14 +74,13 @@ impl Init {
     fn run_interactive(&self, detections: &[detector::Detection], version: &str) -> Result<String> {
         // Print detection info
         if !detections.is_empty() {
-            println!("\nScanning project...");
+            info!("Scanning project...");
             for detection in detections {
-                println!(
+                info!(
                     "  Detected: {} ({})",
                     detection.builtin.name, detection.reason
                 );
             }
-            println!();
         }
 
         // Let user pick builtins
@@ -130,7 +129,7 @@ run = "hk run pre-commit"
             warn!("mise.toml already exists, run with --force to overwrite");
         } else {
             xx::file::write(mise_toml, mise_content)?;
-            println!("Generated mise.toml");
+            info!("Generated mise.toml");
         }
         Ok(())
     }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -1,6 +1,6 @@
 use crate::{Result, config::Config, env, git_util};
 use eyre::bail;
-use log::warn;
+use log::{info, warn};
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
 use std::process::Command;
@@ -77,11 +77,11 @@ impl Install {
             // stale local install so it doesn't double-fire alongside global.
             let removed = remove_local_shims()? + remove_local_config_entries()?;
             if removed > 0 {
-                println!(
+                info!(
                     "hk hooks already configured globally (~/.gitconfig); removed {removed} stale local hook(s) and did not install new ones. Pass `--force-local` to install per-repo hooks anyway."
                 );
             } else {
-                println!(
+                info!(
                     "hk hooks already configured globally (~/.gitconfig); skipping local install. Pass `--force-local` to install per-repo hooks anyway."
                 );
             }
@@ -327,11 +327,11 @@ fn install_global(events: &[String], command: &OsStr) -> Result<()> {
     for event in events {
         write_config_hook("--global", command, event, true)?;
     }
-    println!(
+    info!(
         "Installed hk global hooks in ~/.gitconfig for: {}",
         events.join(", ")
     );
-    println!(
+    info!(
         "In repos without an hk.pkl, hk exits silently — add one with `hk init` to enable hooks."
     );
     Ok(())
@@ -340,7 +340,7 @@ fn install_global(events: &[String], command: &OsStr) -> Result<()> {
 fn install_local_config(events: &[String], command: &OsStr) -> Result<()> {
     for event in events {
         write_config_hook("--local", command, event, false)?;
-        println!("Installed hk hook via git config: hook.hk-{event}.command");
+        info!("Installed hk hook via git config: hook.hk-{event}.command");
     }
     Ok(())
 }
@@ -364,7 +364,7 @@ fn install_local_shims(events: &[String], command: &OsStr) -> Result<()> {
             git_hook_content(&command.to_string_lossy(), event),
         )?;
         xx::file::make_executable(&hook_file)?;
-        println!("Installed hk hook: {}", hook_file.display());
+        info!("Installed hk hook: {}", hook_file.display());
     }
     Ok(())
 }

--- a/src/cli/migrate/pre_commit.rs
+++ b/src/cli/migrate/pre_commit.rs
@@ -152,13 +152,12 @@ impl PreCommit {
             self.config.display(),
             self.output.display()
         );
-        println!("Successfully migrated to hk.pkl!");
-
-        println!("\nNext steps:");
-        println!("1. Review the generated hk.pkl file");
-        println!("2. Complete any TODO items (local/unknown hooks, vendored repos)");
-        println!("3. Run 'hk install' to install git hooks");
-        println!("4. Run 'hk check --all' to test your configuration");
+        info!("Successfully migrated to hk.pkl!");
+        info!("Next steps:");
+        info!("1. Review the generated hk.pkl file");
+        info!("2. Complete any TODO items (local/unknown hooks, vendored repos)");
+        info!("3. Run 'hk install' to install git hooks");
+        info!("4. Run 'hk check --all' to test your configuration");
 
         Ok(())
     }
@@ -217,7 +216,7 @@ impl PreCommit {
 
             // Warn user about language versions
             warn!("Detected default_language_version in pre-commit config");
-            println!("\nLanguage versions detected in .pre-commit-config.yaml:");
+            info!("Language versions detected in .pre-commit-config.yaml:");
 
             for (lang, version) in &config.default_language_version {
                 hk_config
@@ -227,7 +226,7 @@ impl PreCommit {
                 let normalized_version = Self::normalize_language_version(version);
 
                 // Print warning with mise use command
-                println!(
+                info!(
                     "  {}: {} -> Run: mise use {}@{}",
                     lang, version, lang, normalized_version
                 );

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -48,7 +48,7 @@ struct Cli {
     /// Disables progress output
     #[clap(short, long, global = true)]
     no_progress: bool,
-    /// Suppresses non-essential output (info messages, progress indicators)
+    /// Suppresses non-essential output (info messages, progress indicators). Failed-step diagnostics are still shown
     #[clap(short, long, global = true, overrides_with_all = ["verbose", "silent"])]
     quiet: bool,
     /// Suppresses all output including warnings. Only errors are shown

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -48,10 +48,10 @@ struct Cli {
     /// Disables progress output
     #[clap(short, long, global = true)]
     no_progress: bool,
-    /// Suppresses output
+    /// Suppresses non-essential output (info messages, progress indicators)
     #[clap(short, long, global = true, overrides_with_all = ["verbose", "silent"])]
     quiet: bool,
-    /// Suppresses all output
+    /// Suppresses all output including warnings. Only errors are shown
     #[clap(long, global = true, overrides_with_all = ["quiet", "verbose"])]
     silent: bool,
     /// Enable tracing spans and performance diagnostics
@@ -113,11 +113,11 @@ pub async fn run() -> Result<()> {
         level = Some(log::LevelFilter::Debug);
     }
     if args.quiet {
-        clx::progress::set_output(ProgressOutput::Text);
+        clx::progress::set_output(ProgressOutput::Quiet);
         level = Some(log::LevelFilter::Warn);
     }
     if args.silent {
-        clx::progress::set_output(ProgressOutput::Text);
+        clx::progress::set_output(ProgressOutput::Quiet);
         level = Some(log::LevelFilter::Error);
     }
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1198,16 +1198,17 @@ impl Hook {
         // summaries by default — but failed steps still get a summary so the
         // user can see the diagnostic in full (text-mode streaming truncates
         // each line via the `message` prop). `HK_SUMMARY_TEXT=1` forces all
-        // summaries to print in text mode. `--quiet`/`--silent` suppress
-        // summaries entirely.
+        // summaries to print in text mode. `--quiet` suppresses successful-step
+        // summaries but keeps failed-step ones — a failure diagnostic is
+        // essential output. `--silent` suppresses summaries entirely.
         let in_text_mode = clx::progress::output() == ProgressOutput::Text;
         let force_summary = *env::HK_SUMMARY_TEXT;
         let failed_steps = hook_ctx.failed_steps.lock().unwrap().clone();
-        let suppress_summary = settings.quiet || settings.silent;
-        if !suppress_summary && (!in_text_mode || force_summary || !failed_steps.is_empty()) {
+        let only_failed = settings.quiet || (in_text_mode && !force_summary);
+        if !settings.silent && (!only_failed || !failed_steps.is_empty()) {
             let outputs = hook_ctx.output_by_step.lock().unwrap().clone();
             for (step_name, (mode, output)) in outputs.into_iter() {
-                if in_text_mode && !force_summary && !failed_steps.contains(&step_name) {
+                if only_failed && !failed_steps.contains(&step_name) {
                     continue;
                 }
                 let trimmed = output.trim_end();

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -882,6 +882,9 @@ impl Hook {
 
     pub async fn stats(&self, opts: HookOptions, hook_name: &str) -> Result<()> {
         let settings = Settings::get();
+        if settings.quiet || settings.silent {
+            return Ok(());
+        }
         let run_type = self.run_type(&opts);
         let repo = Arc::new(Mutex::new(Git::new()?));
         let git_status = repo.lock().await.status(None)?;
@@ -1195,11 +1198,13 @@ impl Hook {
         // summaries by default — but failed steps still get a summary so the
         // user can see the diagnostic in full (text-mode streaming truncates
         // each line via the `message` prop). `HK_SUMMARY_TEXT=1` forces all
-        // summaries to print in text mode.
+        // summaries to print in text mode. `--quiet`/`--silent` suppress
+        // summaries entirely.
         let in_text_mode = clx::progress::output() == ProgressOutput::Text;
         let force_summary = *env::HK_SUMMARY_TEXT;
         let failed_steps = hook_ctx.failed_steps.lock().unwrap().clone();
-        if !in_text_mode || force_summary || !failed_steps.is_empty() {
+        let suppress_summary = settings.quiet || settings.silent;
+        if !suppress_summary && (!in_text_mode || force_summary || !failed_steps.is_empty()) {
             let outputs = hook_ctx.output_by_step.lock().unwrap().clone();
             for (step_name, (mode, output)) in outputs.into_iter() {
                 if in_text_mode && !force_summary && !failed_steps.contains(&step_name) {

--- a/test/quiet_silent.bats
+++ b/test/quiet_silent.bats
@@ -57,6 +57,45 @@ EOF
     refute_output --partial "files"
 }
 
+@test "check --quiet shows failed step output summary" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] { steps { ["a"] { check = "echo some diagnostic && exit 1" } } }
+}
+EOF
+    git add hk.pkl
+    run hk check --quiet
+    assert_failure
+    assert_output --partial "some diagnostic"
+}
+
+@test "check --stats --quiet suppresses statistics" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] { steps { ["a"] { check = "echo checking {{files}}" } } }
+}
+EOF
+    git add hk.pkl
+    run hk check --stats --quiet
+    assert_success
+    refute_output --partial "Statistics"
+}
+
+@test "check --stats --silent suppresses statistics" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] { steps { ["a"] { check = "echo checking {{files}}" } } }
+}
+EOF
+    git add hk.pkl
+    run hk check --stats --silent
+    assert_success
+    refute_output --partial "Statistics"
+}
+
 @test "check --silent suppresses failed step output summary" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"

--- a/test/quiet_silent.bats
+++ b/test/quiet_silent.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "install --quiet suppresses output" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks { ["pre-commit"] { steps { ["a"] { check = "echo hi" } } } }
+EOF
+    run hk install --quiet
+    assert_success
+    refute_output --partial "Installed"
+}
+
+@test "install --silent suppresses output" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks { ["pre-commit"] { steps { ["a"] { check = "echo hi" } } } }
+EOF
+    run hk install --silent
+    assert_success
+    refute_output --partial "Installed"
+}
+
+@test "check --quiet suppresses progress and info output" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] { steps { ["a"] { check = "echo checking {{files}}" } } }
+}
+EOF
+    git add hk.pkl
+    run hk check --quiet
+    assert_success
+    refute_output --partial "checking"
+    refute_output --partial "files"
+}
+
+@test "check --silent suppresses all output" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] { steps { ["a"] { check = "echo checking {{files}}" } } }
+}
+EOF
+    git add hk.pkl
+    run hk check --silent
+    assert_success
+    refute_output --partial "checking"
+    refute_output --partial "files"
+}
+
+@test "check --silent suppresses failed step output summary" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] { steps { ["a"] { check = "echo some diagnostic && exit 1" } } }
+}
+EOF
+    git add hk.pkl
+    run hk check --silent
+    assert_failure
+    refute_output --partial "some diagnostic"
+    refute_output --partial "output:"
+}
+
+@test "init --quiet suppresses info messages" {
+    run hk init --force --quiet
+    assert_success
+    refute_output --partial "Created"
+    refute_output --partial "Detected"
+}

--- a/test/quiet_silent.bats
+++ b/test/quiet_silent.bats
@@ -93,7 +93,7 @@ EOF
     git add hk.pkl
     run hk check --stats --silent
     assert_success
-    refute_output --partial "Statistics"
+    assert_output ""
 }
 
 @test "check --silent suppresses failed step output summary" {


### PR DESCRIPTION
## Summary

`hk check --silent --all` (and `--quiet`) still printed every step progress line, per-file command lines, and failed-step output summaries. The flags only lowered the log level and switched progress rendering to `Text` mode — which streams each update as a new line rather than suppressing anything.

This revives #782 (reviewed and approved, but auto-closed by the stale bot). The prerequisite `ProgressOutput::Quiet` variant landed in jdx/clx#80 and is available in the clx 2.1.0 release hk already depends on.

## Changes

- `--quiet`/`--silent` now set `ProgressOutput::Quiet` so progress output is actually suppressed (log levels unchanged: Warn / Error)
- Skip the end-of-run step output summaries for `--silent`; `--quiet` suppresses successful-step summaries but keeps failed-step ones, since a failure diagnostic is essential output. `--stats` output is skipped under both flags. This needs an explicit guard: `Quiet` is not `Text`, so the existing `!in_text_mode` condition would otherwise print summaries for every step
- Route informational `println!` calls in `init`/`install`/`migrate` through `info!` so the flags apply there too (visible by default since `HK_LOG` defaults to info)
- Update help text, `settings.toml` docs, `docs/logging.md`, and regenerate `hk.usage.kdl`/`docs/cli`
- Add `test/quiet_silent.bats` (the #782 tests, plus cases for the failed-step summary under `--quiet`/`--silent` and `--stats` suppression)

CI/non-interactive `Text` mode behavior is unchanged (that was #873's separate scope).

## Verification

- `hk check --silent --all` and `hk check --quiet --all` produce zero output on success; exit code only
- A failing step under `--quiet` still prints its output summary; under `--silent` it does not
- `CI=1 hk check --all` still streams text-mode progress as before
- `cargo test` (177 passed), `test/quiet_silent.bats` 9/9, plus check/install/init/migrate bats suites
- `hk check --all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refined `--quiet` and `--silent` behavior across CLI commands.
  * Quiet mode now hides non-essential output while retaining warnings and failure diagnostics.
  * Silent mode now hides all output except errors.
  * Progress, statistics, installation, and initialization messages are suppressed consistently based on the selected mode.

* **Documentation**
  * Updated CLI and configuration help text to clearly explain quiet and silent output levels.

* **Tests**
  * Added coverage for quiet and silent behavior across installation, checks, statistics, and initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->