### PR TITLE
fix(util): skip configuration loading

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -151,6 +151,7 @@ pub async fn run() -> Result<()> {
     // - Completion/Usage: shell completion generation shouldn't require valid config
     // - Version: just prints version info
     // - Builtins: just lists compiled-in builtin names, no project config needed
+    // - Util: standalone file utilities must not recursively load hk config
     let settings = if matches!(
         args.command,
         Commands::Builtins(_)
@@ -159,6 +160,7 @@ pub async fn run() -> Result<()> {
             | Commands::Completion(_)
             | Commands::Sponsors(_)
             | Commands::Usage(_)
+            | Commands::Util(_)
             | Commands::Version(_)
     ) {
         Arc::new(crate::settings::generated::settings::Settings::default())

--- a/test/config_error_handling.bats
+++ b/test/config_error_handling.bats
@@ -77,6 +77,28 @@ EOF
     assert_output --partial "Failed to load config"
 }
 
+@test "hk util ignores invalid project and user config" {
+    echo "clean line" > clean.txt
+
+    cat > hk.pkl <<'EOF'
+invalid project config
+EOF
+
+    run hk util trailing-whitespace clean.txt
+    assert_success
+    refute_output
+
+    rm hk.pkl
+    mkdir -p "$XDG_CONFIG_HOME/hk"
+    cat > "$XDG_CONFIG_HOME/hk/config.pkl" <<'EOF'
+invalid user config
+EOF
+
+    run hk util trailing-whitespace clean.txt
+    assert_success
+    refute_output
+}
+
 
 @test "config error shows helpful details" {
     cd "$BATS_TEST_TMPDIR"


### PR DESCRIPTION
## Summary

- run `hk util` with default settings instead of loading project and user configuration
- avoid redundant Pkl evaluation when builtins invoke multiple utilities in parallel
- cover malformed project and user configs with a regression test

## Context

Builtins such as `trailing-whitespace` shell out to `hk util`. Each child process currently loads `hk.pkl` and the global `config.pkl`, even though utility commands do not consume that configuration. With many utility steps running concurrently, this causes unnecessary parallel config and package-cache evaluation and is a likely source of the intermittent failures reported in [discussion #1077](https://github.com/jdx/hk/discussions/1077#discussioncomment-17664163).

@dkowis, could you build this branch and retry the original configuration with normal concurrency and without the temporary `depends` chain? If it still fails, the exact error output would help isolate any remaining shared-cache race.

## Testing

- `mise run test:bats test/config_error_handling.bats`
- `cargo test cli::tests::test_subcommands_are_sorted`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows startup behavior for `hk util` only; other commands still fail on invalid config as before.
> 
> **Overview**
> **`hk util` no longer loads project or user Pkl config** and instead uses default settings, matching other config-free commands like `version` and `builtins`.
> 
> This avoids redundant Pkl evaluation when builtins (e.g. `trailing-whitespace`) spawn many parallel `hk util` children, which was a likely cause of intermittent failures under normal concurrency.
> 
> A bats regression test asserts **`hk util trailing-whitespace` succeeds** even when `hk.pkl` or `~/.config/hk/config.pkl` is malformed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e1a108a7dab597633a90eba26fa3020340168ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Utility commands now run successfully without loading project or user configuration files.
  * Fixed an issue where invalid configuration could prevent whitespace checks from completing.
  * Confirmed utility commands produce no unexpected output on successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->