### PR TITLE
fix(install): avoid duplicating config hook arguments

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -516,7 +516,9 @@ fn hook_run_args(event: &str, staged_pre_commit: bool) -> OsString {
     } else {
         ""
     };
-    OsString::from(format!(r#" run {event} --from-hook{staged} "$@""#))
+    // Config-based hooks receive their hook arguments from Git automatically.
+    // Forwarding "$@" here would pass every argument twice.
+    OsString::from(format!(r#" run {event} --from-hook{staged}"#))
 }
 
 fn check_hooks_path_config() -> Result<()> {
@@ -602,15 +604,15 @@ mod tests {
     fn hook_run_args_adds_staged_only_for_pre_commit() {
         assert_eq!(
             hook_run_args("pre-commit", true),
-            OsString::from(r#" run pre-commit --from-hook --staged "$@""#)
+            OsString::from(r#" run pre-commit --from-hook --staged"#)
         );
         assert_eq!(
             hook_run_args("pre-push", true),
-            OsString::from(r#" run pre-push --from-hook "$@""#)
+            OsString::from(r#" run pre-push --from-hook"#)
         );
         assert_eq!(
             hook_run_args("pre-commit", false),
-            OsString::from(r#" run pre-commit --from-hook "$@""#)
+            OsString::from(r#" run pre-commit --from-hook"#)
         );
     }
 

--- a/test/install_global.bats
+++ b/test/install_global.bats
@@ -28,7 +28,8 @@ require_git_2_54() {
 
     run git config --global --get hook.hk-pre-commit.command
     assert_success
-    assert_output --partial 'run pre-commit --from-hook --staged "$@"'
+    assert_output --partial 'run pre-commit --from-hook --staged'
+    refute_output --partial '"$@"'
     refute_output --partial '|| hk run'
 
     run git config --global --get hook.hk-pre-rebase.command
@@ -62,7 +63,8 @@ EOF
 
     run git config --global --get hook.hk-pre-rebase.command
     assert_success
-    assert_output --partial 'run pre-rebase --from-hook "$@"'
+    assert_output --partial 'run pre-rebase --from-hook'
+    refute_output --partial '"$@"'
     refute_output --partial '--staged'
 
     run git config --global --get hook.hk-pre-commit.command
@@ -85,7 +87,8 @@ EOF
 
     run git config --global --get hook.hk-pre-commit.command
     assert_success
-    assert_output --partial '~/bin/mise x hk -- hk run pre-commit --from-hook --staged "$@"'
+    assert_output --partial '~/bin/mise x hk -- hk run pre-commit --from-hook --staged'
+    refute_output --partial '"$@"'
     refute_output --partial '|| mise x -- hk run'
 
     command="$(git config --global --get hook.hk-pre-commit.command)"

--- a/test/pre_push.bats
+++ b/test/pre_push.bats
@@ -15,6 +15,17 @@ teardown() {
     temp_del "$TEST_REPO_DIR"
 }
 
+require_git_2_54() {
+    local version major minor
+    version="$(git version | awk '{print $3}')"
+    major="${version%%.*}"
+    minor="${version#*.}"
+    minor="${minor%%.*}"
+    if [ "$major" -lt 2 ] || { [ "$major" -eq 2 ] && [ "$minor" -lt 54 ]; }; then
+        skip "git 2.54+ required for config-based hooks"
+    fi
+}
+
 @test "pre-push hook" {
     export NO_COLOR=1
     if [ "$HK_LIBGIT2" = "0" ]; then
@@ -35,6 +46,31 @@ EOF
     git add test.js
     git commit -m "test"
     HK_LOG=trace run git push origin main
+    assert_failure
+    assert_output --partial "[warn] test.js"
+}
+
+@test "config-based pre-push hook checks pushed files" {
+    require_git_2_54
+    export NO_COLOR=1
+    if [ "$HK_LIBGIT2" = "0" ]; then
+        skip "libgit2 is not installed"
+    fi
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+hooks { ["pre-push"] { steps { ["prettier"] = Builtins.prettier } } }
+EOF
+    git add hk.pkl
+    git commit -m "install hk"
+    git push origin main
+    hk install
+    echo 'console.log("test")' > test.js
+    git add test.js
+    git commit -m "test"
+
+    run git push origin main
+
     assert_failure
     assert_output --partial "[warn] test.js"
 }


### PR DESCRIPTION
## Summary

- rely on Git 2.54+'s automatic argument forwarding for config-based hooks
- keep explicit `"$@"` forwarding for legacy hook shims
- add command-generation assertions and config-based pre-push regression coverage

## Root cause

Git appends hook arguments to `hook.<name>.command`. The installed hk command also expanded `"$@"`, so argument-bearing hooks received every argument twice. For `pre-push`, the duplicate remote and URL were parsed as an explicit file list, overriding push-range discovery and silently skipping file-filtered steps.

This addresses https://github.com/jdx/hk/discussions/1063.

## Validation

- `mise run test:cargo`
- `mise run test:bats test/pre_push.bats`
- `mise run test:bats test/install_global.bats`

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches how every config-installed hook receives Git arguments; wrong behavior would break pre-commit/pre-push globally, but legacy shims are untouched and tests cover install output and config-based pre-push.
> 
> **Overview**
> Fixes **double argument forwarding** for Git 2.54+ config-based hooks (`hook.hk-*.command`). `hook_run_args` no longer appends `"$@"` because Git already passes hook arguments to the configured command; duplicating them broke hooks like **pre-push** (extra remote/URL args were treated as explicit file paths, skipping push-range file checks).
> 
> **Legacy** `.git/hooks/` shims are unchanged and still use `"$@"` via `git_hook_content`.
> 
> Tests now assert installed global/local config commands omit `"$@"`, and a new **config-based pre-push** bats case verifies pushed files are still linted on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd971ed21532ae24f15a534c2877f46982a5ce23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->