### PR TITLE
feat(check): add --unstaged flag to lint working-tree changes only

### DIFF
--- a/docs/cli/check.md
+++ b/docs/cli/check.md
@@ -100,3 +100,7 @@ Display statistics about files matching each step
 ### `--to-ref <TO_REF>`
 
 End reference for checking files (requires --from-ref)
+
+### `--unstaged`
+
+Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -338,6 +338,16 @@
               "double_dash": "Optional",
               "hide": false
             }
+          },
+          {
+            "name": "unstaged",
+            "usage": "--unstaged",
+            "help": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+            "help_first_line": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+            "short": [],
+            "long": ["unstaged"],
+            "hide": false,
+            "global": false
           }
         ],
         "mounts": [],
@@ -780,6 +790,16 @@
               "double_dash": "Optional",
               "hide": false
             }
+          },
+          {
+            "name": "unstaged",
+            "usage": "--unstaged",
+            "help": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+            "help_first_line": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+            "short": [],
+            "long": ["unstaged"],
+            "hide": false,
+            "global": false
           }
         ],
         "mounts": [],
@@ -1289,6 +1309,16 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "unstaged",
+                "usage": "--unstaged",
+                "help": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "help_first_line": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "short": [],
+                "long": ["unstaged"],
+                "hide": false,
+                "global": false
               }
             ],
             "mounts": [],
@@ -1614,6 +1644,16 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "unstaged",
+                "usage": "--unstaged",
+                "help": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "help_first_line": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "short": [],
+                "long": ["unstaged"],
+                "hide": false,
+                "global": false
               }
             ],
             "mounts": [],
@@ -1912,6 +1952,16 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "unstaged",
+                "usage": "--unstaged",
+                "help": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "help_first_line": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "short": [],
+                "long": ["unstaged"],
+                "hide": false,
+                "global": false
               }
             ],
             "mounts": [],
@@ -2219,6 +2269,16 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "unstaged",
+                "usage": "--unstaged",
+                "help": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "help_first_line": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "short": [],
+                "long": ["unstaged"],
+                "hide": false,
+                "global": false
               }
             ],
             "mounts": [],
@@ -2526,6 +2586,16 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "unstaged",
+                "usage": "--unstaged",
+                "help": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "help_first_line": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "short": [],
+                "long": ["unstaged"],
+                "hide": false,
+                "global": false
               }
             ],
             "mounts": [],
@@ -2824,6 +2894,16 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "unstaged",
+                "usage": "--unstaged",
+                "help": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "help_first_line": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "short": [],
+                "long": ["unstaged"],
+                "hide": false,
+                "global": false
               }
             ],
             "mounts": [],
@@ -3141,6 +3221,16 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "unstaged",
+                "usage": "--unstaged",
+                "help": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "help_first_line": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "short": [],
+                "long": ["unstaged"],
+                "hide": false,
+                "global": false
               }
             ],
             "mounts": [],
@@ -3457,6 +3547,16 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "unstaged",
+                "usage": "--unstaged",
+                "help": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "help_first_line": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "short": [],
+                "long": ["unstaged"],
+                "hide": false,
+                "global": false
               }
             ],
             "mounts": [],
@@ -3782,6 +3882,16 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "unstaged",
+                "usage": "--unstaged",
+                "help": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "help_first_line": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+                "short": [],
+                "long": ["unstaged"],
+                "hide": false,
+                "global": false
               }
             ],
             "mounts": [],
@@ -4084,6 +4194,16 @@
               "double_dash": "Optional",
               "hide": false
             }
+          },
+          {
+            "name": "unstaged",
+            "usage": "--unstaged",
+            "help": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+            "help_first_line": "Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed",
+            "short": [],
+            "long": ["unstaged"],
+            "hide": false,
+            "global": false
           }
         ],
         "mounts": [],

--- a/docs/cli/fix.md
+++ b/docs/cli/fix.md
@@ -100,3 +100,7 @@ Display statistics about files matching each step
 ### `--to-ref <TO_REF>`
 
 End reference for checking files (requires --from-ref)
+
+### `--unstaged`
+
+Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -101,6 +101,10 @@ Display statistics about files matching each step
 
 End reference for checking files (requires --from-ref)
 
+### `--unstaged`
+
+Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed
+
 ## Subcommands
 
 - [`hk run commit-msg [FLAGS] <COMMIT_MSG_FILE> [FILES]…`](/cli/run/commit-msg.md)

