### PR TITLE
chore: regenerate aube-lock.yaml on renovate branches

### DIFF
--- a/.github/workflows/aube-lock.yml
+++ b/.github/workflows/aube-lock.yml
@@ -1,0 +1,20 @@
+name: aube-lock
+
+# Regenerates aube-lock.yaml on Renovate branches. Renovate's npm manager
+# updates package.json but has no aube support, leaving the lockfile stale
+# and breaking `aube install --frozen-lockfile` in CI. See
+# jdx/renovate-config for the workflow implementation.
+
+on:
+  push:
+    branches: ["renovate/**"]
+
+permissions:
+  contents: write
+
+jobs:
+  aube-lock:
+    uses: jdx/renovate-config/.github/workflows/aube-lock.yml@35a41bc41050f9febf38d326596631dfb19bbb9c # feat/aube-lockfile-post-upgrade
+    secrets:
+      AUBE_LOCK_APP_ID: ${{ secrets.AUBE_LOCK_APP_ID }}
+      AUBE_LOCK_APP_PRIVATE_KEY: ${{ secrets.AUBE_LOCK_APP_PRIVATE_KEY }}

--- a/.github/workflows/aube-lock.yml
+++ b/.github/workflows/aube-lock.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   aube-lock:
-    uses: jdx/renovate-config/.github/workflows/aube-lock.yml@35a41bc41050f9febf38d326596631dfb19bbb9c # feat/aube-lockfile-post-upgrade
+    uses: jdx/renovate-config/.github/workflows/aube-lock.yml@9c47679710b480fd9eba48dcbb46cb18b5b584c8 # feat/aube-lockfile-post-upgrade
     secrets:
       AUBE_LOCK_APP_ID: ${{ secrets.AUBE_LOCK_APP_ID }}
       AUBE_LOCK_APP_PRIVATE_KEY: ${{ secrets.AUBE_LOCK_APP_PRIVATE_KEY }}

--- a/.github/workflows/aube-lock.yml
+++ b/.github/workflows/aube-lock.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   aube-lock:
-    uses: jdx/renovate-config/.github/workflows/aube-lock.yml@9c47679710b480fd9eba48dcbb46cb18b5b584c8 # feat/aube-lockfile-post-upgrade
+    uses: jdx/renovate-config/.github/workflows/aube-lock.yml@d619510c737e7ebf8a8ad25f8268120bf01f4976 # main
     secrets:
       AUBE_LOCK_APP_ID: ${{ secrets.AUBE_LOCK_APP_ID }}
       AUBE_LOCK_APP_PRIVATE_KEY: ${{ secrets.AUBE_LOCK_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

Renovate has no native aube manager: its npm manager updates `package.json` but leaves `aube-lock.yaml` stale, so `aube install --frozen-lockfile` in `ci-other` fails on every JS dependency bump — most recently #1084 (typescript v6→v7), which needed a manual lockfile fix.

`postUpgradeTasks` can't solve this because they only run on self-hosted Renovate, not the Mend hosted app this org uses.

## Fix

Add a small caller for the shared **`aube-lock`** reusable workflow from [jdx/renovate-config#8](https://github.com/jdx/renovate-config/pull/8). On pushes to `renovate/**` branches (gated to renovate[bot] by immutable sender id), it runs `aube install --no-frozen-lockfile` and commits the regenerated `aube-lock.yaml` back to the branch. No third-party apps involved (deliberately avoids autofix.ci).

- `actionlint` and `zizmor` both pass clean on the caller and on the reusable workflow.
- Currently pinned to the head SHA of the renovate-config PR branch — **re-pin to the merge commit once jdx/renovate-config#8 lands** (merge order: renovate-config first, then this).
- Optional but recommended: org secrets `AUBE_LOCK_APP_ID` / `AUBE_LOCK_APP_PRIVATE_KEY` for a GitHub App scoped to `contents: write`. With them, the lockfile push retriggers CI so the Renovate PR goes green on its own; without them it falls back to `GITHUB_TOKEN` (lockfile still fixed, but checks need a manual re-run due to GitHub's recursion guard).
- Renovate-side prerequisite (included in jdx/renovate-config#8): `gitIgnoredAuthors` for `github-actions[bot]` so Renovate keeps rebasing branches the workflow commits to.

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only automation with scoped branch trigger and optional app secrets; no application runtime or auth logic changes.
> 
> **Overview**
> Adds a GitHub Actions workflow that runs on pushes to **`renovate/**`** and delegates to the shared **`aube-lock`** reusable workflow from `jdx/renovate-config`.
> 
> When Renovate bumps JS deps via the npm manager, **`aube-lock.yaml`** can stay out of sync and **`aube install --frozen-lockfile`** in CI fails. This workflow runs **`aube install`** without a frozen lockfile and commits the updated lockfile back to the branch. It requests **`contents: write`** and passes optional org secrets for a dedicated GitHub App so lockfile commits can retrigger checks; otherwise it falls back to **`GITHUB_TOKEN`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b39e35b1d8b8e37f2b5f856bdfb04330908386e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->