### PR TITLE
fix(config): correct swapped versions in min_hk_version error message

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -24,7 +24,7 @@ pub fn version_cmp_or_bail(v: &str) -> Result<()> {
     match version_cmp(v) {
         Ok(Ordering::Greater) => {
             bail!(
-                "hk version {v} is less than the minimum required version {}",
+                "hk version {} is less than the minimum required version {v}",
                 version()
             );
         }


### PR DESCRIPTION
## Summary
In `version_cmp_or_bail` (`src/version.rs`), the `bail!` message swapped the running version and the required version, so the error was inverted.

The bail triggers when `min_hk_version` (`v`) is *greater* than the running version — i.e. the running version is too old. The intended message is "hk version <running> is less than the minimum required version <min_hk_version>", but the args were reversed:

```diff
-  "hk version {v} is less than the minimum required version {}", version()
+  "hk version {} is less than the minimum required version {v}", version()
```

Example (running hk 1.50.0, `min_hk_version = "999.0.0"`):
- before: `hk version 999.0.0 is less than the minimum required version 1.50.0`
- after: `hk version 1.50.0 is less than the minimum required version 999.0.0`

Verified by building and reproducing in a temp repo (`min_hk_version = "999.0.0"`), plus `mise run test:cargo` (190 passed).

Note: this message currently surfaces via the `Failed to load configuration` panic path — out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the displayed values in the error message shown when the installed version is below the minimum required version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->