### PR TITLE
chore: release v1.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,47 @@
 # Changelog
 
-## [1.51.0](https://github.com/jdx/hk/compare/v1.50.0..v1.51.0) - 2026-07-13
+## [1.52.0](https://github.com/jdx/hk/compare/v1.51.0..v1.52.0) - 2026-07-20
+
+### 🚀 Features
+
+- **(builtins)** add rumdl formatter by [@risu729](https://github.com/risu729) in [#1080](https://github.com/jdx/hk/pull/1080)
+- **(check)** add --unstaged flag to lint working-tree changes only by [@jdx](https://github.com/jdx) in [#1093](https://github.com/jdx/hk/pull/1093)
+- **(config)** add subprojects for nested hk configs in monorepos by [@jdx](https://github.com/jdx) in [#1094](https://github.com/jdx/hk/pull/1094)
+
+### 🐛 Bug Fixes
+
+- **(builtins)** allow detached HEAD for branch guard by [@jdx](https://github.com/jdx) in [#1075](https://github.com/jdx/hk/pull/1075)
+- **(builtins)** avoid batching mise formatter by [@risu729](https://github.com/risu729) in [#1079](https://github.com/jdx/hk/pull/1079)
+- **(config)** correct swapped versions in min_hk_version error message by [@smasato](https://github.com/smasato) in [#1070](https://github.com/jdx/hk/pull/1070)
+- **(conventional-commit)** reject empty and malformed scopes by [@LordAizen1](https://github.com/LordAizen1) in [#1071](https://github.com/jdx/hk/pull/1071)
+- **(git)** lint against empty remote (base ref unresolvable) by [@sshine](https://github.com/sshine) in [#1090](https://github.com/jdx/hk/pull/1090)
+- **(util)** skip configuration loading by [@jdx](https://github.com/jdx) in [#1078](https://github.com/jdx/hk/pull/1078)
+
+### 📚 Documentation
+
+- **(builtins)** use correct annotations key so docs group by category by [@smasato](https://github.com/smasato) in [#1088](https://github.com/jdx/hk/pull/1088)
+- **(config)** document min_hk_version property by [@smasato](https://github.com/smasato) in [#1069](https://github.com/jdx/hk/pull/1069)
+- fix sponsor logo rendering in footer by [@smasato](https://github.com/smasato) in [#1087](https://github.com/jdx/hk/pull/1087)
+
+### 🔍 Other Changes
+
+- regenerate aube-lock.yaml on renovate branches by [@jdx](https://github.com/jdx) in [#1092](https://github.com/jdx/hk/pull/1092)
+
+### 📦️ Dependency Updates
+
+- bump communique to 1.2.3 by [@jdx](https://github.com/jdx) in [#1073](https://github.com/jdx/hk/pull/1073)
+- update anthropics/claude-code-action action to v1.0.170 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1082](https://github.com/jdx/hk/pull/1082)
+- update rust crate pklr to v1.2.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1083](https://github.com/jdx/hk/pull/1083)
+- update anthropics/claude-code-action action to v1.0.171 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1086](https://github.com/jdx/hk/pull/1086)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1091](https://github.com/jdx/hk/pull/1091)
+- remove unused typescript and dead typescript-eslint by [@jdx](https://github.com/jdx) in [#1095](https://github.com/jdx/hk/pull/1095)
+
+### New Contributors
+
+- @sshine made their first contribution in [#1090](https://github.com/jdx/hk/pull/1090)
+- @LordAizen1 made their first contribution in [#1071](https://github.com/jdx/hk/pull/1071)
+
+## [1.51.0](https://github.com/jdx/hk/compare/v1.50.0..v1.51.0) - 2026-07-14
 
 ### 🚀 Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.51.0"
+version = "1.52.0"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT"
 name = "hk"
 repository = "https://github.com/jdx/hk"
 rust-version = "1.88.0"
-version = "1.51.0"
+version = "1.52.0"
 
 [[bin]]
 name = "generate-docs"

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 140+ pre-configured linters and formatters through the `Builtins` mo
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5063,7 +5063,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.51.0",
+  "version": "1.52.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.51.0
+**Version**: 1.52.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined
@@ -261,8 +261,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -295,7 +295,7 @@ Add steps to your hkrc. hk merges them into every project's hooks — steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -388,7 +388,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,8 +105,8 @@ Separately from global *hooks*, you can also create a global *config* file that 
 `hk init` generates an `hk.pkl` file in the root of the repository. Here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -43,7 +43,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,8 +3,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,8 +3,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,8 +3,8 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,8 +4,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -6,8 +6,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -6,8 +6,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -13,8 +13,8 @@ Groups can set common step attributes such as `dir`, `workspace_indicator`, `pre
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {
@@ -114,7 +114,7 @@ its own `hk.pkl` next to its code. The root config lists the subproject director
 
 ```pkl
 // hk.pkl (repo root)
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
 
 subprojects = List("frontend", "backend", "packages/*")
 
@@ -126,8 +126,8 @@ hooks {
 
 ```pkl
 // frontend/hk.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 hooks {
   ["check"] {

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -7,8 +7,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
 amends "pkl/Config.pkl"
 import "pkl/Builtins.pkl"
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -1,6 +1,6 @@
 name hk
 bin hk
-version "1.51.0"
+version "1.52.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)" hide=#true global=#true {


### PR DESCRIPTION
### 🚀 Features

- **(builtins)** add rumdl formatter by [@risu729](https://github.com/risu729) in [#1080](https://github.com/jdx/hk/pull/1080)
- **(check)** add --unstaged flag to lint working-tree changes only by [@jdx](https://github.com/jdx) in [#1093](https://github.com/jdx/hk/pull/1093)
- **(config)** add subprojects for nested hk configs in monorepos by [@jdx](https://github.com/jdx) in [#1094](https://github.com/jdx/hk/pull/1094)

### 🐛 Bug Fixes

- **(builtins)** allow detached HEAD for branch guard by [@jdx](https://github.com/jdx) in [#1075](https://github.com/jdx/hk/pull/1075)
- **(builtins)** avoid batching mise formatter by [@risu729](https://github.com/risu729) in [#1079](https://github.com/jdx/hk/pull/1079)
- **(config)** correct swapped versions in min_hk_version error message by [@smasato](https://github.com/smasato) in [#1070](https://github.com/jdx/hk/pull/1070)
- **(conventional-commit)** reject empty and malformed scopes by [@LordAizen1](https://github.com/LordAizen1) in [#1071](https://github.com/jdx/hk/pull/1071)
- **(git)** lint against empty remote (base ref unresolvable) by [@sshine](https://github.com/sshine) in [#1090](https://github.com/jdx/hk/pull/1090)
- **(util)** skip configuration loading by [@jdx](https://github.com/jdx) in [#1078](https://github.com/jdx/hk/pull/1078)

### 📚 Documentation

- **(builtins)** use correct annotations key so docs group by category by [@smasato](https://github.com/smasato) in [#1088](https://github.com/jdx/hk/pull/1088)
- **(config)** document min_hk_version property by [@smasato](https://github.com/smasato) in [#1069](https://github.com/jdx/hk/pull/1069)
- fix sponsor logo rendering in footer by [@smasato](https://github.com/smasato) in [#1087](https://github.com/jdx/hk/pull/1087)

### 🔍 Other Changes

- regenerate aube-lock.yaml on renovate branches by [@jdx](https://github.com/jdx) in [#1092](https://github.com/jdx/hk/pull/1092)

### 📦️ Dependency Updates

- bump communique to 1.2.3 by [@jdx](https://github.com/jdx) in [#1073](https://github.com/jdx/hk/pull/1073)
- update anthropics/claude-code-action action to v1.0.170 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1082](https://github.com/jdx/hk/pull/1082)
- update rust crate pklr to v1.2.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1083](https://github.com/jdx/hk/pull/1083)
- update anthropics/claude-code-action action to v1.0.171 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1086](https://github.com/jdx/hk/pull/1086)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1091](https://github.com/jdx/hk/pull/1091)
- remove unused typescript and dead typescript-eslint by [@jdx](https://github.com/jdx) in [#1095](https://github.com/jdx/hk/pull/1095)

### New Contributors

- @sshine made their first contribution in [#1090](https://github.com/jdx/hk/pull/1090)
- @LordAizen1 made their first contribution in [#1071](https://github.com/jdx/hk/pull/1071)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and documentation sync only; behavior changes ship via prior merges, not this diff.
> 
> **Overview**
> **Release v1.52.0** — bumps the crate and CLI metadata from `1.51.0` to `1.52.0` (`Cargo.toml`, `Cargo.lock`, `hk.usage.kdl`, generated CLI docs).
> 
> Adds a **CHANGELOG** section for 1.52.0 that records the shipped work (e.g. `--unstaged`, `subprojects`, rumdl builtin, and assorted fixes) from already-merged PRs.
> 
> Updates **docs and example `hk.pkl` snippets** so `amends` / `import` package URIs point at the **v1.52.0** Pkl release instead of v1.51.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31db2ff7e7c21b4e4a096f5adda9d90399f8ec6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->