### PR TITLE
feat(step): add structured argv commands

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,14 +6,14 @@ outline: "deep"
 
 hk builds its effective configuration by layering sources from lowest to highest precedence:
 
-| Precedence | Source | Scope |
-|---|---|---|
-| 1 (lowest) | Built-in defaults | All projects |
-| 2 | [hkrc](#hkrc) (`~/.config/hk/config.pkl`) | All projects (user-level) |
-| 3 | [Project config](#hk-pkl) (`hk.pkl` or `hk.local.pkl`) | Single project |
-| 4 | [Git config](#git-configuration) (global, then local) | Per-repo |
-| 5 | [Environment variables](#settings-reference) (`HK_*`) | Per-invocation |
-| 6 (highest) | [CLI flags](#settings-reference) | Per-invocation |
+| Precedence  | Source                                                 | Scope                     |
+| ----------- | ------------------------------------------------------ | ------------------------- |
+| 1 (lowest)  | Built-in defaults                                      | All projects              |
+| 2           | [hkrc](#hkrc) (`~/.config/hk/config.pkl`)              | All projects (user-level) |
+| 3           | [Project config](#hk-pkl) (`hk.pkl` or `hk.local.pkl`) | Single project            |
+| 4           | [Git config](#git-configuration) (global, then local)  | Per-repo                  |
+| 5           | [Environment variables](#settings-reference) (`HK_*`)  | Per-invocation            |
+| 6 (highest) | [CLI flags](#settings-reference)                       | Per-invocation            |
 
 Higher layers override lower. For hooks and steps, layers are **additive** — hkrc can define hooks the project doesn't have, but the project's definition wins on collision. See the [hkrc](#hkrc) section for merge semantics.
 
@@ -25,12 +25,12 @@ hk is configured via `hk.pkl` which is written in [pkl-lang](https://pkl-lang.or
 
 hk searches for config files in the following order (first match wins):
 
-| Precedence | Path | Purpose |
-|---|---|---|
-| 1 | `hk.local.pkl` | Local overrides, should not be committed to source control |
-| 2 | `.config/hk.local.pkl` | Local overrides, nested under `.config/` |
-| 3 | `hk.pkl` | Standard project config |
-| 4 | `.config/hk.pkl` | Standard project config, nested under `.config/` |
+| Precedence | Path                   | Purpose                                                    |
+| ---------- | ---------------------- | ---------------------------------------------------------- |
+| 1          | `hk.local.pkl`         | Local overrides, should not be committed to source control |
+| 2          | `.config/hk.local.pkl` | Local overrides, nested under `.config/`                   |
+| 3          | `hk.pkl`               | Standard project config                                    |
+| 4          | `.config/hk.pkl`       | Standard project config, nested under `.config/`           |
 
 hk walks up from the current directory to `/`, checking each directory for these files. The first file found is used.
 
@@ -114,8 +114,31 @@ hooks = (repo_config.hooks) {
 
 ```
 
-
 <!--@include: ./gen/pkl-config.md-->
+
+### Step commands
+
+Step commands such as `check`, `check_list_files`, `check_diff`, and `fix` accept either a shell command string or a structured `Command`.
+
+String commands run through a shell. Use them when the command needs shell features such as pipes, redirects, `&&`, variable expansion, or glob expansion:
+
+```pkl
+check = "eslint {{files}} | tee eslint.log"
+```
+
+Use a structured command to execute a program directly, without a shell:
+
+```pkl
+check = new Command {
+    argv = List("wc", "-c", "{{files}}")
+}
+```
+
+The first `argv` entry is the executable, which hk resolves using `PATH`. Each remaining entry is passed to the program as one argument after template rendering. Exact, standalone `{{files}}` and `{{workspace_files}}` entries are special: hk expands them into one argument per file. `{{workspace_files}}` contains paths relative to the matched workspace when `workspace_indicator` is configured.
+
+Structured commands preserve argument boundaries, so filenames containing spaces or shell metacharacters are passed literally. Shell syntax is not interpreted: entries such as `"*"`, `"$HOME"`, `"|"`, and `">"` remain literal arguments. Use a string command if shell interpretation is required.
+
+Structured commands cannot be combined with the step's `shell` or `prefix` options. Other step behavior, including `dir`, `env`, and automatic batching for large file lists, continues to apply.
 
 ### `<GROUP>`
 
@@ -153,14 +176,14 @@ hooks {
 
 Groups may define a small set of step settings that child steps inherit when they do not define their own value:
 
-| Group option | Inherited step option | Type |
-| --- | --- | --- |
-| `dir` | `dir` | `String?` |
-| `prefix` | `prefix` | `String?` |
-| `workspace_indicator` | `workspace_indicator` | `String?` |
-| `shell` | `shell` | `(String \| Script)?` |
-| `stage` | `stage` | `(String \| List<String>)?` |
-| `exclude` | `exclude` | `(String \| List<String> \| Regex)?` |
+| Group option          | Inherited step option | Type                                 |
+| --------------------- | --------------------- | ------------------------------------ |
+| `dir`                 | `dir`                 | `String?`                            |
+| `prefix`              | `prefix`              | `String?`                            |
+| `workspace_indicator` | `workspace_indicator` | `String?`                            |
+| `shell`               | `shell`               | `(String \| Script)?`                |
+| `stage`               | `stage`               | `(String \| List<String>)?`          |
+| `exclude`             | `exclude`             | `(String \| List<String> \| Regex)?` |
 
 Inheritance uses simple override semantics. If a child step defines the field, the child value is used. Otherwise, the group value is copied to the step. Values are not merged.
 
@@ -215,7 +238,6 @@ check = "echo staged: {{ git.staged_files }}"
 
 These lists contain repository-relative paths for files currently in each state.
 
-
 ## `hkrc`
 
 > [!WARNING]
@@ -226,11 +248,11 @@ These lists contain repository-relative paths for files currently in each state.
 
 The `hkrc` is a global configuration file that allows you to customize hk's behavior across all projects. hk discovers it in this order (first match wins):
 
-| Precedence | Path | Purpose |
-|---|---|---|
-| 1 | `.hkrc.pkl` (CWD) | Per-directory override **(deprecated)** |
-| 2 | `~/.hkrc.pkl` | Home directory **(deprecated)** |
-| 3 | `~/.config/hk/config.pkl` | XDG config directory **(recommended)** |
+| Precedence | Path                      | Purpose                                 |
+| ---------- | ------------------------- | --------------------------------------- |
+| 1          | `.hkrc.pkl` (CWD)         | Per-directory override **(deprecated)** |
+| 2          | `~/.hkrc.pkl`             | Home directory **(deprecated)**         |
+| 3          | `~/.config/hk/config.pkl` | XDG config directory **(recommended)**  |
 
 ~~Use the `--hkrc` flag to override discovery and use a specific path.~~ The `--hkrc` flag is deprecated.
 
@@ -319,15 +341,15 @@ hooks = (upstream.hooks) {
 
 This section lists the configuration settings that control how hk behaves. Settings are sourced from multiple places; higher precedence overrides lower. Some list settings (e.g., `exclude`, `skip_steps`, `skip_hooks`, `hide_warnings`) use union semantics, combining values from multiple sources.
 
-| Precedence | Source | Example |
-|---|---|---|
-| 1 | CLI flags | `hk check --fail-fast` |
-| 2 | Environment variables (HK_*) | `HK_JOBS=8 hk check` |
-| 3 | Git config (local repo) | `git config --local hk.jobs 4` |
-| 4 | Git config (global/system) | `git config --global hk.failFast false` |
-| 5 | Project config (hk.pkl) | `jobs = 4` in `hk.pkl` |
-| 6 | User rc (hkrc) | `jobs = 4` in `~/.config/hk/config.pkl` |
-| 7 | Built-in defaults | `jobs = 0` (auto, CPU cores) |
+| Precedence | Source                         | Example                                 |
+| ---------- | ------------------------------ | --------------------------------------- |
+| 1          | CLI flags                      | `hk check --fail-fast`                  |
+| 2          | Environment variables (HK\_\*) | `HK_JOBS=8 hk check`                    |
+| 3          | Git config (local repo)        | `git config --local hk.jobs 4`          |
+| 4          | Git config (global/system)     | `git config --global hk.failFast false` |
+| 5          | Project config (hk.pkl)        | `jobs = 4` in `hk.pkl`                  |
+| 6          | User rc (hkrc)                 | `jobs = 4` in `~/.config/hk/config.pkl` |
+| 7          | Built-in defaults              | `jobs = 0` (auto, CPU cores)            |
 
 ### Git Configuration
 

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -21,6 +21,15 @@ class Script {
   other: String?
 }
 
+/// A command executed directly without a shell.
+///
+/// The first entry is the executable. Exact `{{files}}` and
+/// `{{workspace_files}}` entries expand to one argument per file.
+/// Structured commands cannot be combined with a step's `shell` or `prefix`.
+class Command {
+  argv: List<String>
+}
+
 /// Default: auto-detected
 ///
 /// Specifies the preferred default branch to compare against when hk needs a reference
@@ -416,7 +425,15 @@ class Step {
   /// - `{{workspace_indicator}}`: Full path to the matched workspace indicator file
   ///   (e.g., `packages/app/package.json`).
   /// - `{{workspace_files}}`: A list of files relative to `{{workspace}}`.
-  check: (String | Script)?
+  ///
+  /// To bypass the shell and pass files as separate arguments, use `Command`:
+  ///
+  /// ```pkl
+  /// check = new Command {
+  ///   argv = List("wc", "-c", "{{files}}")
+  /// }
+  /// ```
+  check: (String | Script | Command)?
 
   /// A command that returns a list of files that need fixing.
   /// This is used to optimize the fix step when `check_first` is enabled.
@@ -431,7 +448,7 @@ class Step {
   ///     }
   /// }
   /// ```
-  check_list_files: (String | Script)?
+  check_list_files: (String | Script | Command)?
 
   /// A command that shows the diff of what would be changed.
   /// This is an alternative to `check` that can provide more detailed information about what would be changed.
@@ -441,7 +458,7 @@ class Step {
   /// produce standard unified diffs (black, ruff, shfmt, etc.).
   ///
   /// Falls back to running the fix command if patch application fails.
-  check_diff: (String | Script)?
+  check_diff: (String | Script | Command)?
 
   /// A command to run that modifies files.
   /// This typically is a "fix" command like `eslint --fix` or `prettier --write`.
@@ -457,7 +474,7 @@ class Step {
   ///
   /// By default, hk will use `fix` commands but this can be overridden by setting
   /// [`HK_FIX=0`](https://hk.jdx.dev/configuration#hk-fix) or running `hk run <HOOK> --check`.
-  fix: (String | Script)?
+  fix: (String | Script | Command)?
 
   /// If true, hk will run the check step first and only run the fix step if the check step fails.
   check_first: Boolean = true

--- a/pkl/builtins/actionlint.pkl
+++ b/pkl/builtins/actionlint.pkl
@@ -12,7 +12,7 @@ import "./test/helpers.pkl"
 const actionlint = new Config.Step {
   glob = List(".github/workflows/*.yml", ".github/workflows/*.yaml")
   batch = true
-  check = "actionlint {{ files }}"
+  check = new Config.Command { argv = List("actionlint", "{{files}}") }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = ".github/workflows/test.yml"

--- a/pkl/builtins/biome.pkl
+++ b/pkl/builtins/biome.pkl
@@ -12,8 +12,12 @@ import "./test/helpers.pkl"
 }
 biome = new Config.Step {
   glob = List("**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.json")
-  check = "biome check --no-errors-on-unmatched {{ files }}"
-  fix = "biome check --write --no-errors-on-unmatched {{ files }}"
+  check = new Config.Command {
+    argv = List("biome", "check", "--no-errors-on-unmatched", "{{files}}")
+  }
+  fix = new Config.Command {
+    argv = List("biome", "check", "--write", "--no-errors-on-unmatched", "{{files}}")
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.ts" }
     local const before = "x=1"

--- a/pkl/builtins/prettier.pkl
+++ b/pkl/builtins/prettier.pkl
@@ -39,9 +39,9 @@ prettier = new Config.Step {
       "**/*.vue",
     )
   batch = true
-  check = "prettier --check {{ files }}"
-  check_list_files = "prettier --list-different {{ files }}"
-  fix = "prettier --write {{ files }}"
+  check = new Config.Command { argv = List("prettier", "--check", "{{files}}") }
+  check_list_files = new Config.Command { argv = List("prettier", "--list-different", "{{files}}") }
+  fix = new Config.Command { argv = List("prettier", "--write", "{{files}}") }
   tests {
     ["formats json"] {
       run = "fix"

--- a/pkl/builtins/ruff.pkl
+++ b/pkl/builtins/ruff.pkl
@@ -12,11 +12,11 @@ import "./test/helpers.pkl"
 }
 ruff = new Config.Step {
   glob = List("**/*.py", "**/*.pyi")
-  check = "ruff check --force-exclude {{ files }}"
+  check = new Config.Command { argv = List("ruff", "check", "--force-exclude", "{{files}}") }
   // `ruff check --diff` can exit 0 even if non-fixable issues exist, making it an
   // unreliable signal for whether to run `fix`. We use `check` instead.
   // check_diff = "ruff check --force-exclude --diff {{ files }}"
-  fix = "ruff check --force-exclude --fix {{ files }}"
+  fix = new Config.Command { argv = List("ruff", "check", "--force-exclude", "--fix", "{{files}}") }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.py"

--- a/pkl/builtins/rustfmt.pkl
+++ b/pkl/builtins/rustfmt.pkl
@@ -8,9 +8,11 @@ import "./test/helpers.pkl"
 }
 rustfmt = new Config.Step {
   glob = "**/*.rs"
-  check = "rustfmt --check --edition 2024 {{ files }}"
-  check_list_files = "rustfmt --check --edition 2024 --files-with-diff {{ files }}"
-  fix = "rustfmt --edition 2024 {{ files }}"
+  check = new Config.Command { argv = List("rustfmt", "--check", "--edition", "2024", "{{files}}") }
+  check_list_files = new Config.Command {
+    argv = List("rustfmt", "--check", "--edition", "2024", "--files-with-diff", "{{files}}")
+  }
+  fix = new Config.Command { argv = List("rustfmt", "--edition", "2024", "{{files}}") }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.rs"

--- a/pkl/builtins/shellcheck.pkl
+++ b/pkl/builtins/shellcheck.pkl
@@ -16,7 +16,7 @@ shellcheck = new Config.Step {
       new Config.FileSelector { glob = List("**/*.sh", "**/*.bash") },
       new Config.FileSelector { types = List("sh", "bash") },
     )
-  check = "shellcheck {{ files }}"
+  check = new Config.Command { argv = List("shellcheck", "{{files}}") }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.sh"

--- a/src/step/batching.rs
+++ b/src/step/batching.rs
@@ -52,6 +52,12 @@ fn shell_command_safe_limit(arg_max: usize, max_arg_strlen: Option<usize>) -> us
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct RenderedCommandSize {
+    aggregate: usize,
+    max_argument: Option<usize>,
+}
+
 impl Step {
     fn auto_batch_safe_limit(&self, command: &Command) -> usize {
         if command.is_argv() {
@@ -90,7 +96,7 @@ impl Step {
         original_job: &StepJob,
         files: &[PathBuf],
         base_tctx: &tera::Context,
-    ) -> Option<usize> {
+    ) -> Option<RenderedCommandSize> {
         let run_cmd = if original_job.check_first {
             self.check_first_cmd().map(|cmd| cmd.command())
         } else {
@@ -113,7 +119,35 @@ impl Step {
         run_cmd
             .render(&tctx, self.prefix.as_deref())
             .ok()
-            .map(|command| command.execution_size())
+            .map(|command| RenderedCommandSize {
+                aggregate: command.execution_size(),
+                max_argument: command.max_argument_size(),
+            })
+    }
+
+    fn validate_direct_argument_size(
+        &self,
+        command: Option<&Command>,
+        size: Option<RenderedCommandSize>,
+        max_arg_strlen: Option<usize>,
+    ) -> Result<()> {
+        let Some(max_argument) = command
+            .filter(|command| command.is_argv())
+            .and(size.and_then(|size| size.max_argument))
+        else {
+            return Ok(());
+        };
+        if let Some(limit) = max_arg_strlen
+            && max_argument > limit
+        {
+            bail!(
+                "{}: structured argv contains a {}-byte argument, exceeding the {}-byte platform limit",
+                self.name,
+                max_argument,
+                limit
+            );
+        }
+        Ok(())
     }
 
     /// Automatically batch jobs whose rendered run command would exceed the safe exec limit.
@@ -165,8 +199,10 @@ impl Step {
             });
 
             // Try render-based sizing first; fall back to byte estimation on render failure.
-            let full_size = self
-                .render_run_command_size(&job, &job.files, base_tctx)
+            let rendered_size = self.render_run_command_size(&job, &job.files, base_tctx);
+            self.validate_direct_argument_size(run_cmd, rendered_size, platform_max_arg_strlen())?;
+            let full_size = rendered_size
+                .map(|size| size.aggregate)
                 .unwrap_or_else(|| self.estimate_files_string_size(&job.files));
 
             if full_size <= safe_limit {
@@ -189,6 +225,7 @@ impl Step {
                 let remaining = &job.files[offset..];
                 let single_size = self
                     .render_run_command_size(&job, &remaining[..1], base_tctx)
+                    .map(|size| size.aggregate)
                     .unwrap_or_else(|| self.estimate_files_string_size(&remaining[..1]));
                 if single_size > safe_limit {
                     bail!(
@@ -207,6 +244,7 @@ impl Step {
                     let mid = (low + high).div_ceil(2);
                     let test_size = self
                         .render_run_command_size(&job, &remaining[..mid], base_tctx)
+                        .map(|size| size.aggregate)
                         .unwrap_or_else(|| self.estimate_files_string_size(&remaining[..mid]));
                     if test_size <= safe_limit {
                         low = mid;
@@ -268,6 +306,54 @@ mod tests {
         };
 
         assert_eq!(step.auto_batch_safe_limit(&command), expected);
+    }
+
+    #[test]
+    fn structured_argv_rejects_oversized_individual_argument() {
+        let command = Command::Argv(super::super::types::ArgvCommand {
+            argv: vec!["tool".to_string(), "x".repeat(100)],
+        });
+        let step = Step {
+            name: "test".to_string(),
+            ..Default::default()
+        };
+        let size = RenderedCommandSize {
+            aggregate: 105,
+            max_argument: Some(101),
+        };
+
+        let err = step
+            .validate_direct_argument_size(Some(&command), Some(size), Some(100))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("101-byte argument"));
+        assert!(err.to_string().contains("100-byte platform limit"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn structured_argv_auto_batch_rejects_linux_max_arg_strlen() {
+        let limit = platform_max_arg_strlen().unwrap();
+        let step = Step {
+            name: "test".to_string(),
+            check: Some(Command::Argv(super::super::types::ArgvCommand {
+                // The terminating NUL makes this one byte larger than the limit.
+                argv: vec!["tool".to_string(), "x".repeat(limit)],
+            })),
+            ..Default::default()
+        };
+        let job = StepJob::new(
+            Arc::new(step.clone()),
+            vec![PathBuf::from("file.txt")],
+            RunType::Check,
+        );
+
+        let err = step
+            .auto_batch_jobs(vec![job], &tera::Context::default())
+            .unwrap_err();
+
+        assert!(err.to_string().contains("structured argv"));
+        assert!(err.to_string().contains("platform limit"));
     }
 
     #[test]
@@ -339,6 +425,7 @@ mod tests {
         assert!(jobs.iter().all(|job| {
             step.render_run_command_size(job, &job.files, &tctx)
                 .unwrap()
+                .aggregate
                 <= 100
         }));
     }

--- a/src/step/batching.rs
+++ b/src/step/batching.rs
@@ -15,10 +15,15 @@ use eyre::{Result, bail};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use super::{ShellType, types::Step};
+use super::{
+    ShellType,
+    types::{Command, Step},
+};
 
 const CMD_COMMAND_LINE_LIMIT: usize = 8191;
 const CMD_COMMAND_LINE_SAFE_LIMIT: usize = CMD_COMMAND_LINE_LIMIT / 2;
+const WINDOWS_CREATE_PROCESS_LIMIT: usize = 32767;
+const WINDOWS_CREATE_PROCESS_SAFE_LIMIT: usize = WINDOWS_CREATE_PROCESS_LIMIT / 2;
 #[cfg(target_os = "linux")]
 // Linux limits each argv/envp string to 32 pages, independently of ARG_MAX.
 const LINUX_MAX_ARG_STRLEN_PAGES: usize = 32;
@@ -48,7 +53,14 @@ fn shell_command_safe_limit(arg_max: usize, max_arg_strlen: Option<usize>) -> us
 }
 
 impl Step {
-    fn auto_batch_safe_limit(&self) -> usize {
+    fn auto_batch_safe_limit(&self, command: &Command) -> usize {
+        if command.is_argv() {
+            return if cfg!(windows) {
+                WINDOWS_CREATE_PROCESS_SAFE_LIMIT
+            } else {
+                *env::ARG_MAX / 2
+            };
+        }
         match self.shell_type() {
             ShellType::Cmd => CMD_COMMAND_LINE_SAFE_LIMIT,
             _ => shell_command_safe_limit(*env::ARG_MAX, platform_max_arg_strlen()),
@@ -80,19 +92,13 @@ impl Step {
         base_tctx: &tera::Context,
     ) -> Option<usize> {
         let run_cmd = if original_job.check_first {
-            self.check_first_cmd().map(|cmd| cmd.script())
+            self.check_first_cmd().map(|cmd| cmd.command())
         } else {
             self.run_cmd(original_job.run_type)
         }?;
-        let run = run_cmd.to_string();
-        if run.trim().is_empty() {
+        if run_cmd.is_empty() {
             return None;
         }
-        let run = if let Some(prefix) = &self.prefix {
-            format!("{prefix} {run}")
-        } else {
-            run
-        };
 
         let mut temp = StepJob::new(
             Arc::clone(&original_job.step),
@@ -104,7 +110,10 @@ impl Step {
             temp = temp.with_workspace_indicator(wi.clone());
         }
         let tctx = temp.tctx(base_tctx);
-        tera::render(&run, &tctx).ok().map(|s| s.len())
+        run_cmd
+            .render(&tctx, self.prefix.as_deref())
+            .ok()
+            .map(|command| command.execution_size())
     }
 
     /// Automatically batch jobs whose rendered run command would exceed the safe exec limit.
@@ -122,14 +131,14 @@ impl Step {
         jobs: Vec<StepJob>,
         base_tctx: &tera::Context,
     ) -> Result<Vec<StepJob>> {
-        self.auto_batch_jobs_with_limit(jobs, base_tctx, self.auto_batch_safe_limit())
+        self.auto_batch_jobs_with_limit(jobs, base_tctx, None)
     }
 
     fn auto_batch_jobs_with_limit(
         &self,
         jobs: Vec<StepJob>,
         base_tctx: &tera::Context,
-        safe_limit: usize,
+        safe_limit_override: Option<usize>,
     ) -> Result<Vec<StepJob>> {
         if self.stdin.is_some() {
             // stdin path doesn't pass files via argv; never auto-batch
@@ -143,6 +152,17 @@ impl Step {
                 batched_jobs.push(job);
                 continue;
             }
+
+            let run_cmd = if job.check_first {
+                self.check_first_cmd().map(|cmd| cmd.command())
+            } else {
+                self.run_cmd(job.run_type)
+            };
+            let safe_limit = safe_limit_override.unwrap_or_else(|| {
+                run_cmd
+                    .map(|command| self.auto_batch_safe_limit(command))
+                    .unwrap_or(*env::ARG_MAX / 2)
+            });
 
             // Try render-based sizing first; fall back to byte estimation on render failure.
             let full_size = self
@@ -225,10 +245,29 @@ mod tests {
     fn cmd_shell_uses_cmd_command_line_limit() {
         let step = Step {
             shell: Some("cmd.exe".parse().unwrap()),
+            check: Some("echo {{files}}".parse().unwrap()),
             ..Default::default()
         };
 
-        assert_eq!(step.auto_batch_safe_limit(), CMD_COMMAND_LINE_SAFE_LIMIT);
+        assert_eq!(
+            step.auto_batch_safe_limit(step.check.as_ref().unwrap()),
+            CMD_COMMAND_LINE_SAFE_LIMIT
+        );
+    }
+
+    #[test]
+    fn structured_argv_uses_aggregate_process_limit() {
+        let command = Command::Argv(super::super::types::ArgvCommand {
+            argv: vec!["echo".to_string(), "{{files}}".to_string()],
+        });
+        let step = Step::default();
+        let expected = if cfg!(windows) {
+            WINDOWS_CREATE_PROCESS_SAFE_LIMIT
+        } else {
+            *env::ARG_MAX / 2
+        };
+
+        assert_eq!(step.auto_batch_safe_limit(&command), expected);
     }
 
     #[test]
@@ -239,7 +278,8 @@ mod tests {
         };
 
         let expected = shell_command_safe_limit(*env::ARG_MAX, platform_max_arg_strlen());
-        assert_eq!(step.auto_batch_safe_limit(), expected);
+        let command: Command = "echo {{files}}".parse().unwrap();
+        assert_eq!(step.auto_batch_safe_limit(&command), expected);
     }
 
     #[test]
@@ -292,7 +332,7 @@ mod tests {
         let tctx = tera::Context::default();
 
         let jobs = step
-            .auto_batch_jobs_with_limit(vec![job], &tctx, 100)
+            .auto_batch_jobs_with_limit(vec![job], &tctx, Some(100))
             .unwrap();
 
         assert!(jobs.len() > 1);
@@ -321,7 +361,7 @@ mod tests {
         );
 
         let err = step
-            .auto_batch_jobs_with_limit(vec![job], &tera::Context::default(), 100)
+            .auto_batch_jobs_with_limit(vec![job], &tera::Context::default(), Some(100))
             .unwrap_err();
 
         assert!(err.to_string().contains("file.txt"));

--- a/src/step/mod.rs
+++ b/src/step/mod.rs
@@ -47,6 +47,7 @@ mod types;
 // Re-export public API
 pub use expr_env::{EXPR_CTX, EXPR_ENV};
 pub use shell::ShellType;
+pub(crate) use types::RenderedCommand;
 pub use types::{FileSelector, OutputSummary, Pattern, RunType, Script, Step};
 
 // Re-export for potential external use (currently only used internally)

--- a/src/step/output.rs
+++ b/src/step/output.rs
@@ -6,7 +6,6 @@
 
 use crate::step_context::StepContext;
 use crate::step_job::StepJob;
-use crate::tera;
 use crate::ui::style;
 use std::sync::Arc;
 
@@ -95,7 +94,7 @@ impl Step {
         &self,
         ctx: &StepContext,
         job: &StepJob,
-        run_cmd: Option<&super::types::Script>,
+        run_cmd: Option<&super::types::Command>,
         cmd_result: Option<&ensembler::CmdResult>,
     ) {
         // Only suggest fixes when the entire hook run is in check mode,
@@ -129,28 +128,24 @@ impl Step {
         // Build a minimal context based on the suggested files, honoring dir/workspace
         let temp_job = StepJob::new(Arc::new(self.clone()), suggest_files, RunType::Fix);
         let suggest_ctx = temp_job.tctx(&ctx.hook_ctx.tctx);
-        if let Some(mut fix_cmd) = self
+        if let Some(fix_cmd) = self
             .run_cmd(RunType::Fix)
-            .map(|s| s.to_string())
-            .filter(|s| !s.trim().is_empty())
+            .filter(|command| !command.is_empty())
+            && let Ok(rendered) = fix_cmd.render(&suggest_ctx, self.prefix.as_deref())
         {
-            if let Some(prefix) = &self.prefix {
-                fix_cmd = format!("{prefix} {fix_cmd}");
-            }
-            if let Ok(rendered) = tera::render(&fix_cmd, &suggest_ctx) {
-                let is_multi_line = rendered.contains('\n');
-                if is_multi_line {
-                    // Too long to inline; suggest hk fix with step filter
-                    let step_flag = format!("-S {}", &self.name);
-                    let cmd = format!(
-                        "To fix, run: {}",
-                        style::edim(format!("hk fix {}", step_flag))
-                    );
-                    ctx.hook_ctx.add_fix_suggestion(cmd);
-                } else {
-                    let cmd = format!("To fix, run: {}", style::edim(rendered));
-                    ctx.hook_ctx.add_fix_suggestion(cmd);
-                }
+            let rendered = rendered.display(self.shell_type());
+            let is_multi_line = rendered.contains('\n');
+            if is_multi_line {
+                // Too long to inline; suggest hk fix with step filter
+                let step_flag = format!("-S {}", &self.name);
+                let cmd = format!(
+                    "To fix, run: {}",
+                    style::edim(format!("hk fix {}", step_flag))
+                );
+                ctx.hook_ctx.add_fix_suggestion(cmd);
+            } else {
+                let cmd = format!("To fix, run: {}", style::edim(rendered));
+                ctx.hook_ctx.add_fix_suggestion(cmd);
             }
         }
     }

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -24,7 +24,7 @@ use std::process::Stdio;
 
 use super::expr_env::EXPR_ENV;
 use super::shell::ShellType;
-use super::types::{CheckFirstCmd, Pattern, RunType, Script, Step};
+use super::types::{CheckFirstCmd, Command, Pattern, RenderedCommand, RunType, Step};
 use crate::error::Error;
 
 /// Cap on the per-job progress message in printable characters. The
@@ -143,7 +143,7 @@ impl Step {
             None
         };
         let run_cmd = if let Some(check_first_cmd) = check_first_cmd {
-            Some(check_first_cmd.script())
+            Some(check_first_cmd.command())
         } else {
             self.run_cmd(job.run_type)
         };
@@ -151,25 +151,23 @@ impl Step {
             || (check_first_cmd.is_none() && run_cmd == self.check_list_files.as_ref());
         let ran_check_diff = matches!(check_first_cmd, Some(CheckFirstCmd::Diff(_)))
             || (check_first_cmd.is_none() && run_cmd == self.check_diff.as_ref());
-        let Some(mut run) = run_cmd
-            .map(|s| s.to_string())
-            .filter(|s| !s.trim().is_empty())
-        else {
+        let Some(run_cmd) = run_cmd.filter(|command| !command.is_empty()) else {
             eyre::bail!("{self}: no run command");
         };
-        if let Some(prefix) = &self.prefix {
-            run = format!("{prefix} {run}");
-        }
         // Render twice: once with the full file list for execution, and
         // once with the display context — which truncates `files` /
         // `workspace_files` to `first_file …` when there are multiple
         // files. A 98-file step would otherwise emit ~4KB of paths in the
         // progress message; this keeps the command shape and one
         // concrete example path visible without unbounded expansion.
-        let run_for_display =
-            tera::render(&run, &tctx.for_display()).unwrap_or_else(|_| run.clone());
-        let run = tera::render(&run, &tctx)
+        let run_for_display = run_cmd
+            .render(&tctx.for_display(), self.prefix.as_deref())
+            .map(|command| command.display(self.shell_type()))
+            .unwrap_or_else(|_| run_cmd.to_string());
+        let rendered_command = run_cmd
+            .render(&tctx, self.prefix.as_deref())
             .wrap_err_with(|| format!("{self}: failed to render command template"))?;
+        let run = rendered_command.display(self.shell_type());
         let display_pattern = |pattern: &Pattern| match pattern {
             Pattern::Globs(globs) => globs.join(" "),
             Pattern::Regex { pattern, .. } => format!("regex: {pattern}"),
@@ -216,31 +214,36 @@ impl Step {
         // strings, so we must append the final command line verbatim via
         // `raw_arg` — otherwise Rust re-escapes the already-quoted payload and
         // cmd.exe delivers tools arguments with literal `"` characters embedded.
-        let use_raw_cmd = cfg!(windows) && matches!(self.shell_type(), ShellType::Cmd);
-        let mut cmd = if let Some(shell) = &self.shell {
-            let shell = shell.to_string();
-            let shell = shell.split_whitespace().collect_vec();
-            let mut cmd = if use_raw_cmd {
-                CmdLineRunner::new_direct(shell[0])
-            } else {
-                CmdLineRunner::new(shell[0])
-            };
-            for arg in shell[1..].iter() {
-                cmd = cmd.arg(arg);
+        let mut cmd = match &rendered_command {
+            RenderedCommand::Argv(argv) => CmdLineRunner::new_direct(&argv[0]).args(&argv[1..]),
+            RenderedCommand::Shell(run) => {
+                let use_raw_cmd = cfg!(windows) && matches!(self.shell_type(), ShellType::Cmd);
+                if let Some(shell) = &self.shell {
+                    let shell = shell.to_string();
+                    let shell = shell.split_whitespace().collect_vec();
+                    let mut cmd = if use_raw_cmd {
+                        CmdLineRunner::new_direct(shell[0])
+                    } else {
+                        CmdLineRunner::new(shell[0])
+                    };
+                    for arg in shell[1..].iter() {
+                        cmd = cmd.arg(arg);
+                    }
+                    if use_raw_cmd {
+                        cmd.raw_arg(run)
+                    } else {
+                        cmd.arg(run)
+                    }
+                } else if use_raw_cmd {
+                    CmdLineRunner::new_direct("cmd.exe").arg("/c").raw_arg(run)
+                } else {
+                    CmdLineRunner::new("sh")
+                        .arg("-o")
+                        .arg("errexit")
+                        .arg("-c")
+                        .arg(run)
+                }
             }
-            if use_raw_cmd {
-                cmd.raw_arg(&run)
-            } else {
-                cmd.arg(&run)
-            }
-        } else if use_raw_cmd {
-            CmdLineRunner::new_direct("cmd.exe").arg("/c").raw_arg(&run)
-        } else {
-            CmdLineRunner::new("sh")
-                .arg("-o")
-                .arg("errexit")
-                .arg("-c")
-                .arg(&run)
         };
         cmd = cmd
             .with_pr(job.progress.as_ref().unwrap().clone())
@@ -335,7 +338,7 @@ impl Step {
                     );
 
                     // If we're in check mode and a fix command exists, collect a helpful suggestion
-                    self.collect_fix_suggestion(ctx, job, run_cmd, Some(&e.3));
+                    self.collect_fix_suggestion(ctx, job, Some(run_cmd), Some(&e.3));
                 }
                 if job.check_first && job.run_type == RunType::Check {
                     ctx.progress.set_status(ProgressStatus::Warn);
@@ -371,6 +374,20 @@ impl Step {
                 name
             );
         }
+        let commands = [
+            self.check.as_ref(),
+            self.check_list_files.as_ref(),
+            self.check_diff.as_ref(),
+            self.fix.as_ref(),
+        ];
+        if commands.iter().flatten().any(|command| command.is_argv()) {
+            if self.shell.is_some() {
+                eyre::bail!("Step '{name}' can't combine structured argv commands with `shell`.");
+            }
+            if self.prefix.is_some() {
+                eyre::bail!("Step '{name}' can't combine structured argv commands with `prefix`.");
+            }
+        }
         self.name = name.to_string();
         if self.interactive {
             self.exclusive = true;
@@ -382,7 +399,7 @@ impl Step {
     ///
     /// For Fix mode, returns the fix command if available, otherwise falls back to check.
     /// For Check mode, returns check, check_diff, or check_list_files (in that preference order).
-    pub fn run_cmd(&self, run_type: RunType) -> Option<&Script> {
+    pub fn run_cmd(&self, run_type: RunType) -> Option<&Command> {
         match run_type {
             RunType::Fix => {
                 self.fix
@@ -403,7 +420,7 @@ impl Step {
     ///
     /// Prefers check_diff, then check_list_files, then check.
     pub fn check_first_cmd(&self) -> Option<CheckFirstCmd<'_>> {
-        let is_present = |s: &&Script| !s.to_string().trim().is_empty();
+        let is_present = |command: &&Command| !command.is_empty();
         self.check_diff
             .as_ref()
             .filter(is_present)
@@ -425,7 +442,7 @@ impl Step {
     /// Check if this step has a command for the given run type.
     pub fn has_command_for(&self, run_type: RunType) -> bool {
         self.run_cmd(run_type)
-            .map(|cmd| !cmd.to_string().trim().is_empty())
+            .map(|command| !command.is_empty())
             .unwrap_or(false)
     }
 
@@ -482,6 +499,7 @@ impl Step {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::step::Script;
 
     #[test]
     fn truncate_progress_message_passes_short_input() {
@@ -518,12 +536,12 @@ mod tests {
         // on every other platform the `other` fallback provides a valid command.
         let step = Step {
             name: "test_step".to_string(),
-            check: Some(Script {
+            check: Some(Command::Shell(Script {
                 linux: None,
                 macos: None,
                 windows: Some("".to_string()),
                 other: Some("other_cmd".to_string()),
-            }),
+            })),
             fix: None,
             ..Default::default()
         };
@@ -544,12 +562,12 @@ mod tests {
         // Test that has_command_for returns true when command is valid
         let step = Step {
             name: "test_step".to_string(),
-            check: Some(Script {
+            check: Some(Command::Shell(Script {
                 linux: Some("cmd".to_string()),
                 macos: Some("cmd".to_string()),
                 windows: Some("cmd".to_string()),
                 other: Some("cmd".to_string()),
-            }),
+            })),
             fix: None,
             ..Default::default()
         };

--- a/src/step/types.rs
+++ b/src/step/types.rs
@@ -418,7 +418,12 @@ impl Command {
                         if index == 0 {
                             eyre::bail!("the executable cannot be a file-list placeholder");
                         }
-                        rendered.extend(tctx.string_list(list).unwrap_or_default());
+                        let values = tctx.string_list(list).ok_or_else(|| {
+                            eyre::eyre!(
+                                "structured argv placeholder `{arg}` is unavailable in this step context"
+                            )
+                        })?;
+                        rendered.extend(values);
                     } else {
                         rendered.push(tera::render(arg, tctx)?);
                     }
@@ -437,6 +442,14 @@ impl RenderedCommand {
         match self {
             Self::Shell(script) => script.len(),
             Self::Argv(argv) => argv.iter().map(|arg| arg.len() + 1).sum(),
+        }
+    }
+
+    pub(crate) fn max_argument_size(&self) -> Option<usize> {
+        match self {
+            Self::Shell(_) => None,
+            // execve counts each argument's terminating NUL toward MAX_ARG_STRLEN.
+            Self::Argv(argv) => argv.iter().map(|arg| arg.len() + 1).max(),
         }
     }
 
@@ -554,6 +567,20 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("cannot use `prefix`"));
+    }
+
+    #[test]
+    fn structured_argv_rejects_unavailable_workspace_files() {
+        let command = Command::Argv(ArgvCommand {
+            argv: vec!["tool".to_string(), "{{workspace_files}}".to_string()],
+        });
+
+        let err = command.render(&tera::Context::default(), None).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("`{{workspace_files}}` is unavailable")
+        );
     }
 
     #[test]

--- a/src/step/types.rs
+++ b/src/step/types.rs
@@ -4,11 +4,12 @@
 //! - [`Step`] - The main configuration struct for a linting/formatting step
 //! - [`FileSelector`] - A positive file selector used by `match_any`
 //! - [`Pattern`] - File matching patterns (globs or regex)
-//! - [`Script`] - Platform-specific command scripts
+//! - [`Command`] - Shell scripts or structured argument vectors
+//! - [`Script`] - Platform-specific shell scripts
 //! - [`RunType`] - Whether to run in check or fix mode
 //! - [`OutputSummary`] - How to capture and display command output
 
-use crate::step_test::StepTest;
+use crate::{Result, step_test::StepTest, tera};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, PickFirst, serde_as};
@@ -190,19 +191,19 @@ pub struct Step {
 
     /// Command to check for issues (exit non-zero if issues found)
     #[serde_as(as = "Option<PickFirst<(_, DisplayFromStr)>>")]
-    pub check: Option<Script>,
+    pub check: Option<Command>,
 
     /// Command that outputs a list of files needing fixes (one per line)
     #[serde_as(as = "Option<PickFirst<(_, DisplayFromStr)>>")]
-    pub check_list_files: Option<Script>,
+    pub check_list_files: Option<Command>,
 
     /// Command that outputs a unified diff of needed changes
     #[serde_as(as = "Option<PickFirst<(_, DisplayFromStr)>>")]
-    pub check_diff: Option<Script>,
+    pub check_diff: Option<Command>,
 
     /// Command to fix issues
     #[serde_as(as = "Option<PickFirst<(_, DisplayFromStr)>>")]
-    pub fix: Option<Script>,
+    pub fix: Option<Command>,
 
     /// File that indicates workspace roots (e.g., `Cargo.toml` for Rust)
     pub workspace_indicator: Option<String>,
@@ -347,6 +348,127 @@ pub struct Script {
     pub other: Option<String>,
 }
 
+/// A command represented as an executable followed by its arguments.
+///
+/// Exact `{{files}}` and `{{workspace_files}}` entries expand to multiple
+/// arguments. Every other entry is rendered as one Tera-templated argument.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArgvCommand {
+    pub argv: Vec<String>,
+}
+
+/// A step command that either runs through a shell or executes an argv directly.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Command {
+    Argv(ArgvCommand),
+    Shell(Script),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RenderedCommand {
+    Shell(String),
+    Argv(Vec<String>),
+}
+
+impl Command {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Shell(script) => script.to_string().trim().is_empty(),
+            Self::Argv(command) => command.argv.is_empty(),
+        }
+    }
+
+    pub fn is_argv(&self) -> bool {
+        matches!(self, Self::Argv(_))
+    }
+
+    pub(crate) fn render(
+        &self,
+        tctx: &tera::Context,
+        prefix: Option<&str>,
+    ) -> Result<RenderedCommand> {
+        match self {
+            Self::Shell(script) => {
+                let script = script.to_string();
+                let script = if let Some(prefix) = prefix {
+                    format!("{prefix} {script}")
+                } else {
+                    script
+                };
+                Ok(RenderedCommand::Shell(tera::render(&script, tctx)?))
+            }
+            Self::Argv(command) => {
+                if prefix.is_some() {
+                    eyre::bail!("structured argv commands cannot use `prefix`");
+                }
+                let mut rendered = Vec::new();
+                for (index, arg) in command.argv.iter().enumerate() {
+                    let placeholder = arg
+                        .chars()
+                        .filter(|c| !c.is_whitespace())
+                        .collect::<String>();
+                    let list = match placeholder.as_str() {
+                        "{{files}}" => Some("files_list"),
+                        "{{workspace_files}}" => Some("workspace_files_list"),
+                        _ => None,
+                    };
+                    if let Some(list) = list {
+                        if index == 0 {
+                            eyre::bail!("the executable cannot be a file-list placeholder");
+                        }
+                        rendered.extend(tctx.string_list(list).unwrap_or_default());
+                    } else {
+                        rendered.push(tera::render(arg, tctx)?);
+                    }
+                }
+                if rendered.is_empty() || rendered[0].trim().is_empty() {
+                    eyre::bail!("structured argv command must contain an executable");
+                }
+                Ok(RenderedCommand::Argv(rendered))
+            }
+        }
+    }
+}
+
+impl RenderedCommand {
+    pub(crate) fn execution_size(&self) -> usize {
+        match self {
+            Self::Shell(script) => script.len(),
+            Self::Argv(argv) => argv.iter().map(|arg| arg.len() + 1).sum(),
+        }
+    }
+
+    pub(crate) fn display(&self, shell_type: super::ShellType) -> String {
+        match self {
+            Self::Shell(script) => script.clone(),
+            Self::Argv(argv) => argv
+                .iter()
+                .map(|arg| shell_type.quote(arg))
+                .collect::<Vec<_>>()
+                .join(" "),
+        }
+    }
+}
+
+impl FromStr for Command {
+    type Err = eyre::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::Shell(s.parse()?))
+    }
+}
+
+impl Display for Command {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Shell(script) => script.fmt(f),
+            Self::Argv(command) => write!(f, "{}", command.argv.join(" ")),
+        }
+    }
+}
+
 impl FromStr for Script {
     type Err = eyre::Error;
 
@@ -377,15 +499,15 @@ impl Display for Script {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CheckFirstCmd<'a> {
-    Diff(&'a Script),
-    ListFiles(&'a Script),
-    Check(&'a Script),
+    Diff(&'a Command),
+    ListFiles(&'a Command),
+    Check(&'a Command),
 }
 
 impl<'a> CheckFirstCmd<'a> {
-    pub(crate) fn script(self) -> &'a Script {
+    pub(crate) fn command(self) -> &'a Command {
         match self {
-            Self::Diff(script) | Self::ListFiles(script) | Self::Check(script) => script,
+            Self::Diff(command) | Self::ListFiles(command) | Self::Check(command) => command,
         }
     }
 }
@@ -393,6 +515,46 @@ impl<'a> CheckFirstCmd<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn structured_argv_expands_file_lists_as_distinct_arguments() {
+        let command = Command::Argv(ArgvCommand {
+            argv: vec![
+                "tool".to_string(),
+                "--label={{color}}".to_string(),
+                "{{files}}".to_string(),
+                "{{workspace_files}}".to_string(),
+            ],
+        });
+        let mut tctx = tera::Context::default();
+        tctx.insert("color", "blue");
+        tctx.insert("files_list", &vec!["a b.txt", "semi;colon.txt"]);
+        tctx.insert("workspace_files_list", &vec!["src/lib.rs"]);
+
+        assert_eq!(
+            command.render(&tctx, None).unwrap(),
+            RenderedCommand::Argv(vec![
+                "tool".to_string(),
+                "--label=blue".to_string(),
+                "a b.txt".to_string(),
+                "semi;colon.txt".to_string(),
+                "src/lib.rs".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn structured_argv_rejects_shell_prefix() {
+        let command = Command::Argv(ArgvCommand {
+            argv: vec!["tool".to_string()],
+        });
+
+        let err = command
+            .render(&tera::Context::default(), Some("env FOO=bar"))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("cannot use `prefix`"));
+    }
 
     #[test]
     fn test_script_empty_windows_command() {

--- a/src/step/types.rs
+++ b/src/step/types.rs
@@ -376,7 +376,7 @@ impl Command {
     pub fn is_empty(&self) -> bool {
         match self {
             Self::Shell(script) => script.to_string().trim().is_empty(),
-            Self::Argv(command) => command.argv.is_empty(),
+            Self::Argv(command) => command.argv.is_empty() || command.argv[0].trim().is_empty(),
         }
     }
 
@@ -567,6 +567,29 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("cannot use `prefix`"));
+    }
+
+    #[test]
+    fn structured_argv_with_blank_executable_is_empty() {
+        let command = Command::Argv(ArgvCommand {
+            argv: vec!["  ".to_string(), "--flag".to_string()],
+        });
+
+        assert!(command.is_empty());
+    }
+
+    #[test]
+    fn structured_argv_with_file_list_executable_is_invalid_not_empty() {
+        let command = Command::Argv(ArgvCommand {
+            argv: vec!["{{files}}".to_string()],
+        });
+
+        assert!(!command.is_empty());
+        let err = command.render(&tera::Context::default(), None).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("executable cannot be a file-list placeholder")
+        );
     }
 
     #[test]

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -37,6 +37,15 @@ impl Context {
         self.ctx.insert(key.into(), val);
     }
 
+    pub fn string_list(&self, key: &str) -> Option<Vec<String>> {
+        self.ctx.get(key)?.as_array().map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(ToString::to_string))
+                .collect()
+        })
+    }
+
     pub fn with_globs<P: AsRef<Path>>(&mut self, globs: &[P]) -> &mut Self {
         let globs = globs.iter().map(|m| m.as_ref().to_str().unwrap()).join(" ");
         self.insert("globs", &globs);
@@ -80,13 +89,18 @@ impl Context {
         workspace_dir: &Path,
         files: &[P],
     ) -> &mut Self {
-        let files = files
+        let files_list = files
             .iter()
             .map(|m| {
                 let p = m.as_ref();
                 let rel = p.strip_prefix(workspace_dir).unwrap_or(p);
-                shell_type.quote(rel.to_str().unwrap())
+                rel.to_str().unwrap().to_string()
             })
+            .collect::<Vec<_>>();
+        self.insert("workspace_files_list", &files_list);
+        let files = files_list
+            .iter()
+            .map(|file| shell_type.quote(file))
             .join(" ");
         self.insert("workspace_files", &files);
         self
@@ -105,8 +119,22 @@ impl Context {
         if let Some(truncated) = truncate_quoted_list(self.ctx.get("workspace_files")) {
             ctx.insert("workspace_files", &truncated);
         }
+        if let Some(truncated) = truncate_string_list(self.ctx.get("files_list")) {
+            ctx.insert("files_list", &truncated);
+        }
+        if let Some(truncated) = truncate_string_list(self.ctx.get("workspace_files_list")) {
+            ctx.insert("workspace_files_list", &truncated);
+        }
         ctx
     }
+}
+
+fn truncate_string_list(value: Option<&tera::Value>) -> Option<Vec<String>> {
+    let values = value?.as_array()?;
+    if values.len() <= 1 {
+        return None;
+    }
+    Some(vec![values[0].as_str()?.to_string(), "…".to_string()])
 }
 
 /// Truncate a space-separated quoted-token list to "first …" when it
@@ -223,5 +251,16 @@ mod tests {
         assert_eq!(truncate_quoted_list(Some(&v)), None);
         let v = tera::Value::from("   ");
         assert_eq!(truncate_quoted_list(Some(&v)), None);
+    }
+
+    #[test]
+    fn for_display_truncates_raw_file_lists() {
+        let mut ctx = Context::default();
+        ctx.insert("files_list", &vec!["a b.txt", "c.txt"]);
+
+        assert_eq!(
+            ctx.for_display().string_list("files_list"),
+            Some(vec!["a b.txt".to_string(), "…".to_string()])
+        );
     }
 }

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -4,8 +4,7 @@ use std::time::Instant;
 
 use crate::{
     Result, git_util,
-    step::RunType,
-    step::Step,
+    step::{RenderedCommand, RunType, Step},
     step_test::{RunKind, StepTest},
     tera,
 };
@@ -28,22 +27,28 @@ async fn execute_cmd(
     tctx: &tera::Context,
     base_dir: &Path,
     test: &StepTest,
-    cmd_str: &str,
+    command: &RenderedCommand,
     stdin: &Option<String>,
 ) -> Result<(String, String, i32)> {
-    let mut runner = if let Some(shell) = &step.shell {
-        let shell = shell.to_string();
-        let mut parts = shell.split_whitespace();
-        let bin = parts.next().unwrap_or("sh");
-        CmdLineRunner::new(bin).args(parts)
-    } else {
-        CmdLineRunner::new("sh").arg("-o").arg("errexit").arg("-c")
+    let mut runner = match command {
+        RenderedCommand::Argv(argv) => CmdLineRunner::new_direct(&argv[0]).args(&argv[1..]),
+        RenderedCommand::Shell(cmd_str) => {
+            let runner = if let Some(shell) = &step.shell {
+                let shell = shell.to_string();
+                let mut parts = shell.split_whitespace();
+                let bin = parts.next().unwrap_or("sh");
+                CmdLineRunner::new(bin).args(parts)
+            } else {
+                CmdLineRunner::new("sh").arg("-o").arg("errexit").arg("-c")
+            };
+            runner.arg(cmd_str)
+        }
     };
     if let Some(stdin) = stdin {
         let rendered_stdin = tera::render(stdin, tctx)?;
         runner = runner.stdin_string(rendered_stdin);
     }
-    runner = runner.arg(cmd_str).current_dir(base_dir);
+    runner = runner.current_dir(base_dir);
     for (k, v) in &step.env {
         let v = tera::render(v, tctx)?;
         runner = runner.env(k, v);
@@ -223,25 +228,19 @@ pub async fn run_test_named(step: &Step, name: &str, test: &StepTest) -> Result<
         RunKind::Check => RunType::Check,
     };
 
-    let Some(mut run) = step
-        .run_cmd(run_type)
-        .map(|s| s.to_string())
-        .filter(|s| !s.trim().is_empty())
-    else {
+    let Some(run_cmd) = step.run_cmd(run_type).filter(|command| !command.is_empty()) else {
         eyre::bail!("{}: no command for test", step.name);
     };
-    if let Some(prefix) = &step.prefix {
-        run = format!("{prefix} {run}");
-    }
-    let run = tera::render(&run, &tctx)?;
+    let run = run_cmd.render(&tctx, step.prefix.as_deref())?;
 
     // Run pre-command (before)
     let mut before_stdout = String::new();
     let mut before_stderr = String::new();
     if let Some(cmd_str) = &test.before {
         let rendered = tera::render(cmd_str, &tctx)?;
+        let command = RenderedCommand::Shell(rendered);
         let (stdout, stderr, code) =
-            execute_cmd(step, &tctx, &base_dir, test, &rendered, &None).await?;
+            execute_cmd(step, &tctx, &base_dir, test, &command, &None).await?;
         before_stdout = stdout.clone();
         before_stderr = stderr.clone();
         if code != 0 {
@@ -267,8 +266,9 @@ pub async fn run_test_named(step: &Step, name: &str, test: &StepTest) -> Result<
     let mut after_fail: Option<(i32, String, String)> = None;
     if let Some(cmd_str) = &test.after {
         let rendered = tera::render(cmd_str, &tctx)?;
+        let command = RenderedCommand::Shell(rendered);
         let (a_stdout, a_stderr, a_code) =
-            execute_cmd(step, &tctx, &base_dir, test, &rendered, &None).await?;
+            execute_cmd(step, &tctx, &base_dir, test, &command, &None).await?;
         if a_code != 0 {
             after_fail = Some((a_code, a_stdout, a_stderr));
         }

--- a/test/structured_argv.bats
+++ b/test/structured_argv.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "structured argv preserves literal arguments and file boundaries" {
+    cat <<'EOF' > capture-args
+#!/bin/sh
+printf '%s\n' "$@" > argv.log
+EOF
+    chmod +x capture-args
+    touch 'a b.txt' 'semi;colon.txt'
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["capture"] {
+                glob = "*.txt"
+                check = new Command {
+                    argv = List("{{root}}/capture-args", "\$HOME", "*", "{{files}}")
+                }
+            }
+        }
+    }
+}
+EOF
+
+    run hk check --all
+    assert_success
+
+    run cat argv.log
+    assert_success
+    assert_line --index 0 '$HOME'
+    assert_line --index 1 '*'
+    assert_line 'a b.txt'
+    assert_line 'semi;colon.txt'
+    assert_equal "${#lines[@]}" 4
+}


### PR DESCRIPTION
## Summary

- add a `Command` configuration with an explicit `argv` list for direct execution without a shell
- expand exact `{{files}}` and `{{workspace_files}}` entries into distinct raw arguments
- preserve existing string and platform `Script` behavior, including shell-specific batching limits
- apply direct execution consistently to normal runs, `hk test`, batching, progress output, and fix suggestions

Example:

```pkl
check = new Command {
  argv = List("wc", "-c", "{{files}}")
}
```

Follow-up to [discussion #1061](https://github.com/jdx/hk/discussions/1061).

## Testing

- `mise run test:cargo` (185 passed)
- `mise run test:bats test/structured_argv.bats`
- `mise run test:bats test/check_list_files_empty_with_stderr.bats`
- `cargo check --workspace`
- `cargo fmt --all -- --check`

The full local test/check tasks also require `git-lfs` and `actionlint`, which are not installed in this environment; targeted and adjacent suites pass.

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core step execution and batching paths and migrates popular builtins to argv; string commands are preserved but any quoting/exec differences in those tools could surface in edge cases.
> 
> **Overview**
> Adds a **`Command`** config shape with an explicit **`argv`** list so step **`check`**, **`fix`**, **`check_list_files`**, and **`check_diff`** can run a binary via **`PATH`** without a shell. String and platform **`Script`** commands behave as before.
> 
> Standalone **`{{files}}`** and **`{{workspace_files}}`** argv entries expand to **one argument per file** (raw paths), so names with spaces or shell metacharacters are passed literally; other argv entries are still Tera-rendered per argument. Structured commands **cannot** be used with **`shell`** or **`prefix`**.
> 
> Execution, **`hk test`**, fix suggestions, and progress text go through shared **`Command`** rendering; argv runs use direct process spawn. Auto-batching sizes argv commands against aggregate limits (including Windows) and rejects oversized single arguments on Linux (**`MAX_ARG_STRLEN`**). Several builtins (e.g. prettier, ruff, biome) now use structured **`Command`** instead of shell strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2436b59b708f1d5abfde423fa7761e0e6efcbed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->