### PR TITLE
fix(stash): wait for transient index locks

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -3,6 +3,8 @@ use std::{
     ffi::{CString, OsString},
     path::PathBuf,
     process::Command,
+    thread,
+    time::Duration,
 };
 
 use crate::Result;
@@ -49,6 +51,38 @@ where
     let args = args.into_iter().map(|s| s.into()).collect::<Vec<_>>();
     // Silently ignore stderr output by using an empty handler
     xx::process::cmd("git", args).on_stderr_line(|_line| {})
+}
+
+fn run_git_stash(cmd: &xx::process::XXExpression) -> Result<()> {
+    const LOCK_RETRY_DELAYS: [Duration; 5] = [
+        Duration::from_millis(25),
+        Duration::from_millis(50),
+        Duration::from_millis(100),
+        Duration::from_millis(200),
+        Duration::from_millis(400),
+    ];
+
+    let index_lock = git_cmd_silent(["rev-parse", "--git-path", "index.lock"])
+        .read()
+        .ok()
+        .map(PathBuf::from);
+
+    if let Some(index_lock) = index_lock {
+        for delay in LOCK_RETRY_DELAYS {
+            if !index_lock.exists() {
+                break;
+            }
+            debug!(
+                "waiting {}ms for transient git index lock {}",
+                delay.as_millis(),
+                index_lock.display()
+            );
+            thread::sleep(delay);
+        }
+    }
+
+    cmd.run()?;
+    Ok(())
 }
 
 fn git_run<I, S>(args: I) -> Result<()>
@@ -850,7 +884,7 @@ impl Git {
                     cmd = cmd.arg("--");
                     cmd = cmd.args(utf8_paths);
                 }
-                cmd.run()?;
+                run_git_stash(&cmd)?;
                 // Record the stash commit we just created and save patch backup
                 if let Ok(h) = git_cmd(["rev-parse", "-q", "--verify", "stash@{0}"]).read() {
                     let commit_hash = h.trim().to_string();
@@ -876,7 +910,7 @@ impl Git {
                         if *env::HK_STASH_UNTRACKED {
                             cmd = cmd.arg("--include-untracked");
                         }
-                        cmd.run()?;
+                        run_git_stash(&cmd)?;
                         // Record the stash commit we just created and save patch backup
                         if let Ok(h) = git_cmd(["rev-parse", "-q", "--verify", "stash@{0}"]).read()
                         {
@@ -900,7 +934,7 @@ impl Git {
                     cmd = cmd.args(utf8_paths);
                 }
             }
-            cmd.run()?;
+            run_git_stash(&cmd)?;
             // Record the stash commit we just created and save patch backup
             if let Ok(h) = git_cmd(["rev-parse", "-q", "--verify", "stash@{0}"]).read() {
                 let commit_hash = h.trim().to_string();

--- a/test/stash_index_lock_retry.bats
+++ b/test/stash_index_lock_retry.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "git stash waits for a transient index lock" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    stash = "git"
+    steps {
+      ["check"] {
+        glob = "*.txt"
+        check = "true"
+      }
+    }
+  }
+}
+EOF
+
+    printf 'staged v1\n' > staged.txt
+    printf 'unstaged v1\n' > unstaged.txt
+    git add hk.pkl staged.txt unstaged.txt
+    git commit -m "init"
+
+    printf 'staged v2\n' > staged.txt
+    printf 'unstaged v2\n' > unstaged.txt
+    git add staged.txt
+
+    : > .git/index.lock
+    (sleep 0.2; rm -f .git/index.lock) &
+
+    run hk run pre-commit
+    assert_success
+
+    run git diff -- unstaged.txt
+    assert_success
+    assert_output --partial "+unstaged v2"
+
+    run git diff --cached -- staged.txt
+    assert_success
+    assert_output --partial "+staged v2"
+
+    run git stash list
+    assert_success
+    assert_output ""
+}

--- a/test/stash_index_lock_retry.bats
+++ b/test/stash_index_lock_retry.bats
@@ -9,7 +9,9 @@ teardown() {
     _common_teardown
 }
 
-@test "git stash waits for a transient index lock" {
+assert_stash_waits_for_transient_index_lock() {
+    local use_libgit2="$1"
+
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
 hooks {
@@ -37,7 +39,7 @@ EOF
     : > .git/index.lock
     (sleep 0.2; rm -f .git/index.lock) &
 
-    run hk run pre-commit
+    run env HK_LIBGIT2="$use_libgit2" hk run pre-commit
     assert_success
 
     run git diff -- unstaged.txt
@@ -51,4 +53,12 @@ EOF
     run git stash list
     assert_success
     assert_output ""
+}
+
+@test "partial-path git stash waits for a transient index lock with libgit2 enabled" {
+    assert_stash_waits_for_transient_index_lock 1
+}
+
+@test "git stash waits for a transient index lock with libgit2 disabled" {
+    assert_stash_waits_for_transient_index_lock 0
 }


### PR DESCRIPTION
Closes the transient lock failure reported in discussion #1056.

## What changed

- resolve the active worktree index lock with git rev-parse
- wait up to 775 ms with bounded backoff before shell-based stash operations
- preserve Git's normal failure when a lock persists
- cover transient lock release in both libgit2 and shell-Git test modes

## Root cause

Shell-based stash paths attempted git stash immediately, so direct hk runs could fail when another Git process briefly held the index lock.

## Validation

- cargo fmt --all -- --check
- mise run test:bats test/stash_index_lock_retry.bats
- mise run test:cargo (178 passed)

Related: https://github.com/jdx/hk/discussions/1056

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to retry timing around existing stash commands; stash/unstash behavior is unchanged aside from tolerating short-lived locks.
> 
> **Overview**
> Fixes **pre-commit / hook runs failing** when another Git process briefly holds `index.lock` during shell-based `git stash push`.
> 
> Adds **`run_git_stash`**, which resolves the worktree lock path via `git rev-parse --git-path index.lock`, **sleeps with bounded backoff** (up to ~775ms) while the file exists, then runs the stash command. **All three shell-git stash paths** in `push_stash` now use this helper instead of calling `run()` immediately; **libgit2 `stash_save` is unchanged**, and a **persistent lock still surfaces as a normal Git error** after the wait window.
> 
> New **Bats coverage** (`test/stash_index_lock_retry.bats`) holds a fake lock for 200ms during `hk run pre-commit` with **`HK_LIBGIT2` on and off**, asserting the hook succeeds and staged/unstaged state is preserved without leaving a stash entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 112ff75e367e53e26b185ea24a27cc4a8a9c985e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when running stash-related operations while Git’s index is temporarily locked.
  - Commands now wait briefly and retry automatically, reducing failures caused by transient lock files.
  - Preserved staged and unstaged changes correctly across supported Git execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->