### PR TITLE
feat(builtins): add rumdl formatter

### DIFF
--- a/pkl/builtins/rumdl.pkl
+++ b/pkl/builtins/rumdl.pkl
@@ -11,47 +11,24 @@ rumdl = new Config.Step {
   check_diff = "rumdl check --diff {{ files }}"
   fix = "rumdl check --fix {{ files }}"
   tests {
-    local const testMaker = new helpers.TestMaker {
-      filename = "file.md"
-      extra_files = new Mapping<String, String> {
-        [".rumdl.toml"] = "[MD007]\nindent = 2\n"
-      }
-    }
-    ["check bad file"] =
-      testMaker.checkFail(
-        """
-        # Hello
-
-        - indent 1
-                   - indent 2
-
-        """,
-        1,
-      )
-    ["check good file"] = testMaker.checkPass("# Hello\n\n- indent 1\n  - indent 2\n")
+    local const testMaker = new helpers.TestMaker { filename = "file.md" }
+    ["check bad file"] = testMaker.checkFail("# Hello\n\n\nParagraph\n", 1)
+    ["check good file"] = testMaker.checkPass("# Hello\n\nParagraph\n")
     ["fix bad file violations remain"] =
       testMaker.fixFail(
-        """
-        - indent 1
-                   - indent 2
-
-        """,
-        """
-        - indent 1
-          - indent 2
-
-        """,
+        "Paragraph\n\n\nSecond paragraph\n\n",
+        "Paragraph\n\nSecond paragraph\n",
         1,
       )
     ["fix bad file all violations are fixed"] =
       testMaker.fixPass(
-        "# Hello\n\n- indent 1\n           - indent 2\n",
-        "# Hello\n\n- indent 1\n  - indent 2\n",
+        "# Hello\n\n\nParagraph\n",
+        "# Hello\n\nParagraph\n",
       )
     ["fix good file"] =
       testMaker.fixPass(
-        "# Hello\n\n- indent 1\n  - indent 2\n",
-        "# Hello\n\n- indent 1\n  - indent 2\n",
+        "# Hello\n\nParagraph\n",
+        "# Hello\n\nParagraph\n",
       )
   }
 }

--- a/pkl/builtins/rumdl.pkl
+++ b/pkl/builtins/rumdl.pkl
@@ -4,7 +4,7 @@ import "./test/helpers.pkl"
 
 @Builtins.meta {
   category = "Markdown"
-  description = "Markdown linter and formatter"
+  description = "Markdown linter"
 }
 rumdl = new Config.Step {
   glob = List("**/*.md", "**/*.markdown")

--- a/pkl/builtins/rumdl_format.pkl
+++ b/pkl/builtins/rumdl_format.pkl
@@ -1,0 +1,22 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+import "./test/helpers.pkl"
+
+@Builtins.meta {
+  category = "Markdown"
+  description = "Markdown formatter"
+}
+rumdl_format = new Config.Step {
+  glob = List("**/*.md", "**/*.markdown")
+  check_diff = "rumdl fmt --check --diff {{ files }}"
+  fix = "rumdl fmt {{ files }}"
+  tests {
+    local const testMaker = new helpers.TestMaker { filename = "file.md" }
+    local const before = "# Hello\n\n\nParagraph\n"
+    local const after = "# Hello\n\nParagraph\n"
+    ["check bad file"] = testMaker.checkFail(before, 1)
+    ["check good file"] = testMaker.checkPass(after)
+    ["fix bad file"] = testMaker.fixPass(before, after)
+    ["fix good file"] = testMaker.fixPass(after, after)
+  }
+}

--- a/test/builtin_tool_stubs/rumdl
+++ b/test/builtin_tool_stubs/rumdl
@@ -1,4 +1,4 @@
 #!/usr/bin/env -S mise tool-stub
 
-version = "0.0.198"
+version = "0.1.0"
 tool = "aqua:rvben/rumdl"


### PR DESCRIPTION
## Summary

- add a separate `rumdl_format` builtin using `rumdl fmt --check --diff` and `rumdl fmt`
- add check and fix tests for the formatter
- bump the rumdl test stub from 0.0.198 to 0.1.0, where `fmt --check` was introduced
- update the existing rumdl linter fixtures for behavior supported by rumdl 0.1.0

## Why

The existing `rumdl` builtin runs `rumdl check` and `rumdl check --fix`. Rumdl also exposes a formatter-mode command with different exit semantics, and hk already models linter/formatter pairs separately for tools such as ruff, taplo, and tombi.

## Impact

Users can opt into Markdown formatting independently as `Builtins.rumdl_format`, while retaining `Builtins.rumdl` for linting and autofixes.

## Validation

- `mise run pkl:gen`
- `pkl format --diff-name-only pkl/builtins/rumdl.pkl pkl/builtins/rumdl_format.pkl`
- focused `hk test --step rumdl --step rumdl_format` (9 cases passed)