### PR TITLE
fix(git): lint against empty remote (base ref unresolvable)

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1488,9 +1488,6 @@ impl Git {
     pub fn files_between_refs(&self, from_ref: &str, to_ref: Option<&str>) -> Result<Vec<PathBuf>> {
         let to_ref = to_ref.unwrap_or("HEAD");
         if let Some(repo) = &self.repo {
-            let from_obj = repo
-                .revparse_single(from_ref)
-                .wrap_err(format!("Failed to parse reference: {from_ref}"))?;
             let to_obj = repo
                 .revparse_single(to_ref)
                 .wrap_err(format!("Failed to parse reference: {to_ref}"))?;
@@ -1498,6 +1495,24 @@ impl Git {
             let to_tree = to_obj
                 .peel_to_tree()
                 .wrap_err(format!("Failed to get tree for reference: {to_ref}"))?;
+
+            let from_obj = match repo.revparse_single(from_ref) {
+                Ok(from_obj) => from_obj,
+                // Unresolvable from-ref (e.g. first push, `default_branch()` returned the literal
+                // "origin/HEAD"): diff against the empty tree so all pushed files are linted.
+                // Passing `None` as the old tree diffs against empty without materializing an
+                // empty-tree object in the ODB, keeping this query side-effect free.
+                Err(err) if err.code() == ErrorCode::NotFound => {
+                    debug!("could not resolve from-ref '{from_ref}'; diffing against empty tree");
+                    let diff = repo
+                        .diff_tree_to_tree(None, Some(&to_tree), None)
+                        .wrap_err("Failed to diff against empty tree")?;
+                    return collect_existing_paths_from_diff(diff);
+                }
+                Err(err) => {
+                    return Err(err).wrap_err(format!("Failed to resolve from-ref: {from_ref}"));
+                }
+            };
 
             // Prefer merge-base semantics (`from...to`). In shallow clones the
             // merge base can be missing, so fall back to a direct `from..to`
@@ -1539,7 +1554,7 @@ impl Git {
             };
 
             collect_existing_paths_from_diff(diff)
-        } else {
+        } else if git_rev_exists(from_ref)? {
             let range = match git_merge_base(from_ref, to_ref)? {
                 Some(merge_base) => format!("{}..{}", merge_base.trim(), to_ref),
                 None => format!("{from_ref}..{to_ref}"),
@@ -1552,6 +1567,16 @@ impl Git {
                 "--diff-filter=ACMRTUXB",
                 range.as_str(),
             ])?;
+            Ok(output
+                .split('\0')
+                .filter(|p| !p.is_empty())
+                .map(PathBuf::from)
+                .collect())
+        } else {
+            // No resolvable base: lint every file at `to_ref`. `ls-tree` is
+            // object-format agnostic, unlike a hard-coded empty-tree hash.
+            debug!("could not resolve from-ref '{from_ref}'; listing all files at {to_ref}");
+            let output = git_read(["ls-tree", "-z", "-r", "--name-only", to_ref])?;
             Ok(output
                 .split('\0')
                 .filter(|p| !p.is_empty())
@@ -1580,6 +1605,24 @@ fn collect_existing_paths_from_diff(diff: Diff<'_>) -> Result<Vec<PathBuf>> {
     .wrap_err("Failed to process diff")?;
 
     Ok(files.into_iter().collect())
+}
+
+fn git_rev_exists(rev: &str) -> Result<bool> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", rev])
+        .output()
+        .wrap_err("Failed to run git rev-parse")?;
+
+    match output.status.code() {
+        // 0: rev resolves. 1: rev is absent (with --quiet). Anything else (or a
+        // spawn failure above) is a real error, not evidence the rev is missing.
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        _ => Err(eyre!(
+            "Failed to check rev '{rev}': {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )),
+    }
 }
 
 fn git_merge_base(from_ref: &str, to_ref: &str) -> Result<Option<String>> {

--- a/test/git.bats
+++ b/test/git.bats
@@ -194,6 +194,64 @@ EOF
     refute_output --partial "unrelated.txt"
 }
 
+@test "files_between_refs lints all files when from-ref is unresolvable using libgit2" {
+    echo "main content" > main.txt
+    mkdir -p src
+    echo "nested content" > src/nested.txt
+    git add main.txt src/nested.txt
+    git commit -m "main commit"
+    MAIN_COMMIT=$(git rev-parse HEAD)
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["print-files"] {
+                check = "echo '{{files}}'"
+            }
+        }
+    }
+}
+EOF
+
+    # An unresolvable from-ref (mirrors the empty-remote first push, where
+    # default_branch() yields the literal "origin/HEAD") diffs against the
+    # empty tree, so every file at to-ref is linted.
+    HK_LIBGIT2=1 run hk check --from-ref=origin/HEAD --to-ref=$MAIN_COMMIT
+    assert_success
+    assert_output --partial "print-files – main.txt src/nested.txt"
+}
+
+@test "files_between_refs lints all files when from-ref is unresolvable using shell git" {
+    echo "main content" > main.txt
+    mkdir -p src
+    echo "nested content" > src/nested.txt
+    git add main.txt src/nested.txt
+    git commit -m "main commit"
+    MAIN_COMMIT=$(git rev-parse HEAD)
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["print-files"] {
+                check = "echo '{{files}}'"
+            }
+        }
+    }
+}
+EOF
+
+    # Shell-git fallback: git_rev_exists() returns false for the unresolvable
+    # from-ref, so files_between_refs lists every file at to-ref via ls-tree
+    # (object-format agnostic, unlike a hard-coded empty-tree hash).
+    HK_LIBGIT2=0 run hk check --from-ref=origin/HEAD --to-ref=$MAIN_COMMIT
+    assert_success
+    assert_output --partial "print-files – main.txt src/nested.txt"
+}
+
 @test "files staged for deletion are not included with --all" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"

--- a/test/pre_push.bats
+++ b/test/pre_push.bats
@@ -103,6 +103,31 @@ EOF
     assert_output --partial "[warn] new.js"
 }
 
+@test "pre-push hook on first push to empty remote" {
+    export NO_COLOR=1
+    if [ "$HK_LIBGIT2" = "0" ]; then
+        skip "libgit2 is not installed"
+    fi
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+hooks { ["pre-push"] { steps { ["prettier"] = Builtins.prettier } } }
+EOF
+    git add hk.pkl
+    git commit -m "install hk"
+    hk install --legacy
+
+    # First push to an empty remote: no origin/HEAD, no remote branches, so
+    # default_branch() falls through to the literal "origin/HEAD". The push
+    # should lint the pushed files, not fail resolving that ref.
+    echo 'console.log("first")' > first.js
+    git add first.js
+    git commit -m "add first.js"
+    HK_LOG=trace run git push -u origin main
+    assert_failure
+    assert_output --partial "[warn] first.js"
+}
+
 @test "pre-push hook skips branch deletion" {
     export NO_COLOR=1
     if [ "$HK_LIBGIT2" = "0" ]; then


### PR DESCRIPTION
This happens when you activate a pre-push hook before having pushed once.

The empty remote will fail to resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved first-push behavior to empty remote repositories by ensuring pre-push checks still run and report expected lint warnings.
  * When a starting reference (`--from-ref`) can’t be resolved, comparison now falls back to listing all files at the target reference instead of failing.
* **Tests**
  * Added coverage for first push to an empty remote and for `files-between-refs` behavior when `--from-ref` is unresolvable (for both libgit2 and shell-git modes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->