--- a/docs/cli/run/commit-msg.md
+++ b/docs/cli/run/commit-msg.md
@@ -102,3 +102,7 @@ Display statistics about files matching each step
 ### `--to-ref <TO_REF>`
 
 End reference for checking files (requires --from-ref)
+
+### `--unstaged`
+
+Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed

--- a/docs/cli/run/post-checkout.md
+++ b/docs/cli/run/post-checkout.md
@@ -109,3 +109,7 @@ Display statistics about files matching each step
 ### `--to-ref <TO_REF>`
 
 End reference for checking files (requires --from-ref)
+
+### `--unstaged`
+
+Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed

--- a/docs/cli/run/post-commit.md
+++ b/docs/cli/run/post-commit.md
@@ -97,3 +97,7 @@ Display statistics about files matching each step
 ### `--to-ref <TO_REF>`
 
 End reference for checking files (requires --from-ref)
+
+### `--unstaged`
+
+Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed

--- a/docs/cli/run/post-merge.md
+++ b/docs/cli/run/post-merge.md
@@ -101,3 +101,7 @@ Display statistics about files matching each step
 ### `--to-ref <TO_REF>`
 
 End reference for checking files (requires --from-ref)
+
+### `--unstaged`
+
+Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed

--- a/docs/cli/run/post-rewrite.md
+++ b/docs/cli/run/post-rewrite.md
@@ -101,3 +101,7 @@ Display statistics about files matching each step
 ### `--to-ref <TO_REF>`
 
 End reference for checking files (requires --from-ref)
+
+### `--unstaged`
+
+Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed

--- a/docs/cli/run/pre-commit.md
+++ b/docs/cli/run/pre-commit.md
@@ -100,3 +100,7 @@ Display statistics about files matching each step
 ### `--to-ref <TO_REF>`
 
 End reference for checking files (requires --from-ref)
+
+### `--unstaged`
+
+Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed

--- a/docs/cli/run/pre-push.md
+++ b/docs/cli/run/pre-push.md
@@ -106,3 +106,7 @@ Display statistics about files matching each step
 ### `--to-ref <TO_REF>`
 
 End reference for checking files (requires --from-ref)
+
+### `--unstaged`
+
+Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed

--- a/docs/cli/run/pre-rebase.md
+++ b/docs/cli/run/pre-rebase.md
@@ -105,3 +105,7 @@ Display statistics about files matching each step
 ### `--to-ref <TO_REF>`
 
 End reference for checking files (requires --from-ref)
+
+### `--unstaged`
+
+Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed

--- a/docs/cli/run/prepare-commit-msg.md
+++ b/docs/cli/run/prepare-commit-msg.md
@@ -110,3 +110,7 @@ Display statistics about files matching each step
 ### `--to-ref <TO_REF>`
 
 End reference for checking files (requires --from-ref)
