### PR TITLE
docs: align social links icons vertically center

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -368,6 +368,11 @@ h1, .vp-doc h1 {
   text-transform: uppercase;
 }
 
+/* Social links */
+.VPSocialLinks {
+  align-items: center !important;
+}
+
 .VPSocialLinks a[href*="github.com/jdx/hk"] {
   display: inline-flex !important;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- Add `align-items: center` to `.VPSocialLinks` to fix vertical alignment of social links icons (GitHub, Discord)
- Same issue and fix as jdx/mise#10424

In hk's docs, the navbar (≥1280px) is unaffected because VitePress's `VPNavBarSocialLinks` already applies `align-items: center`. The misalignment appears in the hamburger menu (<1280px), where `.VPSocialLinks` has no `align-items` and the GitHub icon sits 6px higher than the Discord icon due to the star-count badge's `padding-bottom: 12px` / `margin-bottom: -12px` offset.

#### Test plan

- [x] Visual verification with a local `vitepress dev` build: icons align in the hamburger menu, and the navbar (≥1280px) with the star-count badge is unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the vertical alignment of social links in the documentation site’s theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->