### PR TITLE
fix(conventional-commit): reject empty and malformed scopes

### DIFF
--- a/src/cli/util/check_conventional_commit.rs
+++ b/src/cli/util/check_conventional_commit.rs
@@ -66,10 +66,22 @@ fn parse_commit_title(title: &str, allowed_types: &[String]) -> Result<bool> {
         return Err(eyre::eyre!("Invalid commit type: '{commit_type}'"));
     }
 
-    if let Some(scope) = type_and_scope.next()
-        && !scope.ends_with(')')
-    {
-        return Err(eyre::eyre!("Invalid scope, missing closing parentheses"));
+    if let Some(scope) = type_and_scope.next() {
+        // Per the spec, a scope is "a noun ... surrounded by parenthesis", i.e. a
+        // single `(<non-empty>)` pair. `scope` here is everything after the first
+        // `(`, so it must end with `)`, be non-empty inside, and contain no further
+        // parentheses.
+        let Some(inner) = scope.strip_suffix(')') else {
+            return Err(eyre::eyre!("Invalid scope, missing closing parentheses"));
+        };
+        if inner.is_empty() {
+            return Err(eyre::eyre!("Invalid scope, empty scope"));
+        }
+        if inner.contains('(') || inner.contains(')') {
+            return Err(eyre::eyre!(
+                "Invalid scope, unexpected parentheses after closing parenthesis"
+            ));
+        }
     }
 
     // Ensure description has been provided and isn't an empty string
@@ -165,6 +177,45 @@ mod tests {
         let commit_msg_file = NamedTempFile::new().unwrap();
         let path = commit_msg_file.path().to_path_buf();
         fs::write(&path, b"test(scope): test description").unwrap();
+
+        let result = check_conventional_commit(&path, &["test".to_string()]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_empty_scope() {
+        let commit_msg_file = NamedTempFile::new().unwrap();
+        let path = commit_msg_file.path().to_path_buf();
+        fs::write(&path, b"test(): test description").unwrap();
+
+        let result = check_conventional_commit(&path, &["test".to_string()]);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid scope, empty scope"
+        );
+    }
+
+    #[test]
+    fn test_junk_after_closing_paren() {
+        let commit_msg_file = NamedTempFile::new().unwrap();
+        let path = commit_msg_file.path().to_path_buf();
+        fs::write(&path, b"test(scope)(x): test description").unwrap();
+
+        let result = check_conventional_commit(&path, &["test".to_string()]);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid scope, unexpected parentheses after closing parenthesis"
+        );
+    }
+
+    #[test]
+    fn test_valid_scope_with_bang() {
+        // Regression guard: `!` is stripped before the scope split, so this must stay valid.
+        let commit_msg_file = NamedTempFile::new().unwrap();
+        let path = commit_msg_file.path().to_path_buf();
+        fs::write(&path, b"test(scope)!: test description").unwrap();
 
         let result = check_conventional_commit(&path, &["test".to_string()]);
         assert!(result.is_ok());


### PR DESCRIPTION
`check-conventional-commit` accepts two malformed scopes that Conventional Commits 1.0.0 rejects. The scope validation only checked that the substring after the first `(` ends with `)`, so:

- `feat(): description` is accepted. The scope is `)`, which ends with `)`, so it passes. But clause 4 says a scope "MUST consist of a noun describing a section of the codebase surrounded by parenthesis", and an empty scope has no noun.

- `feat(scope)(x): description` is accepted. The scope substring is `scope)(x)`, which also ends with `)`. But that is not a single parenthesized noun, it has junk after the closing paren.

The fix keeps the existing "missing closing parentheses" behavior and adds two structural checks: the scope inside the parens must be non-empty, and it must not contain further parentheses. It does not restrict which characters a scope may contain, since the spec only requires "a noun surrounded by parenthesis" without enumerating allowed characters.

Tests: added `test(): ...` (empty scope) and `test(scope)(x): ...` (junk after paren) as failing-then-passing cases, plus `test(scope)!: ...` as a regression guard that the `!` path stays valid. Existing tests are unchanged and still pass.

*This PR was written with assistance from Claude Code.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of conventional commit titles with optional scopes.
  * Commit titles with missing or empty scopes, or unexpected parentheses, are now correctly rejected.
  * Valid titles using a scope followed by `!` continue to be accepted.

* **Tests**
  * Added coverage for invalid and valid scoped commit title formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->