### PR TITLE
fix(step): respect linux argument size limit

### DIFF
--- a/src/step/batching.rs
+++ b/src/step/batching.rs
@@ -139,7 +139,7 @@ impl Step {
         let mut batched_jobs = Vec::with_capacity(jobs.len());
 
         for job in jobs {
-            if job.skip_reason.is_some() || job.files.len() <= 1 {
+            if job.skip_reason.is_some() || job.files.is_empty() {
                 batched_jobs.push(job);
                 continue;
             }
@@ -301,6 +301,31 @@ mod tests {
                 .unwrap()
                 <= 100
         }));
+    }
+
+    #[test]
+    fn auto_batch_rejects_oversized_single_file_command() {
+        let step = Step {
+            name: "test".to_string(),
+            check: Some(
+                format!("echo {} {{{{files}}}}", "x".repeat(100))
+                    .parse()
+                    .unwrap(),
+            ),
+            ..Default::default()
+        };
+        let job = StepJob::new(
+            Arc::new(step.clone()),
+            vec![PathBuf::from("file.txt")],
+            RunType::Check,
+        );
+
+        let err = step
+            .auto_batch_jobs_with_limit(vec![job], &tera::Context::default(), 100)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("file.txt"));
+        assert!(err.to_string().contains("100-byte command-line limit"));
     }
 }
 

--- a/src/step/batching.rs
+++ b/src/step/batching.rs
@@ -11,6 +11,7 @@
 use crate::env;
 use crate::step_job::StepJob;
 use crate::tera;
+use eyre::{Result, bail};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -18,12 +19,39 @@ use super::{ShellType, types::Step};
 
 const CMD_COMMAND_LINE_LIMIT: usize = 8191;
 const CMD_COMMAND_LINE_SAFE_LIMIT: usize = CMD_COMMAND_LINE_LIMIT / 2;
