### PR TITLE
docs(builtins): use correct annotations key so docs group by category

### DIFF
--- a/bin/generate_docs.rs
+++ b/bin/generate_docs.rs
@@ -180,7 +180,7 @@ fn generate_builtins_doc() -> Result<(), Box<dyn std::error::Error>> {
             if let Some(serde_json::Value::Object(props)) = properties {
                 for (name, prop) in props {
                     // Get annotations from the property
-                    let annotations = prop.get("annnotations"); // Note: typo in reflect.pkl
+                    let annotations = prop.get("annotations");
                     let (category, description) =
                         if let Some(serde_json::Value::Array(anns)) = annotations {
                             let mut cat = "Uncategorized".to_string();


### PR DESCRIPTION
## Summary

The Built-in Linters reference (`docs/builtins.md` → generated `docs/gen/builtins.md`) lists every builtin under a single `## Uncategorized` heading, even though each `pkl/builtins/*.pkl` already declares a category via `@Builtins.meta { category = "..." }`.

Root cause: `bin/generate_docs.rs` reads the reflected annotations with a misspelled key. `scripts/reflect.pkl` emits the property as `annotations`, but the generator looked up `annnotations` (three `n`s), so the lookup always returned `None` and `category` fell back to `"Uncategorized"`:

```rust
-                    let annotations = prop.get("annnotations"); // typo: never matches
+                    let annotations = prop.get("annotations");
```

## Result

Regenerating with `cargo run --bin generate-docs` now groups builtins under their real categories (AsciiDoc, Build Systems, Go, JavaScript/TypeScript, Python, Rust, ... — 24 in total) instead of one flat `Uncategorized` section.

Only `check-byte-order-marker` and `fix-byte-order-marker` remain under `Uncategorized`, since those two builtins don't set a `category` in their `.pkl` (can be addressed separately).

## Testing

- `cargo run --bin generate-docs` and confirmed `docs/gen/builtins.md` emits per-category `##` headings.
- Rendered the VitePress docs locally and verified the categories and the "On this page" outline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed generated built-in reference documentation so categories and descriptions are populated correctly.
  * Prevented entries from incorrectly appearing as “Uncategorized” with empty descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->