### PR TITLE
feat(builtins): add sherif linter

### DIFF
--- a/pkl/builtins/sherif.pkl
+++ b/pkl/builtins/sherif.pkl
@@ -1,0 +1,65 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+import "./test/helpers.pkl"
+
+@Builtins.meta {
+  category = "JavaScript/TypeScript"
+  description = "Opinionated, zero-config linter for TypeScript & JavaScript monorepos"
+  project_indicators {
+    new { file = "package.json"; contains = "\"sherif\"" }
+  }
+}
+sherif = new Config.Step {
+  // sherif always scans the whole workspace from the repo root; it does not
+  // accept file arguments, so there's no {{ files }} in the commands below.
+  // https://github.com/QuiiBz/sherif
+  glob = List("**/package.json", "**/pnpm-workspace.yaml")
+  check = "sherif"
+  // --no-install skips the package-manager install sherif otherwise runs
+  // after autofixing. --select highest|lowest (for multiple-dependency-
+  // versions autofix) is left to the user to configure if needed.
+  // Note: fix may rewrite package.json files across the whole workspace
+  // (e.g. multiple-dependency-versions), including files hk did not match
+  // or lock for this run.
+  fix = "sherif --fix --no-install"
+  tests {
+    // sherif refuses to run --fix whenever the CI env var is set to any
+    // value ("Cannot fix issues inside a CI environment", exit 1). hk test
+    // inherits the parent process env and can only add env vars, never
+    // unset them, and this repo's GitHub Actions CI runs the builtin tests
+    // with CI=true. So only check-mode tests are included here; fix tests
+    // would fail in CI even though they pass locally.
+    local const bad =
+      """
+      {
+        "name": "root",
+        "packageManager": "npm@10.0.0",
+        "workspaces": [
+          "packages/*"
+        ]
+      }
+
+      """
+    local const good =
+      """
+      {
+        "name": "root",
+        "packageManager": "npm@10.0.0",
+        "workspaces": [
+          "packages/*"
+        ],
+        "private": true
+      }
+
+      """
+    local const testMaker = new helpers.TestMaker {
+      filename = "package.json"
+      extra_files = new Mapping<String, String> {
+        ["packages/a/package.json"] = "{\"name\":\"a\",\"version\":\"1.0.0\"}\n"
+        ["packages/b/package.json"] = "{\"name\":\"b\",\"version\":\"1.0.0\"}\n"
+      }
+    }
+    ["check bad file"] = testMaker.checkFail(bad, 1)
+    ["check good file"] = testMaker.checkPass(good)
+  }
+}

--- a/test/builtin_tool_stubs/sherif
+++ b/test/builtin_tool_stubs/sherif
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "1.13.0"
+tool = "npm:sherif"


### PR DESCRIPTION
## Summary

Adds a builtin for [sherif](https://github.com/QuiiBz/sherif), the opinionated, zero-config linter for TypeScript & JavaScript monorepos.

- `check = "sherif"` / `fix = "sherif --fix --no-install"`
- sherif always scans the whole workspace from the repo root and takes no file arguments, so the commands omit `{{ files }}` (same shape as `cargo_check` / `tf_lint` / `gomod_tidy`)
- `--no-install` skips the package-manager install sherif otherwise runs after autofixing; `--select highest|lowest` (for the `multiple-dependency-versions` autofix) is left to the user to configure
- `glob` covers `**/package.json` and `**/pnpm-workspace.yaml`, the manifests sherif lints
- Project indicator: `"sherif"` in `package.json`
- The fix may rewrite `package.json` files across the whole workspace (e.g. `multiple-dependency-versions`), including files hk did not match or lock for the run — inherent to workspace-scoped fixers (same as `knip` / `gomod_tidy`); noted in a comment

## Test notes

The pkl tests exercise the `root-package-private-field` rule against a minimal npm-workspaces fixture (root `package.json` plus two packages). They are check-only by design: sherif refuses to run `--fix` whenever the `CI` env var is set to **any** value ("Cannot fix issues inside a CI environment"), hk's test runner can only add env vars — never unset inherited ones — and CI runs the builtin tests with `CI=true`, so fix tests would fail there despite passing locally.

```
ok - sherif :: check bad file
ok - sherif :: check good file
```

The fix path was verified end-to-end locally through hk: `hk fix --all` on the bad fixture adds `"private": true` (exit 0, idempotent on re-run, workspace packages untouched), and `hk check --all` passes on the fixed state and fails on the broken one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a tool stub for Sherif, pinned to version 1.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->