+
+### `--unstaged`
+
+Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -64,6 +64,7 @@ cmd check help="Checks code" {
     flag --to-ref help="End reference for checking files (requires --from-ref)" {
         arg <TO_REF>
     }
+    flag --unstaged help="Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed"
     arg "[FILES]…" help="Run on specific files" required=#false var=#true
 }
 cmd completion help="Generates shell completion scripts" {
@@ -133,6 +134,7 @@ cmd fix help="Fixes code" {
     flag --to-ref help="End reference for checking files (requires --from-ref)" {
         arg <TO_REF>
     }
+    flag --unstaged help="Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed"
     arg "[FILES]…" help="Run on specific files" required=#false var=#true
 }
 cmd init help="Generates a new hk.pkl file for a project" {
@@ -208,6 +210,7 @@ cmd run help="Run a hook" {
     flag --to-ref help="End reference for checking files (requires --from-ref)" {
         arg <TO_REF>
     }
+    flag --unstaged help="Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed"
     arg "[OTHER]" required=#false hide=#true
     arg "[FILES]…" help="Run on specific files" required=#false var=#true
     cmd commit-msg {
@@ -251,6 +254,7 @@ cmd run help="Run a hook" {
         flag --to-ref help="End reference for checking files (requires --from-ref)" {
             arg <TO_REF>
         }
+        flag --unstaged help="Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed"
         arg <COMMIT_MSG_FILE> help="The path to the file that contains the commit message"
         arg "[FILES]…" help="Run on specific files" required=#false var=#true
     }
@@ -294,6 +298,7 @@ cmd run help="Run a hook" {
         flag --to-ref help="End reference for checking files (requires --from-ref)" {
             arg <TO_REF>
         }
+        flag --unstaged help="Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed"
         arg <PREV_HEAD> help="SHA of the HEAD before the checkout"
         arg <NEW_HEAD> help="SHA of the new HEAD"
         arg <IS_BRANCH_CHECKOUT> help="Flag indicating whether the checkout was a branch checkout (1) or file checkout (0)"
@@ -339,6 +344,7 @@ cmd run help="Run a hook" {
         flag --to-ref help="End reference for checking files (requires --from-ref)" {
             arg <TO_REF>
         }
+        flag --unstaged help="Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed"
         arg "[FILES]…" help="Run on specific files" required=#false var=#true
     }
     cmd post-merge {
@@ -381,6 +387,7 @@ cmd run help="Run a hook" {
         flag --to-ref help="End reference for checking files (requires --from-ref)" {
             arg <TO_REF>
         }
+        flag --unstaged help="Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed"
         arg <IS_SQUASH> help="Flag indicating whether the merge was a squash merge (1) or not (0)"
         arg "[FILES]…" help="Run on specific files" required=#false var=#true
     }
@@ -424,6 +431,7 @@ cmd run help="Run a hook" {
         flag --to-ref help="End reference for checking files (requires --from-ref)" {
             arg <TO_REF>
         }
+        flag --unstaged help="Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed"
         arg <COMMAND> help="The command that triggered the rewrite (\"amend\" or \"rebase\")"
         arg "[FILES]…" help="Run on specific files" required=#false var=#true
     }
@@ -468,6 +476,7 @@ cmd run help="Run a hook" {
         flag --to-ref help="End reference for checking files (requires --from-ref)" {
             arg <TO_REF>
         }
+        flag --unstaged help="Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed"
         arg "[FILES]…" help="Run on specific files" required=#false var=#true
     }
     cmd pre-push {
@@ -511,6 +520,7 @@ cmd run help="Run a hook" {
         flag --to-ref help="End reference for checking files (requires --from-ref)" {
             arg <TO_REF>
         }
+        flag --unstaged help="Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed"
         arg "[REMOTE]" help="Remote name" required=#false
         arg "[URL]" help="Remote URL" required=#false
         arg "[FILES]…" help="Run on specific files" required=#false var=#true
@@ -555,6 +565,7 @@ cmd run help="Run a hook" {
         flag --to-ref help="End reference for checking files (requires --from-ref)" {
             arg <TO_REF>
         }
+        flag --unstaged help="Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed"
         arg <UPSTREAM> help="The upstream from which the series was forked"
         arg "[BRANCH]" help="The branch being rebased (unset when rebasing the current branch)" required=#false
         arg "[FILES]…" help="Run on specific files" required=#false var=#true
@@ -600,6 +611,7 @@ cmd run help="Run a hook" {
         flag --to-ref help="End reference for checking files (requires --from-ref)" {
             arg <TO_REF>
         }
+        flag --unstaged help="Run on unstaged and untracked files only (excludes staged files), without stashing. Useful for linting files an agent just changed"
         arg <COMMIT_MSG_FILE> help="The path to the file that contains the commit message so far"
         arg "[SOURCE]" help="The source of the commit message (e.g., \"message\", \"template\", \"merge\")" required=#false
         arg "[SHA]" help="The SHA of the commit being amended (if applicable)" required=#false

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1359,6 +1359,17 @@ impl Hook {
             }
             let all_files = all_files.into_iter().collect_vec();
             glob::get_matches(glob, &all_files)?.into_iter().collect()
+        } else if opts.unstaged {
+            // Checked before `from_ref` because `pre-push` fills from_ref/to_ref
+            // programmatically after arg parsing (bypassing the clap conflict),
+            // and an explicit `--unstaged` should still win there.
+            file_progress.prop("message", "Fetching unstaged files");
+            git_status
+                .unstaged_files
+                .iter()
+                .chain(git_status.untracked_files.iter())
+                .cloned()
+                .collect()
         } else if let Some(from) = &opts.from_ref {
             if opts.to_ref.as_deref().map(crate::git::is_zero_sha) == Some(true) {
                 file_progress.prop("message", "No files to compare for remote branch deletion");
@@ -1385,14 +1396,6 @@ impl Hook {
                 all_files.extend(git_status.untracked_files.iter().cloned());
             }
             all_files
-        } else if opts.unstaged {
-            file_progress.prop("message", "Fetching unstaged files");
-            git_status
-                .unstaged_files
-                .iter()
-                .chain(git_status.untracked_files.iter())
-                .cloned()
-                .collect()
         } else if opts.staged || stash || self.defaults_to_staged_files() {
             file_progress.prop("message", "Fetching staged files");
             git_status.staged_files.iter().cloned().collect()

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -545,7 +545,7 @@ impl Hook {
     }
 
     fn resolve_stash_method_for_opts(&self, opts: &HookOptions) -> StashMethod {
-        if opts.staged {
+        if opts.staged || opts.unstaged {
             StashMethod::None
         } else if let Some(stash_str) = &opts.stash {
             stash_str
@@ -1385,6 +1385,14 @@ impl Hook {
                 all_files.extend(git_status.untracked_files.iter().cloned());
             }
             all_files
+        } else if opts.unstaged {
+            file_progress.prop("message", "Fetching unstaged files");
+            git_status
+                .unstaged_files
+                .iter()
+                .chain(git_status.untracked_files.iter())
+                .cloned()
+                .collect()
         } else if opts.staged || stash || self.defaults_to_staged_files() {
             file_progress.prop("message", "Fetching staged files");
             git_status.staged_files.iter().cloned().collect()

--- a/src/hook_options.rs
+++ b/src/hook_options.rs
@@ -6,7 +6,7 @@ pub(crate) struct HookOptions {
     #[clap(conflicts_with_all = &["all", "fix", "check"], value_hint = clap::ValueHint::FilePath)]
     pub files: Option<Vec<String>>,
     /// Run on all files instead of just staged files
-    #[clap(short, long, conflicts_with = "staged")]
+    #[clap(short, long, conflicts_with_all = &["staged", "unstaged"])]
     pub all: bool,
     /// Run check command instead of fix command
     #[clap(short, long, overrides_with = "fix")]
@@ -61,7 +61,7 @@ pub(crate) struct HookOptions {
     /// Run on staged files only without stashing unstaged changes
     #[clap(
         long,
-        conflicts_with_all = &["files", "all", "from_ref", "glob", "pr", "stash", "to_ref"]
+        conflicts_with_all = &["files", "all", "from_ref", "glob", "pr", "stash", "to_ref", "unstaged"]
     )]
     pub staged: bool,
     /// Stash method to use for git hooks
@@ -73,6 +73,13 @@ pub(crate) struct HookOptions {
     /// End reference for checking files (requires --from-ref)
     #[clap(long)]
     pub to_ref: Option<String>,
+    /// Run on unstaged and untracked files only (excludes staged files),
+    /// without stashing. Useful for linting files an agent just changed.
+    #[clap(
+        long,
+        conflicts_with_all = &["files", "all", "from_ref", "glob", "pr", "stash", "to_ref", "staged"]
+    )]
+    pub unstaged: bool,
     /// Prefilled tera context
     #[clap(skip)]
     pub tctx: Context,
@@ -83,6 +90,11 @@ impl HookOptions {
         if self.staged && self.stash.is_some() {
             return Err(eyre::eyre!(
                 "argument '--staged' cannot be used with '--stash <STASH>'"
+            ));
+        }
+        if self.unstaged && self.stash.is_some() {
+            return Err(eyre::eyre!(
+                "argument '--unstaged' cannot be used with '--stash <STASH>'"
             ));
         }
         Ok(())

--- a/test/unstaged_flag.bats
+++ b/test/unstaged_flag.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "hk run check --unstaged passes only unstaged and untracked files and does not stash" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["capture"] {
+                check = "printf '%s\n' {{files}} | sort > seen.txt"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "init"
+
+    echo "tracked" > tracked.txt
+    git add tracked.txt
+    git commit -m "add tracked"
+
+    # tracked.txt: modified in working tree (unstaged)
+    echo "unstaged" >> tracked.txt
+    # staged.txt: staged only -> should be excluded
+    echo "staged" > staged.txt
+    git add staged.txt
+    # untracked.txt: untracked -> should be included
+    echo "untracked" > untracked.txt
+
+    run hk check --unstaged
+    assert_success
+
+    run cat seen.txt
+    assert_output $'tracked.txt\nuntracked.txt'
+
+    run git stash list
+    assert_output ""
+}
+
+@test "hk run check --unstaged conflicts with --staged" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["check"] {
+                check = "true"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "init"
+
+    run hk check --unstaged --staged
+    assert_failure
+}
+
+@test "hk run check --unstaged conflicts with explicit stash option" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["check"] {
+                check = "true"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "init"
+
+    run hk check --unstaged --stash git
+    assert_failure
+    assert_output --partial "cannot be used with"
+}

--- a/test/unstaged_flag.bats
+++ b/test/unstaged_flag.bats
@@ -9,7 +9,7 @@ teardown() {
     _common_teardown
 }
 
-@test "hk run check --unstaged passes only unstaged and untracked files and does not stash" {
+@test "hk check --unstaged passes only unstaged and untracked files and does not stash" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
 hooks {
@@ -47,7 +47,39 @@ EOF
     assert_output ""
 }
 
-@test "hk run check --unstaged conflicts with --staged" {
+@test "hk run check --unstaged passes only unstaged and untracked files" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["capture"] {
+                check = "printf '%s\n' {{files}} | sort > seen.txt"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "init"
+
+    echo "tracked" > tracked.txt
+    git add tracked.txt
+    git commit -m "add tracked"
+
+    echo "unstaged" >> tracked.txt
+    echo "staged" > staged.txt
+    git add staged.txt
+    echo "untracked" > untracked.txt
+
+    run hk run check --unstaged
+    assert_success
+
+    run cat seen.txt
+    assert_output $'tracked.txt\nuntracked.txt'
+}
+
+@test "hk check --unstaged conflicts with --staged" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
 hooks {
@@ -65,9 +97,10 @@ EOF
 
     run hk check --unstaged --staged
     assert_failure
+    assert_output --partial "cannot be used with"
 }
 
-@test "hk run check --unstaged conflicts with explicit stash option" {
+@test "hk check --unstaged conflicts with explicit stash option" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
 hooks {


### PR DESCRIPTION
## Summary

Adds a `--unstaged` flag (available on `hk check`, `hk fix`, and `hk run <hook>`) that selects **only unstaged and untracked files**, excluding staged files, without stashing. It is the strict inverse of `--staged`.

## Motivation

From [discussion #1089](https://github.com/jdx/hk/discussions/1089): the user wants an agent-stop hook (à la [Evil Martians' agent hooks + nano-staged](https://evilmartians.com/chronicles/stop-writing-rules-in-agents-md-use-agent-hooks-and-nano-staged-instead)) that lints just the files an AI agent touched. Agents edit/create files in the working tree without staging them, so `--unstaged` targets exactly that set.

Previously the file-selection modes were:

| Flag | Files |
|---|---|
| (default, non-pre-commit) | staged + unstaged + untracked |
| `--staged` | staged only |
| `--all` | whole repo |
| `--from-ref/--to-ref`, `--pr` | diff between refs |

There was no way to select working-tree changes while excluding what's already staged. `--unstaged` fills that gap.

## Behavior

- Selects `unstaged_files ∪ untracked_files`.
- Does not stash (like `--staged`).
- Conflicts with `--staged`, `--all`, `--files`, `--from-ref`/`--to-ref`, `--glob`, `--pr`, and `--stash`.

## Tests

Added `test/unstaged_flag.bats` covering:
- only unstaged + untracked files are passed (staged file excluded), no stash created
- conflict with `--staged`
- conflict with explicit `--stash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI and file-selection path with clap conflicts and bats coverage; no changes to default hook behavior when the flag is omitted.
> 
> **Overview**
> Adds **`--unstaged`** on `hk check`, `hk fix`, and `hk run` so hooks run only on **unstaged plus untracked** files, excluding staged changes—the inverse of **`--staged`**.
> 
> Selection runs **before** ref-based modes (so it still applies when hooks set `from_ref`/`to_ref` internally, e.g. pre-push). Stashing is skipped when **`--unstaged`** is set, matching **`--staged`**. The flag conflicts with **`--staged`**, **`--all`**, explicit file/ref/glob/PR selection, and **`--stash`** (with validation mirroring staged).
> 
> CLI docs, `hk.usage.kdl`, and generated `commands.json` are updated. **`test/unstaged_flag.bats`** covers file set, no stash, and conflicts with **`--staged`** / **`--stash`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe3d9637e99415a1c375c12e063401e05c7a6aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->