### PR TITLE
fix(builtins): avoid batching mise formatter

### DIFF
--- a/pkl/builtins/mise.pkl
+++ b/pkl/builtins/mise.pkl
@@ -25,7 +25,8 @@ mise = new Config.Step {
       ".config/mise/mise.*.toml",
       ".config/mise/conf.d/*.toml",
     )
-  batch = true
+  // `mise fmt` processes all configuration files itself and accepts no file arguments.
+  batch = false
   check = "mise fmt --check"
   fix = "mise fmt"
   tests {


### PR DESCRIPTION
## Summary

- stop batching the `mise` builtin
- document that `mise fmt` processes project configuration files itself and accepts no file arguments

## Root cause

The builtin set `batch = true` even though its check and fix commands do not render `{{ files }}`. With multiple matched configuration files, hk could therefore launch duplicate whole-project formatter jobs instead of dividing file-aware work.

## Impact

The mise formatter now runs once per hook invocation, avoiding redundant work and possible concurrent writes to the same configuration files.

## Validation

- `mise run pkl:gen`
- focused `hk test --step mise` (all four cases passed)
- full `test/builtins_tests.bats` attempted; the mise cases passed, while the suite failed on unrelated unavailable host toolchains/backends including Ruby, Java, and npm tools