### PR TITLE
docs: fix sponsor logo rendering in footer

### DIFF
--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -136,8 +136,10 @@ onMounted(async () => {
 
 .EndevSponsorsLogo img {
   display: block;
-  max-height: 22px;
+  height: 22px;
+  width: auto;
   max-width: 120px;
+  object-fit: contain;
 }
 
 .EndevSponsorsCta {


### PR DESCRIPTION
## Summary

Fixes the sponsor logos in the docs footer (`EndevSponsors`). The title-tier logo (`entire-lockup.svg`) has a `viewBox` but no `width`/`height` attributes, so it has no intrinsic size. The previous CSS only constrained the image with `max-height`/`max-width`, which leaves such an SVG with no definite dimensions — Chrome collapses it to `0×0` (blank box) while other engines fall back to the default `300×150`, overflowing the container.

Giving the image an explicit `height` (with `width: auto` + `object-fit: contain`) makes every logo render at a consistent 22px height regardless of whether the SVG declares intrinsic dimensions.

## Before / After

| Before | After |
| --- | --- |
| <img width="860" height="410" alt="IMG_1605" src="https://github.com/user-attachments/assets/e417310f-c4fe-4153-9a21-4b6f7a050f23" /> | <img width="860" height="410" alt="IMG_1606" src="https://github.com/user-attachments/assets/735ec65a-44d3-4d72-b411-3d7ee1f6c687" /> |

## Validation

- `mise x node@22 -- npm run docs:build` (from `docs/`: `vitepress build`) — passes
- Verified in `vitepress dev` at mobile width: all three logos (Entire, 37signals, CodeRabbit) render at a uniform 22px height; the previously-blank `Entire` box now displays correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved sponsor logo sizing and alignment.
  * Preserved proportional scaling and ensured logos fit neatly within their display area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->