### PR TITLE
test(step): make check list failure test deterministic

### DIFF
--- a/test/check_list_files_empty_with_stderr.bats
+++ b/test/check_list_files_empty_with_stderr.bats
@@ -196,6 +196,7 @@ exit 1
       }
       ["other-step"] {
         glob = List("*.txt")
+        depends = List("format")
         fix = "echo 'other'"
       }
     }


### PR DESCRIPTION
## Summary

- make the failing `check_list_files` test declare `other-step` as dependent on `format`
- preserve the downstream-abort assertion without relying on concurrent scheduling order

## Root cause

The two steps could run concurrently, so on macOS `other-step` sometimes completed before the intentional `format` failure. The test then expected an abort for a step that had already succeeded.

## Validation

- `mise run test:bats:libgit2 test/check_list_files_empty_with_stderr.bats`
- targeted failing case repeated five times with `HK_LIBGIT2=1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production behavior modified.
> 
> **Overview**
> Fixes a flaky bats case in `check_list_files_empty_with_stderr.bats` by adding **`depends = List("format")`** on `other-step`.
> 
> Without that edge, `format` and `other-step` could run in parallel, so on macOS `other-step` sometimes finished before the intentional `check_list_files` failure. The test still expects `hk fix` to fail, `other-step` to show as **aborted**, and no successful `✔ other-step` output—ordering the steps makes that assertion reliable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f924895ab39e10f86f8d785191069d0a28c40360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->