+#[cfg(target_os = "linux")]
+// Linux limits each argv/envp string to 32 pages, independently of ARG_MAX.
+const LINUX_MAX_ARG_STRLEN_PAGES: usize = 32;
+
+#[cfg(target_os = "linux")]
+fn platform_max_arg_strlen() -> Option<usize> {
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if page_size > 0 {
+        Some((page_size as usize).saturating_mul(LINUX_MAX_ARG_STRLEN_PAGES))
+    } else {
+        Some(128 * 1024)
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn platform_max_arg_strlen() -> Option<usize> {
+    None
+}
+
+fn shell_command_safe_limit(arg_max: usize, max_arg_strlen: Option<usize>) -> usize {
+    let aggregate_limit = arg_max / 2;
+    match max_arg_strlen {
+        // execve includes the terminating NUL in MAX_ARG_STRLEN.
+        Some(max_arg_strlen) => aggregate_limit.min(max_arg_strlen.saturating_sub(1)),
+        None => aggregate_limit,
+    }
+}
 
 impl Step {
     fn auto_batch_safe_limit(&self) -> usize {
         match self.shell_type() {
             ShellType::Cmd => CMD_COMMAND_LINE_SAFE_LIMIT,
-            _ => *env::ARG_MAX / 2,
+            _ => shell_command_safe_limit(*env::ARG_MAX, platform_max_arg_strlen()),
         }
     }
 
@@ -79,10 +107,10 @@ impl Step {
         tera::render(&run, &tctx).ok().map(|s| s.len())
     }
 
-    /// Automatically batch jobs whose rendered run command would exceed the safe ARG_MAX limit.
+    /// Automatically batch jobs whose rendered run command would exceed the safe exec limit.
     ///
-    /// Uses 50% of the effective command-line limit as the safety margin
-    /// (accounts for env vars, shell wrappers, and the command itself).
+    /// Uses 50% of ARG_MAX as an aggregate safety margin and also respects
+    /// platform-specific per-command limits such as Linux's MAX_ARG_STRLEN.
     /// Renders the actual run command with each candidate file subset; if the rendered command
     /// fits, no batching is performed. Otherwise binary-searches the largest batch size whose
     /// rendered command still fits.
@@ -93,13 +121,21 @@ impl Step {
         &self,
         jobs: Vec<StepJob>,
         base_tctx: &tera::Context,
-    ) -> Vec<StepJob> {
+    ) -> Result<Vec<StepJob>> {
+        self.auto_batch_jobs_with_limit(jobs, base_tctx, self.auto_batch_safe_limit())
+    }
+
+    fn auto_batch_jobs_with_limit(
+        &self,
+        jobs: Vec<StepJob>,
+        base_tctx: &tera::Context,
+        safe_limit: usize,
+    ) -> Result<Vec<StepJob>> {
         if self.stdin.is_some() {
             // stdin path doesn't pass files via argv; never auto-batch
-            return jobs;
+            return Ok(jobs);
         }
 
-        let safe_limit = self.auto_batch_safe_limit();
         let mut batched_jobs = Vec::with_capacity(jobs.len());
 
         for job in jobs {
@@ -126,28 +162,43 @@ impl Step {
                 safe_limit
             );
 
-            // Binary search the largest batch size whose rendered command fits.
-            let mut low = 1;
-            let mut high = job.files.len();
-            while low < high {
-                let mid = (low + high).div_ceil(2);
-                let test_size = self
-                    .render_run_command_size(&job, &job.files[..mid], base_tctx)
-                    .unwrap_or_else(|| self.estimate_files_string_size(&job.files[..mid]));
-                if test_size <= safe_limit {
-                    low = mid;
-                } else {
-                    high = mid - 1;
+            // Size every chunk independently: later paths may be much longer
+            // than the paths at the start of the job.
+            let mut offset = 0;
+            while offset < job.files.len() {
+                let remaining = &job.files[offset..];
+                let single_size = self
+                    .render_run_command_size(&job, &remaining[..1], base_tctx)
+                    .unwrap_or_else(|| self.estimate_files_string_size(&remaining[..1]));
+                if single_size > safe_limit {
+                    bail!(
+                        "{}: rendered command for {} is {} bytes, exceeding the {}-byte command-line limit",
+                        self.name,
+                        remaining[0].display(),
+                        single_size,
+                        safe_limit
+                    );
                 }
-            }
-            let batch_size = low.max(1);
 
-            debug!(
-                "{}: using batch size of {} files per batch",
-                self.name, batch_size
-            );
+                // Binary search the largest prefix of the remaining files that fits.
+                let mut low = 1;
+                let mut high = remaining.len();
+                while low < high {
+                    let mid = (low + high).div_ceil(2);
+                    let test_size = self
+                        .render_run_command_size(&job, &remaining[..mid], base_tctx)
+                        .unwrap_or_else(|| self.estimate_files_string_size(&remaining[..mid]));
+                    if test_size <= safe_limit {
+                        low = mid;
+                    } else {
+                        high = mid - 1;
+                    }
+                }
+                let batch_size = low;
 
-            for chunk in job.files.chunks(batch_size) {
+                debug!("{}: using batch size of {} files", self.name, batch_size);
+
+                let chunk = &remaining[..batch_size];
                 let mut new_job = StepJob::new(Arc::clone(&job.step), chunk.to_vec(), job.run_type);
                 // Preserve job-level state that isn't reconstructed by StepJob::new.
                 new_job.check_first = job.check_first;
@@ -156,10 +207,11 @@ impl Step {
                     new_job = new_job.with_workspace_indicator(wi.clone());
                 }
                 batched_jobs.push(new_job);
+                offset += batch_size;
             }
         }
 
-        batched_jobs
+        Ok(batched_jobs)
     }
 }
 
@@ -186,7 +238,16 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(step.auto_batch_safe_limit(), *env::ARG_MAX / 2);
+        let expected = shell_command_safe_limit(*env::ARG_MAX, platform_max_arg_strlen());
+        assert_eq!(step.auto_batch_safe_limit(), expected);
+    }
+
+    #[test]
+    fn linux_shell_limit_accounts_for_max_arg_strlen() {
+        assert_eq!(
+            shell_command_safe_limit(2 * 1024 * 1024, Some(128 * 1024)),
+            128 * 1024 - 1
+        );
     }
 
     #[test]
@@ -206,9 +267,40 @@ mod tests {
             .collect();
         let job = StepJob::new(Arc::new(step.clone()), files, RunType::Check);
 
-        let jobs = step.auto_batch_jobs(vec![job], &tera::Context::default());
+        let jobs = step
+            .auto_batch_jobs(vec![job], &tera::Context::default())
+            .unwrap();
 
         assert!(jobs.len() > 1);
+    }
+
+    #[test]
+    fn auto_batch_sizes_each_chunk_independently() {
+        let step = Step {
+            name: "test".to_string(),
+            check: Some("echo {{files}}".parse().unwrap()),
+            ..Default::default()
+        };
+        let mut files = (0..20)
+            .map(|i| PathBuf::from(format!("s{i}")))
+            .collect::<Vec<_>>();
+        files.extend(
+            (0..20)
+                .map(|i| PathBuf::from(format!("long-directory-name-{i:02}/long-file-name.txt"))),
+        );
+        let job = StepJob::new(Arc::new(step.clone()), files, RunType::Check);
+        let tctx = tera::Context::default();
+
+        let jobs = step
+            .auto_batch_jobs_with_limit(vec![job], &tctx, 100)
+            .unwrap();
+
+        assert!(jobs.len() > 1);
+        assert!(jobs.iter().all(|job| {
+            step.render_run_command_size(job, &job.files, &tctx)
+                .unwrap()
+                <= 100
+        }));
     }
 }
 

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -75,7 +75,7 @@ impl Step {
         // Apply ARG_MAX-safe auto-batching now that the full tera context is
         // available — only split jobs whose rendered run command would actually
         // exceed the limit.
-        let mut jobs = self.auto_batch_jobs(jobs, &ctx.hook_ctx.tctx);
+        let mut jobs = self.auto_batch_jobs(jobs, &ctx.hook_ctx.tctx)?;
         if let Some(job) = jobs.first_mut() {
             job.semaphore = Some(semaphore);
         }

--- a/test/auto_batch_large_files.bats
+++ b/test/auto_batch_large_files.bats
@@ -15,7 +15,7 @@ hooks {
     ["check"] {
         steps {
             ["count-files"] {
-                check = "echo 'Processing {{files}}' | wc -w"
+                check = "echo batch >> batches.log; echo 'Processing {{files}}' | wc -w"
             }
         }
     }
@@ -35,9 +35,11 @@ EOF
     run hk check
     assert_success
 
-    # The output should show multiple batches were created
-    # Each batch should process a subset of files
-    # We verify by checking that the command executed without errors
+    # Linux must split the command at MAX_ARG_STRLEN. Other platforms have
+    # different command-line limits, so the batch count is platform-specific.
+    if [[ "$OSTYPE" == "linux"* ]]; then
+        [ "$(wc -l < batches.log)" -gt 1 ]
+    fi
 }
 
 @test "auto-batch does not break small file lists" {

--- a/test/auto_batch_large_files.bats
+++ b/test/auto_batch_large_files.bats
@@ -22,9 +22,10 @@ hooks {
 }
 EOF
 
-    # Create a large number of files with long paths to exceed ARG_MAX safe limit
-    # We'll create files in deeply nested directories to ensure long paths
-    for i in {1..1000}; do
+    # Make the rendered sh -c argument exceed Linux's 128 KiB MAX_ARG_STRLEN.
+    # This remains below ARG_MAX / 2 on a typical glibc system, which is the
+    # regression case for discussion #1061.
+    for i in {1..1200}; do
         dir="very/long/directory/path/number/$i/with/many/levels/to/increase/path/length"
         mkdir -p "$dir"
         echo "test" > "$dir/file_with_very_long_name_to_increase_arg_size_$i.txt"


### PR DESCRIPTION
## Summary

- cap rendered shell commands at Linux's per-string `MAX_ARG_STRLEN` limit in addition to the aggregate `ARG_MAX` margin
- size each generated batch independently so later, longer paths cannot overflow a batch sized from earlier paths
- return a clear error when even a single-file command cannot fit
- extend auto-batching coverage above the Linux 128 KiB boundary

## Root cause

hk passes each rendered command to the shell as one `sh -c` argument. Linux limits each argument to 32 pages independently of the aggregate `ARG_MAX` allowance. On a typical glibc system, hk therefore allowed a roughly 1 MiB rendered command even though Linux rejects an individual argument at 128 KiB.

The previous batching algorithm also calculated one file-count batch size from the first paths and reused it for every chunk. A later chunk containing longer paths could still exceed the byte limit.

## Impact

Large monorepos can run shell-backed steps on Linux without hitting `E2BIG` when the rendered file list exceeds `MAX_ARG_STRLEN`. Other platforms retain their existing limits.

Closes discussion #1061.

## Tests

- `cargo fmt --check`
- `mise run test:cargo`
- `mise run test:bats test/auto_batch_large_files.bats`

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core step job splitting and safe limits on Linux; mis-sizing could affect any shell-backed step with large file lists, though behavior is covered by new unit and bats tests.
> 
> **Overview**
> **Shell auto-batching** now caps rendered commands using both the existing `ARG_MAX / 2` margin and Linux’s per-argument **MAX_ARG_STRLEN** (32 pages via `sysconf`), so a single `sh -c` string cannot exceed ~128 KiB even when aggregate `ARG_MAX` would allow more.
> 
> **Batching algorithm** no longer picks one batch size from the start of the file list and reuses it for every chunk. It walks the list in slices, binary-searches each prefix independently, and **fails with a clear error** when even a one-file command exceeds the limit. `auto_batch_jobs` returns **`Result`**; step execution propagates that error.
> 
> **Tests**: unit cases for MAX_ARG_STRLEN math, independent chunk sizing, and oversized single-file commands; the bats scenario targets the Linux 128 KiB regression (1200 long paths, asserts multiple batches on Linux only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9500448107befe47df459361c46e58b3f87a3fbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->