### PR TITLE
fix(builtins): allow detached HEAD for branch guard

### DIFF
--- a/pkl/builtins/no_commit_to_branch.pkl
+++ b/pkl/builtins/no_commit_to_branch.pkl
@@ -20,5 +20,11 @@ no_commit_to_branch = new Config.Step {
       before = "git init -q && git checkout -q -b main"
       expect { code = 1 }
     }
+    ["passes with detached HEAD"] {
+      run = "check"
+      write { ["{{tmp}}/.gitkeep"] = "" }
+      before = "git init -q && git checkout -q -b feature-branch && git -c user.name=Test -c user.email=test@example.com commit --allow-empty -qm initial && git checkout -q --detach HEAD"
+      expect { code = 0 }
+    }
   }
 }

--- a/pkl/builtins/no_commit_to_branch.pkl
+++ b/pkl/builtins/no_commit_to_branch.pkl
@@ -23,7 +23,8 @@ no_commit_to_branch = new Config.Step {
     ["passes with detached HEAD"] {
       run = "check"
       write { ["{{tmp}}/.gitkeep"] = "" }
-      before = "git init -q && git checkout -q -b feature-branch && git -c user.name=Test -c user.email=test@example.com commit --allow-empty -qm initial && git checkout -q --detach HEAD"
+      before =
+        "git init -q && git checkout -q -b feature-branch && git -c user.name=Test -c user.email=test@example.com commit --allow-empty -qm initial && git checkout -q --detach HEAD"
       expect { code = 0 }
     }
   }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -137,11 +137,13 @@ fn has_global_hk_hooks() -> Result<bool> {
     match output.status.code().unwrap_or(1) {
         0 => Ok(!output.stdout.is_empty()),
         1 => Ok(false),
-        code => bail!(
-            "git config --get-regexp failed (exit {}): {}",
-            code,
-            String::from_utf8_lossy(&output.stderr).trim()
-        ),
+        code => {
+            bail!(
+                "git config --get-regexp failed (exit {}): {}",
+                code,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
     }
 }
 

--- a/src/cli/util/no_commit_to_branch.rs
+++ b/src/cli/util/no_commit_to_branch.rs
@@ -16,14 +16,14 @@ impl NoCommitToBranch {
             .clone()
             .unwrap_or_else(|| vec!["main".to_string(), "master".to_string()]);
 
-        if let Some(current_branch) = get_current_branch()? {
-            if protected_branches.contains(&current_branch) {
-                return Err(std::io::Error::other(format!(
-                    "Cannot commit directly to protected branch '{}'",
-                    current_branch
-                ))
-                .into());
-            }
+        if let Some(current_branch) = get_current_branch()?
+            && protected_branches.contains(&current_branch)
+        {
+            return Err(std::io::Error::other(format!(
+                "Cannot commit directly to protected branch '{}'",
+                current_branch
+            ))
+            .into());
         }
 
         Ok(())

--- a/src/cli/util/no_commit_to_branch.rs
+++ b/src/cli/util/no_commit_to_branch.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use std::path::Path;
 use std::process::Command;
 
 #[derive(Debug, clap::Args)]
@@ -15,47 +16,91 @@ impl NoCommitToBranch {
             .clone()
             .unwrap_or_else(|| vec!["main".to_string(), "master".to_string()]);
 
-        let current_branch = get_current_branch()?;
-
-        if protected_branches.contains(&current_branch) {
-            return Err(std::io::Error::other(format!(
-                "Cannot commit directly to protected branch '{}'",
-                current_branch
-            ))
-            .into());
+        if let Some(current_branch) = get_current_branch()? {
+            if protected_branches.contains(&current_branch) {
+                return Err(std::io::Error::other(format!(
+                    "Cannot commit directly to protected branch '{}'",
+                    current_branch
+                ))
+                .into());
+            }
         }
 
         Ok(())
     }
 }
 
-fn get_current_branch() -> Result<String> {
+fn get_current_branch() -> Result<Option<String>> {
+    get_current_branch_in(Path::new("."))
+}
+
+fn get_current_branch_in(dir: &Path) -> Result<Option<String>> {
     // Use symbolic-ref instead of rev-parse to work in repos without commits
     let output = Command::new("git")
-        .args(["symbolic-ref", "--short", "HEAD"])
+        .args(["symbolic-ref", "--quiet", "--short", "HEAD"])
+        .current_dir(dir)
         .output()?;
 
-    if !output.status.success() {
-        return Err(std::io::Error::other("Failed to get current git branch").into());
+    if output.status.success() {
+        let branch = String::from_utf8(output.stdout)?.trim().to_string();
+        return Ok(Some(branch));
     }
 
-    let branch = String::from_utf8(output.stdout)?.trim().to_string();
+    // A detached HEAD is expected during operations such as interactive rebases.
+    if output.status.code() == Some(1) {
+        return Ok(None);
+    }
 
-    Ok(branch)
+    Err(std::io::Error::other("Failed to get current git branch").into())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn git(dir: &Path, args: &[&str]) {
+        assert!(
+            Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .status()
+                .unwrap()
+                .success()
+        );
+    }
+
     #[test]
-    fn test_get_current_branch() {
-        // This test will only pass in a git repository
-        // In CI or non-git environments, it might fail
-        let result = get_current_branch();
-        if let Ok(branch) = result {
-            // Branch name should not be empty
-            assert!(!branch.is_empty());
-        }
+    fn test_get_current_branch_attached_and_detached() {
+        let dir = tempfile::tempdir().unwrap();
+        git(dir.path(), &["init", "-q"]);
+        git(dir.path(), &["checkout", "-q", "-b", "feature"]);
+
+        assert_eq!(
+            get_current_branch_in(dir.path()).unwrap(),
+            Some("feature".to_string())
+        );
+
+        git(
+            dir.path(),
+            &[
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "--allow-empty",
+                "-qm",
+                "initial",
+            ],
+        );
+        git(dir.path(), &["checkout", "-q", "--detach", "HEAD"]);
+
+        assert_eq!(get_current_branch_in(dir.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn test_get_current_branch_errors_outside_repository() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(get_current_branch_in(dir.path()).is_err());
     }
 }

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -199,14 +199,18 @@ pub async fn run_test_named(step: &Step, name: &str, test: &StepTest) -> Result<
     // Handle `workspace_indicator`
     if let Some(workspaces) = step.workspaces_for_files(&abs_files)? {
         let workspace_indicator = match workspaces.len() {
-            0 => eyre::bail!("{}: no workspace_indicator found for files", step.name,),
+            0 => {
+                eyre::bail!("{}: no workspace_indicator found for files", step.name,);
+            }
             1 => workspaces.into_iter().next().unwrap(),
-            n => eyre::bail!(
-                "{}: expected exactly one workspace_indicator, found {}: {:?}",
-                step.name,
-                n,
-                workspaces
-            ),
+            n => {
+                eyre::bail!(
+                    "{}: expected exactly one workspace_indicator, found {}: {:?}",
+                    step.name,
+                    n,
+                    workspaces
+                );
+            }
         };
 
         tctx.with_workspace_indicator(&workspace_indicator);


### PR DESCRIPTION
## Summary

- treat a detached `HEAD` as not being on a protected branch
- preserve errors for genuine Git failures, such as running outside a repository
- add Rust and builtin regression coverage for attached and detached states

## Root cause

`git symbolic-ref --short HEAD` exits with status 1 during operations such as interactive rebases because `HEAD` is detached. The branch guard treated every nonzero status as fatal, preventing commits created while rewording or otherwise replaying commits.

Using `--quiet` and handling status 1 as the expected detached state matches the behavior of the upstream `pre-commit-hooks` implementation without hiding unrelated Git errors.

Fixes the problem reported in https://github.com/jdx/hk/discussions/1074.

## Validation

- `cargo test test_get_current_branch -- --nocapture`
- `cargo run --quiet --bin hk -- test --step no_commit_to_branch`
- `mise run build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to a git hook utility with explicit tests; detached HEAD now skips protection instead of erroring.
> 
> **Overview**
> Fixes **`hk util no-commit-to-branch`** treating **detached `HEAD`** (e.g. during interactive rebase) as a fatal Git error instead of allowing the check to pass.
> 
> Branch resolution now uses **`git symbolic-ref --quiet --short HEAD`**, returns **`None`** when Git exits **1** (detached), and only rejects commits when the current branch name is on the protected list (**`main`**, **`master`** by default). Real failures (e.g. not in a repo) still error.
> 
> Adds a **builtin regression test** for detached HEAD and **Rust unit tests** for attached, detached, and non-repository cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba28c632f14856f6a6fec32d99c5cbabb7ccf070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->