### PR TITLE
docs(config): document min_hk_version property

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ lto      = true
 [package.metadata.release]
 pre-release-hook = ["mise", "run", "pre-release", "--version", "{{version}}"]
 pre-release-replacements = [
-  { file = "pkl/Config.pkl", search = 'min_hk_version = ".*"', replace = 'min_hk_version = "{{version | truncate(length=1)}}.0.0"' },
+  { file = "pkl/Config.pkl", search = '(min_hk_version[^=]*= )".*"', replace = '${1}"{{version | truncate(length=1)}}.0.0"' },
 ]
 
 [profile.dev]

--- a/bin/generate_docs.rs
+++ b/bin/generate_docs.rs
@@ -355,7 +355,6 @@ fn generate_pkl_config_doc() -> Result<(), Box<dyn std::error::Error>> {
     for (key, value) in properties {
         match key.as_str() {
             "output" => continue,
-            "min_hk_version" => continue,
             // TODO(thejcannon): Include these
             "display_skip_reasons" => continue,
             "warnings" => continue,

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -2,7 +2,16 @@
 module hk.Config
 import "pkl:base" as base
 
-min_hk_version = "{{version | truncate(length=1)}}.0.0"
+/// The minimum hk version required by this config.
+///
+/// If the running hk version is older, hk errors out while loading the config.
+///
+/// Example:
+///
+/// ```pkl
+/// min_hk_version = "1.0.0"
+/// ```
+min_hk_version: String = "{{version | truncate(length=1)}}.0.0"
 
 typealias StashMethod = Boolean | "git" | "patch-file" | "none"
 


### PR DESCRIPTION
## Summary

`min_hk_version` has existed since the initial implementation but was never documented — it had no docstring in `Config.pkl` and was explicitly skipped in `bin/generate_docs.rs`. This PR documents it:

- `pkl/Config.pkl`: add a docstring with an example, and a `String` type annotation (the generated heading becomes `min_hk_version: String` instead of `min_hk_version: Unknown`)
- `bin/generate_docs.rs`: stop skipping `min_hk_version` so it appears in `docs/gen/pkl-config.md`
- `Cargo.toml`: adjust the `pre-release-replacements` pattern to only replace the value, so the release-time substitution keeps working with the type annotation

## Verification

- `mise run docs:gen` produces the new `min_hk_version: String` section
- Verified the runtime behavior locally: `min_hk_version = "999.0.0"` fails at config load, `"0.1.0"` passes

## Note

While testing, I noticed the error message swaps the running and required versions, and it surfaces via a panic. I plan to address these in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the minimum supported Haskell version setting to the generated configuration reference, making this requirement visible to users.

- **Bug Fixes**
  - Improved release version updates so the minimum supported version is changed accurately without altering surrounding configuration text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->