### PR TITLE
feat(config): add subprojects for nested hk configs in monorepos

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -182,6 +182,7 @@ If set to `true`:
 
 - When installing hooks with `hk install`, hk will use `mise x` to execute hooks which won't require activating mise to use mise tools
 - When generating files with `hk init`, hk will create a `mise.toml` file with hk configured
+- When running steps with a `dir`, hk resolves the mise environment for that directory (`mise env`, cached per directory) so tools and env vars from the directory's mise config are available — see [mise integration](/mise_integration#per-directory-environments-monorepos)
 
 ## `HK_PKL_BACKEND`
 

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -69,6 +69,30 @@ PRETTIER_CONFIG = ".prettierrc.json"
 
 mise has much more functionality around environment variables, so see the [mise docs](https://mise.jdx.dev/environments/) for more information.
 
+## Per-directory environments (monorepos)
+
+When `HK_MISE=1` is set, hk resolves the mise environment for each step's `dir` by
+running `mise env` in that directory (cached, once per directory per run). Tools and
+env vars defined by a subdirectory's mise config — such as a
+[mise monorepo](https://mise.jdx.dev/tasks/monorepo.html) config root's `mise.toml` —
+are available to steps running in that directory, even when hk is started from the
+repo root:
+
+```pkl
+hooks {
+    ["check"] {
+        steps {
+            ["oxlint"] = (Builtins.ox_lint) {
+                // with HK_MISE=1, tools from subproject/mise.toml are on PATH
+                dir = "subproject"
+            }
+        }
+    }
+}
+```
+
+Explicit step `env` values always win over the mise-provided environment.
+
 ## Recommended Setup
 
 The recommended approach is to use `mise.toml` as the source of truth for your tools and environment, while using `hk` specifically for managing the Git lifecycle.

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -105,3 +105,50 @@ hooks {
 - Group-level defaults keep shared settings close to the component they apply to.
 - Child steps can override inherited values when a tool needs a different working directory, glob, shell, stage, prefix, workspace indicator, or exclude list.
 - Override semantics are simple: a child value replaces the group value instead of merging with it.
+
+## Nested configs with `subprojects`
+
+Instead of describing every component in the root `hk.pkl`, each subproject can own
+its own `hk.pkl` next to its code. The root config lists the subproject directories
+(literals or globs):
+
+```pkl
+// hk.pkl (repo root)
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+
+subprojects = List("frontend", "backend", "packages/*")
+
+hooks {
+  ["check"] {}
+  ["pre-commit"] { fix = true }
+}
+```
+
+```pkl
+// frontend/hk.pkl
+amends "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.51.0/hk@1.51.0#/Builtins.pkl"
+
+hooks {
+  ["check"] {
+    steps {
+      ["eslint"] = (Builtins.eslint) { batch = true }
+      ["prettier"] = (Builtins.prettier) { batch = true }
+    }
+  }
+}
+```
+
+When hk runs from the repo root, each subproject's hooks are merged in, scoped to
+its directory:
+
+- Step working directories and glob matching are relative to the subdirectory, so
+  `frontend/hk.pkl` only sees files under `frontend/`.
+- Step names are prefixed with the directory (e.g. `frontend:eslint`), which is the
+  name to use with `--step` or `skip_steps`.
+- A subproject's `env` applies to its own steps only.
+- Glob entries like `packages/*` match any directory containing an hk config file;
+  directories without one are skipped.
+
+This maps directly onto [mise monorepo config roots](https://mise.jdx.dev/tasks/monorepo.html):
+the same directories that own a `mise.toml` can own their `hk.pkl`.

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -185,6 +185,22 @@ stage: Boolean?
 /// Default: 20
 stash_backup_count: UInt?
 
+/// Directories containing their own hk config files, for monorepos. Entries may be
+/// literal directories or glob patterns (e.g. `"packages/*"`).
+///
+/// Each subproject's hooks are merged into this config, scoped to its directory:
+/// step working directories and glob matching are relative to the subdirectory,
+/// step names are prefixed with `"<dir>:"` (e.g. `packages/web:eslint`), and the
+/// subproject's `env` applies only to its own steps.
+///
+/// This pairs well with [mise monorepo config roots](https://mise.jdx.dev/tasks/monorepo.html):
+/// each config root can own its linting config next to its code.
+///
+/// ```pkl
+/// subprojects = List("subproject", "packages/*")
+/// ```
+subprojects: List<String>?
+
 /// Enables or disables reporting progress via OSC sequences to compatible terminals.
 terminal_progress: Boolean?
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -472,12 +472,7 @@ impl Config {
                 bail!("subprojects entries must be relative paths without '..': {pattern}");
             }
         }
-        let root = self
-            .path
-            .parent()
-            .filter(|p| !p.as_os_str().is_empty())
-            .map(|p| p.to_path_buf())
-            .unwrap_or_else(|| PathBuf::from("."));
+        let root = Self::project_root_of(&self.path);
         for (dir, config_path) in Self::discover_subprojects(&root, &patterns)? {
             debug!("loading subproject config: {}", config_path.display());
             let sub = Self::load_config_cached_with(config_path.clone(), false)?;
@@ -491,6 +486,26 @@ impl Config {
         Ok(())
     }
 
+    /// The project root a config file belongs to. Configs may live at the root
+    /// itself (hk.pkl) or under a `.config/` directory (.config/hk.pkl), in
+    /// which case the root is one level further up.
+    fn project_root_of(config_path: &Path) -> PathBuf {
+        let parent = config_path.parent().filter(|p| !p.as_os_str().is_empty());
+        let parent = match parent {
+            Some(p) => p,
+            None => return PathBuf::from("."),
+        };
+        if parent.file_name().is_some_and(|name| name == ".config") {
+            parent
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| PathBuf::from("."))
+        } else {
+            parent.to_path_buf()
+        }
+    }
+
     /// Resolve `subprojects` entries to (relative dir, config file) pairs.
     /// Literal entries warn when missing; glob matches without a config file
     /// are silently skipped.
@@ -502,11 +517,14 @@ impl Config {
         let walked: Vec<String> = if glob_patterns.is_empty() {
             vec![]
         } else {
+            // `**` patterns get a generous but bounded depth so a pathological
+            // tree can't make discovery walk forever
+            const MAX_WALK_DEPTH: usize = 32;
             let max_depth = glob_patterns
                 .iter()
                 .map(|p| {
                     if p.contains("**") {
-                        usize::MAX
+                        MAX_WALK_DEPTH
                     } else {
                         p.split('/').count()
                     }
@@ -624,14 +642,9 @@ impl Config {
                 report: sub_hook.report.clone(),
                 ..Default::default()
             });
-            // Names of the subproject hook's flat steps, for rewriting `depends`
-            // references to their scoped names.
-            let flat_names = sub_hook
-                .steps
-                .iter()
-                .filter(|(_, sog)| matches!(sog, crate::hook::StepOrGroup::Step(_)))
-                .map(|(name, _)| name.clone())
-                .collect::<IndexSet<_>>();
+            // Names of the subproject hook's steps and groups, for rewriting
+            // `depends` references to their scoped names.
+            let sibling_names = sub_hook.steps.keys().cloned().collect::<IndexSet<_>>();
             for (name, step_or_group) in sub_hook.steps {
                 let scoped_name = format!("{subdir}:{name}");
                 if root_hook.steps.contains_key(&scoped_name) {
@@ -645,7 +658,7 @@ impl Config {
                             .depends
                             .iter()
                             .map(|dep| {
-                                if flat_names.contains(dep) {
+                                if sibling_names.contains(dep) {
                                     format!("{subdir}:{dep}")
                                 } else {
                                     dep.clone()
@@ -1270,6 +1283,26 @@ mod tests {
         assert_eq!(Config::join_subdir("sub", None), "sub");
         assert_eq!(Config::join_subdir("sub", Some("")), "sub");
         assert_eq!(Config::join_subdir("sub", Some("ui")), "sub/ui");
+    }
+
+    #[test]
+    fn project_root_of_handles_config_directory() {
+        assert_eq!(
+            Config::project_root_of(Path::new("/repo/hk.pkl")),
+            PathBuf::from("/repo")
+        );
+        assert_eq!(
+            Config::project_root_of(Path::new("/repo/.config/hk.pkl")),
+            PathBuf::from("/repo")
+        );
+        assert_eq!(
+            Config::project_root_of(Path::new("hk.pkl")),
+            PathBuf::from(".")
+        );
+        assert_eq!(
+            Config::project_root_of(Path::new(".config/hk.pkl")),
+            PathBuf::from(".")
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1236,7 +1236,12 @@ mod tests {
             dir: Some("ui".to_string()), // as propagated by group.init
             ..step("ts")
         };
+        let tsc = Step {
+            depends: vec!["ts".to_string()],
+            ..step("tsc")
+        };
         group.steps.insert("ts".to_string(), ts);
+        group.steps.insert("tsc".to_string(), tsc);
         sub_hook
             .steps
             .insert("build".to_string(), StepOrGroup::Group(Box::new(group)));
@@ -1251,9 +1256,13 @@ mod tests {
         assert_eq!(group.name.as_deref(), Some("sub:build"));
         assert_eq!(group.dir.as_deref(), Some("sub/ui"));
         let ts = group.steps.get("ts").unwrap();
-        // group child names are not prefixed; in-group depends still work
         assert_eq!(ts.name, "ts");
         assert_eq!(ts.dir.as_deref(), Some("sub/ui"));
+        // Group child names are NOT prefixed, and hk builds a per-group
+        // dependency tracker keyed by those child names, so intra-group
+        // `depends` must stay unprefixed to keep resolving after merge.
+        let tsc = group.steps.get("tsc").unwrap();
+        assert_eq!(tsc.depends, vec!["ts".to_string()]);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,13 +10,14 @@ impl Config {
     #[tracing::instrument(level = "info", name = "config.load")]
     pub fn get() -> Result<Self> {
         let mut config = Self::load_project_config()?;
+        config.load_subprojects()?;
         config.apply_hkrc()?;
         config.validate()?;
         Ok(config)
     }
 
     #[tracing::instrument(level = "info", name = "config.read", skip_all, fields(path = %path.display()))]
-    fn read(path: &Path) -> Result<Self> {
+    fn read(path: &Path, apply_env: bool) -> Result<Self> {
         let ext = path.extension().unwrap_or_default().to_str().unwrap();
         let mut config: Config = match ext {
             "toml" => {
@@ -42,7 +43,7 @@ impl Config {
                 bail!("Unsupported file extension: {}", ext);
             }
         };
-        config.init(path)?;
+        config.init(path, apply_env)?;
         Ok(config)
     }
 
@@ -114,7 +115,7 @@ impl Config {
         uri.starts_with("http://") || uri.starts_with("https://") || uri.starts_with("package://")
     }
 
-    fn init(&mut self, path: &Path) -> Result<()> {
+    fn init(&mut self, path: &Path, apply_env: bool) -> Result<()> {
         self.path = path.to_path_buf();
         if let Some(min_hk_version) = &self.min_hk_version {
             version::version_cmp_or_bail(min_hk_version)?;
@@ -122,8 +123,12 @@ impl Config {
         for (name, hook) in self.hooks.iter_mut() {
             hook.init(name)?;
         }
-        for (key, value) in self.env.iter() {
-            unsafe { std::env::set_var(key, value) };
+        // Subproject configs keep their env scoped to their own steps, so only
+        // the root config exports env vars to the hk process itself.
+        if apply_env {
+            for (key, value) in self.env.iter() {
+                unsafe { std::env::set_var(key, value) };
+            }
         }
         // No imperative settings mutation; values are consumed during Settings build
         Ok(())
@@ -137,7 +142,7 @@ impl Config {
         }
         debug!("No config file found, using default");
         let mut config = Config::default();
-        config.init(Path::new(&paths[0]))?;
+        config.init(Path::new(&paths[0]), true)?;
         Ok(config)
     }
 
@@ -187,6 +192,14 @@ impl Config {
     }
 
     fn load_config_cached(path: PathBuf) -> Result<Config> {
+        Self::load_config_cached_with(path, true)
+    }
+
+    /// Load a config file with caching. `is_root` controls whether the config's
+    /// `env` is exported to the hk process (root config only) and whether the
+    /// shared `resolved-config.json` cache slot may be used — subproject configs
+    /// always get a path-keyed cache file so they don't thrash the root's slot.
+    fn load_config_cached_with(path: PathBuf, is_root: bool) -> Result<Config> {
         let hash_key = format!("{}.json", hash::hash_to_str(&path));
         let cache_dir = env::HK_CACHE_DIR.join("configs");
 
@@ -221,7 +234,7 @@ impl Config {
         };
 
         // Build the config cache with all fresh files (imports + main config)
-        let config_cache_path = if has_untracked_imports {
+        let config_cache_path = if has_untracked_imports || !is_root {
             cache_dir.join(hash_key)
         } else {
             cache_dir.join("resolved-config.json")
@@ -239,11 +252,11 @@ impl Config {
         // to apply side-effects (env vars, settings, warnings) that are not stored in cache.
         let mut config = config_cache_mgr
             .get_or_try_init(|| {
-                Self::read(&path)
+                Self::read(&path, is_root)
                     .wrap_err_with(|| format!("Failed to read config file: {}", path.display()))
             })?
             .clone();
-        config.init(&path)?;
+        config.init(&path, is_root)?;
         Ok(config)
     }
 
@@ -395,7 +408,7 @@ impl Config {
             } else {
                 let mut hkrc_config: Config = serde_json::from_value(json_value)
                     .wrap_err("failed to parse hkrc as Config")?;
-                hkrc_config.init(&path)?;
+                hkrc_config.init(&path, true)?;
                 self.merge_from_hkrc(hkrc_config);
             }
         }
@@ -437,6 +450,242 @@ impl Config {
             } else {
                 self.hooks.insert(hook_name, hkrc_hook);
             }
+        }
+    }
+
+    /// Load configs from `subprojects` directories and merge their hooks into
+    /// this config, scoped to each subdirectory. Entries may be literal
+    /// directories ("subproject") or glob patterns ("packages/*").
+    fn load_subprojects(&mut self) -> Result<()> {
+        let Some(patterns) = self.subprojects.clone() else {
+            return Ok(());
+        };
+        if patterns.is_empty() {
+            return Ok(());
+        }
+        for pattern in &patterns {
+            let p = Path::new(pattern);
+            if p.is_absolute()
+                || p.components()
+                    .any(|c| matches!(c, std::path::Component::ParentDir))
+            {
+                bail!("subprojects entries must be relative paths without '..': {pattern}");
+            }
+        }
+        let root = self
+            .path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| PathBuf::from("."));
+        for (dir, config_path) in Self::discover_subprojects(&root, &patterns)? {
+            debug!("loading subproject config: {}", config_path.display());
+            let sub = Self::load_config_cached_with(config_path.clone(), false)?;
+            self.merge_subproject(&dir, sub).wrap_err_with(|| {
+                format!(
+                    "failed to merge subproject config: {}",
+                    config_path.display()
+                )
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Resolve `subprojects` entries to (relative dir, config file) pairs.
+    /// Literal entries warn when missing; glob matches without a config file
+    /// are silently skipped.
+    fn discover_subprojects(root: &Path, patterns: &[String]) -> Result<Vec<(String, PathBuf)>> {
+        let is_glob = |p: &str| p.chars().any(|c| matches!(c, '*' | '?' | '[' | '{'));
+        let mut out: IndexMap<String, PathBuf> = IndexMap::new();
+        // Walk the tree once (bounded by the deepest glob) if any globs are present
+        let glob_patterns = patterns.iter().filter(|p| is_glob(p)).collect::<Vec<_>>();
+        let walked: Vec<String> = if glob_patterns.is_empty() {
+            vec![]
+        } else {
+            let max_depth = glob_patterns
+                .iter()
+                .map(|p| {
+                    if p.contains("**") {
+                        usize::MAX
+                    } else {
+                        p.split('/').count()
+                    }
+                })
+                .max()
+                .unwrap();
+            let mut dirs = vec![];
+            Self::walk_dirs(root, root, max_depth, &mut dirs);
+            dirs.sort();
+            dirs
+        };
+        for pattern in patterns {
+            if is_glob(pattern) {
+                let matcher = globset::GlobBuilder::new(pattern)
+                    .literal_separator(true)
+                    .empty_alternates(true)
+                    .build()
+                    .wrap_err_with(|| format!("invalid subprojects glob: {pattern}"))?
+                    .compile_matcher();
+                for dir in walked.iter().filter(|d| matcher.is_match(d)) {
+                    if out.contains_key(dir) {
+                        continue;
+                    }
+                    if let Some(config_path) = Self::find_subproject_config(&root.join(dir)) {
+                        out.insert(dir.clone(), config_path);
+                    } else {
+                        debug!("subprojects: no hk config in {dir}, skipping");
+                    }
+                }
+            } else {
+                let dir = pattern.trim_end_matches('/').to_string();
+                if !root.join(&dir).is_dir() {
+                    warn!("subprojects: directory not found: {dir}");
+                    continue;
+                }
+                if out.contains_key(&dir) {
+                    continue;
+                }
+                match Self::find_subproject_config(&root.join(&dir)) {
+                    Some(config_path) => {
+                        out.insert(dir, config_path);
+                    }
+                    None => warn!("subprojects: no hk config found in {dir}"),
+                }
+            }
+        }
+        Ok(out.into_iter().collect())
+    }
+
+    /// Recursively collect directories (relative, '/'-separated) up to max_depth,
+    /// skipping hidden directories, node_modules, and symlinks.
+    fn walk_dirs(root: &Path, dir: &Path, max_depth: usize, out: &mut Vec<String>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with('.') || name == "node_modules" {
+                continue;
+            }
+            let path = entry.path();
+            if path.is_symlink() || !path.is_dir() {
+                continue;
+            }
+            let Ok(rel) = path.strip_prefix(root) else {
+                continue;
+            };
+            let rel = rel.to_string_lossy().replace('\\', "/");
+            let depth = rel.split('/').count();
+            if depth <= max_depth {
+                out.push(rel);
+            }
+            if depth < max_depth {
+                Self::walk_dirs(root, &path, max_depth, out);
+            }
+        }
+    }
+
+    fn find_subproject_config(dir: &Path) -> Option<PathBuf> {
+        [
+            "hk.local.pkl",
+            ".config/hk.local.pkl",
+            "hk.pkl",
+            ".config/hk.pkl",
+            "hk.toml",
+            "hk.yaml",
+            "hk.yml",
+            "hk.json",
+        ]
+        .iter()
+        .map(|name| dir.join(name))
+        .find(|p| p.exists())
+    }
+
+    /// Merge a subproject config into this one. Each hook's steps are scoped to
+    /// `subdir`: working directories are joined onto the subdirectory (which also
+    /// scopes glob matching), step/group names are prefixed with "{subdir}:", and
+    /// the subproject's `env` is applied to its own steps only.
+    fn merge_subproject(&mut self, subdir: &str, mut sub: Config) -> Result<()> {
+        if sub.subprojects.as_ref().is_some_and(|s| !s.is_empty()) {
+            warn!(
+                "subprojects: nested `subprojects` in {} is ignored (only one level is supported)",
+                sub.path.display()
+            );
+        }
+        let sub_env = std::mem::take(&mut sub.env);
+        for (hook_name, sub_hook) in std::mem::take(&mut sub.hooks) {
+            let root_hook = self.hooks.entry(hook_name.clone()).or_insert_with(|| Hook {
+                name: hook_name.clone(),
+                fix: sub_hook.fix,
+                stash: sub_hook.stash.clone(),
+                stage: sub_hook.stage,
+                fail_on_fix: sub_hook.fail_on_fix,
+                report: sub_hook.report.clone(),
+                ..Default::default()
+            });
+            // Names of the subproject hook's flat steps, for rewriting `depends`
+            // references to their scoped names.
+            let flat_names = sub_hook
+                .steps
+                .iter()
+                .filter(|(_, sog)| matches!(sog, crate::hook::StepOrGroup::Step(_)))
+                .map(|(name, _)| name.clone())
+                .collect::<IndexSet<_>>();
+            for (name, step_or_group) in sub_hook.steps {
+                let scoped_name = format!("{subdir}:{name}");
+                if root_hook.steps.contains_key(&scoped_name) {
+                    bail!("duplicate step name '{scoped_name}' in hook '{hook_name}'");
+                }
+                let step_or_group = match step_or_group {
+                    crate::hook::StepOrGroup::Step(mut step) => {
+                        Self::scope_subproject_step(&mut step, subdir, &sub_hook.env, &sub_env);
+                        step.name = scoped_name.clone();
+                        step.depends = step
+                            .depends
+                            .iter()
+                            .map(|dep| {
+                                if flat_names.contains(dep) {
+                                    format!("{subdir}:{dep}")
+                                } else {
+                                    dep.clone()
+                                }
+                            })
+                            .collect();
+                        crate::hook::StepOrGroup::Step(step)
+                    }
+                    crate::hook::StepOrGroup::Group(mut group) => {
+                        group.name = Some(scoped_name.clone());
+                        group.dir = Some(Self::join_subdir(subdir, group.dir.as_deref()));
+                        for step in group.steps.values_mut() {
+                            Self::scope_subproject_step(step, subdir, &sub_hook.env, &sub_env);
+                        }
+                        crate::hook::StepOrGroup::Group(group)
+                    }
+                };
+                root_hook.steps.insert(scoped_name, step_or_group);
+            }
+        }
+        Ok(())
+    }
+
+    fn scope_subproject_step(
+        step: &mut crate::step::Step,
+        subdir: &str,
+        hook_env: &IndexMap<String, String>,
+        config_env: &IndexMap<String, String>,
+    ) {
+        step.dir = Some(Self::join_subdir(subdir, step.dir.as_deref()));
+        // step env wins over the subproject's hook env, which wins over its config env
+        for (key, value) in hook_env.iter().chain(config_env.iter()) {
+            step.env.entry(key.clone()).or_insert_with(|| value.clone());
+        }
+    }
+
+    fn join_subdir(subdir: &str, dir: Option<&str>) -> String {
+        match dir {
+            Some(dir) if !dir.is_empty() => format!("{subdir}/{dir}"),
+            _ => subdir.to_string(),
         }
     }
 }
@@ -701,6 +950,9 @@ pub struct Config {
     pub profiles: Option<Vec<String>>,
     pub skip_hooks: Option<Vec<String>>,
     pub skip_steps: Option<Vec<String>>,
+    /// Directories (or glob patterns) containing their own hk config files.
+    /// Their hooks are merged into this config, scoped to the subdirectory.
+    pub subprojects: Option<Vec<String>>,
 }
 
 impl std::fmt::Display for Config {
@@ -887,4 +1139,172 @@ struct PklImports {
 struct ImportAnalysis {
     local_paths: IndexSet<PathBuf>,
     has_untracked_imports: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hook::{Hook, StepOrGroup};
+    use crate::step::Step;
+    use crate::step_group::StepGroup;
+
+    fn step(name: &str) -> Step {
+        Step {
+            name: name.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn hook(name: &str) -> Hook {
+        Hook {
+            name: name.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn merge_subproject_scopes_flat_steps() {
+        let mut root = Config::default();
+        let mut sub = Config::default();
+        sub.env.insert("FOO".to_string(), "from-config".to_string());
+
+        let mut hook = hook("check");
+        let lint = Step {
+            depends: vec!["fmt".to_string(), "external".to_string()],
+            ..step("lint")
+        };
+        let mut fmt = Step {
+            dir: Some("nested".to_string()),
+            ..step("fmt")
+        };
+        fmt.env.insert("FOO".to_string(), "from-step".to_string());
+        hook.steps
+            .insert("lint".to_string(), StepOrGroup::Step(Box::new(lint)));
+        hook.steps
+            .insert("fmt".to_string(), StepOrGroup::Step(Box::new(fmt)));
+        sub.hooks.insert("check".to_string(), hook);
+
+        root.merge_subproject("packages/web", sub).unwrap();
+
+        let hook = root.hooks.get("check").unwrap();
+        let StepOrGroup::Step(lint) = hook.steps.get("packages/web:lint").unwrap() else {
+            panic!("expected step");
+        };
+        assert_eq!(lint.name, "packages/web:lint");
+        assert_eq!(lint.dir.as_deref(), Some("packages/web"));
+        // sibling references are rewritten; unknown names are left alone
+        assert_eq!(
+            lint.depends,
+            vec!["packages/web:fmt".to_string(), "external".to_string()]
+        );
+        assert_eq!(lint.env.get("FOO").map(String::as_str), Some("from-config"));
+
+        let StepOrGroup::Step(fmt) = hook.steps.get("packages/web:fmt").unwrap() else {
+            panic!("expected step");
+        };
+        assert_eq!(fmt.dir.as_deref(), Some("packages/web/nested"));
+        // step env wins over subproject config env
+        assert_eq!(fmt.env.get("FOO").map(String::as_str), Some("from-step"));
+    }
+
+    #[test]
+    fn merge_subproject_scopes_groups() {
+        let mut root = Config::default();
+        root.hooks.insert("check".to_string(), hook("check"));
+
+        let mut sub = Config::default();
+        let mut sub_hook = hook("check");
+        let mut group = StepGroup {
+            name: Some("build".to_string()),
+            dir: Some("ui".to_string()),
+            ..Default::default()
+        };
+        let ts = Step {
+            dir: Some("ui".to_string()), // as propagated by group.init
+            ..step("ts")
+        };
+        group.steps.insert("ts".to_string(), ts);
+        sub_hook
+            .steps
+            .insert("build".to_string(), StepOrGroup::Group(Box::new(group)));
+        sub.hooks.insert("check".to_string(), sub_hook);
+
+        root.merge_subproject("sub", sub).unwrap();
+
+        let hook = root.hooks.get("check").unwrap();
+        let StepOrGroup::Group(group) = hook.steps.get("sub:build").unwrap() else {
+            panic!("expected group");
+        };
+        assert_eq!(group.name.as_deref(), Some("sub:build"));
+        assert_eq!(group.dir.as_deref(), Some("sub/ui"));
+        let ts = group.steps.get("ts").unwrap();
+        // group child names are not prefixed; in-group depends still work
+        assert_eq!(ts.name, "ts");
+        assert_eq!(ts.dir.as_deref(), Some("sub/ui"));
+    }
+
+    #[test]
+    fn merge_subproject_duplicate_name_errors() {
+        let mut root = Config::default();
+        let mut root_hook = hook("check");
+        root_hook.steps.insert(
+            "sub:lint".to_string(),
+            StepOrGroup::Step(Box::new(step("sub:lint"))),
+        );
+        root.hooks.insert("check".to_string(), root_hook);
+
+        let mut sub = Config::default();
+        let mut sub_hook = hook("check");
+        sub_hook.steps.insert(
+            "lint".to_string(),
+            StepOrGroup::Step(Box::new(step("lint"))),
+        );
+        sub.hooks.insert("check".to_string(), sub_hook);
+
+        let err = root.merge_subproject("sub", sub).unwrap_err();
+        assert!(err.to_string().contains("duplicate step name 'sub:lint'"));
+    }
+
+    #[test]
+    fn join_subdir_handles_nested_and_empty() {
+        assert_eq!(Config::join_subdir("sub", None), "sub");
+        assert_eq!(Config::join_subdir("sub", Some("")), "sub");
+        assert_eq!(Config::join_subdir("sub", Some("ui")), "sub/ui");
+    }
+
+    #[test]
+    fn discover_subprojects_literal_and_glob() {
+        let base = std::env::temp_dir().join(format!(
+            "hk-test-discover-subprojects-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&base);
+        for dir in [
+            "sub",
+            "packages/a",
+            "packages/b",
+            "packages/.hidden",
+            "node_modules/pkg",
+        ] {
+            std::fs::create_dir_all(base.join(dir)).unwrap();
+        }
+        for config in [
+            "sub/hk.pkl",
+            "packages/a/hk.pkl",
+            "packages/.hidden/hk.pkl",
+            "node_modules/pkg/hk.pkl",
+        ] {
+            std::fs::write(base.join(config), "").unwrap();
+        }
+
+        let found =
+            Config::discover_subprojects(&base, &["sub".to_string(), "packages/*".to_string()])
+                .unwrap();
+        let dirs = found.iter().map(|(d, _)| d.as_str()).collect::<Vec<_>>();
+        // packages/b has no config, hidden dirs and node_modules are skipped
+        assert_eq!(dirs, vec!["sub", "packages/a"]);
+        assert_eq!(found[0].1, base.join("sub/hk.pkl"));
+
+        std::fs::remove_dir_all(&base).unwrap();
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod hook;
 mod hook_options;
 mod logger;
 mod merge;
+mod mise_env;
 mod plan;
 mod settings;
 mod step;

--- a/src/mise_env.rs
+++ b/src/mise_env.rs
@@ -1,0 +1,57 @@
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex};
+
+use crate::Result;
+
+/// Cache of `mise env` results, resolved at most once per directory per hk
+/// invocation. Keyed by the step's `dir` (relative to the repo root).
+static CACHE: LazyLock<Mutex<HashMap<PathBuf, Arc<tokio::sync::OnceCell<EnvMap>>>>> =
+    LazyLock::new(Default::default);
+
+type EnvMap = Arc<IndexMap<String, String>>;
+
+/// Resolve the mise environment for a directory by running `mise env --json`
+/// there. This picks up tools and env vars defined by that directory's mise
+/// config (e.g. a subproject's mise.toml in a monorepo), which the hk process
+/// itself doesn't have when it was started from the repo root.
+///
+/// Returns an empty map when mise is unavailable or fails; the error is logged
+/// once per directory.
+pub async fn mise_env_for_dir(dir: &Path) -> EnvMap {
+    let cell = CACHE
+        .lock()
+        .unwrap()
+        .entry(dir.to_path_buf())
+        .or_default()
+        .clone();
+    cell.get_or_init(|| async {
+        match fetch(dir).await {
+            Ok(env) => Arc::new(env),
+            Err(err) => {
+                warn!("mise env failed in {}: {err}", dir.display());
+                Default::default()
+            }
+        }
+    })
+    .await
+    .clone()
+}
+
+async fn fetch(dir: &Path) -> Result<IndexMap<String, String>> {
+    let output = tokio::process::Command::new("mise")
+        .args(["env", "--json"])
+        .current_dir(dir)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .await?;
+    if !output.status.success() {
+        eyre::bail!(
+            "mise env exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(serde_json::from_slice(&output.stdout)?)
+}

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -14,12 +14,12 @@ use crate::hook::SkipReason;
 use crate::step_context::StepContext;
 use crate::step_job::{StepJob, StepJobStatus};
 use crate::timings::StepTimingGuard;
-use crate::{Result, tera};
+use crate::{Result, env, tera};
 use clx::progress::ProgressStatus;
 use ensembler::CmdLineRunner;
 use eyre::WrapErr;
 use itertools::Itertools;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use super::expr_env::EXPR_ENV;
@@ -264,6 +264,16 @@ impl Step {
         }
         if let Some(dir) = &self.dir {
             cmd = cmd.current_dir(dir);
+            // With HK_MISE enabled, resolve the mise environment for the step's
+            // directory so tools/env from that directory's mise config (e.g. a
+            // subproject's mise.toml) are available even when hk was started
+            // from the repo root. Explicit step env still wins below.
+            if *env::HK_MISE {
+                let mise_env = crate::mise_env::mise_env_for_dir(Path::new(dir)).await;
+                for (key, value) in mise_env.iter() {
+                    cmd = cmd.env(key, value);
+                }
+            }
         }
         for (key, value) in &self.env {
             let value = tera::render(value, &tctx)?;

--- a/test/config_completeness.bats
+++ b/test/config_completeness.bats
@@ -11,8 +11,8 @@ teardown() {
 
 @test "Ensure settings.toml and Config.pkl match" {
     # Checks to see if the root properties in Config.pkl are all defined in settings.toml.
-    # Excludes: hooks, output, and min_hk_version
+    # Excludes structural config that isn't a setting: hooks, output, min_hk_version, and subprojects
     diff -u --label "settings.toml" --label "Config.pkl" \
         <(taplo get -f $PROJECT_ROOT/settings.toml -o json | jq -r 'to_entries | map(select(.value.sources | has("pkl"))) | .[].key' | sort)\
-        <(pkl eval $PKL_PATH/Config.pkl --format json -x "import (\"file:$PROJECT_ROOT/scripts/reflect.pkl\").render(module)" | jq -r '.moduleClass.properties | keys[] | select(. != "hooks" and . != "output" and . != "min_hk_version")' | sort)
+        <(pkl eval $PKL_PATH/Config.pkl --format json -x "import (\"file:$PROJECT_ROOT/scripts/reflect.pkl\").render(module)" | jq -r '.moduleClass.properties | keys[] | select(. != "hooks" and . != "output" and . != "min_hk_version" and . != "subprojects")' | sort)
 }

--- a/test/mise_env.bats
+++ b/test/mise_env.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+    if ! command -v mise >/dev/null 2>&1; then
+        skip "mise is not installed"
+    fi
+    # trust mise configs created inside the test repo
+    export MISE_TRUSTED_CONFIG_PATHS="$TEST_TEMP_DIR"
+}
+teardown() {
+    _common_teardown
+}
+
+@test "HK_MISE resolves mise env for the step dir" {
+    export HK_MISE=1
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["toolvar"] {
+                dir = "sub"
+                glob = "*.txt"
+                check = "echo TOOLVAR=\$TOOLVAR; exit 1"
+            }
+        }
+    }
+}
+EOF
+    mkdir -p sub
+    cat <<EOF > sub/mise.toml
+[env]
+TOOLVAR = "from-sub-mise"
+EOF
+    echo "content" > sub/file.txt
+    git add .
+    git commit -m "initial commit"
+
+    run hk check --all
+    assert_failure
+    assert_output --partial "TOOLVAR=from-sub-mise"
+}
+
+@test "mise env is not resolved without HK_MISE" {
+    unset HK_MISE
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["toolvar"] {
+                dir = "sub"
+                glob = "*.txt"
+                check = "echo TOOLVAR=\${TOOLVAR:-unset}; exit 1"
+            }
+        }
+    }
+}
+EOF
+    mkdir -p sub
+    cat <<EOF > sub/mise.toml
+[env]
+TOOLVAR = "from-sub-mise"
+EOF
+    echo "content" > sub/file.txt
+    git add .
+    git commit -m "initial commit"
+
+    run hk check --all
+    assert_failure
+    assert_output --partial "TOOLVAR=unset"
+}
+
+@test "step env wins over mise env" {
+    export HK_MISE=1
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["toolvar"] {
+                dir = "sub"
+                glob = "*.txt"
+                env {
+                    ["TOOLVAR"] = "from-step-env"
+                }
+                check = "echo TOOLVAR=\$TOOLVAR; exit 1"
+            }
+        }
+    }
+}
+EOF
+    mkdir -p sub
+    cat <<EOF > sub/mise.toml
+[env]
+TOOLVAR = "from-sub-mise"
+EOF
+    echo "content" > sub/file.txt
+    git add .
+    git commit -m "initial commit"
+
+    run hk check --all
+    assert_failure
+    assert_output --partial "TOOLVAR=from-step-env"
+}

--- a/test/subprojects.bats
+++ b/test/subprojects.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+teardown() {
+    _common_teardown
+}
+
+@test "subprojects merges nested configs scoped to their directory" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+subprojects = List("sub", "packages/*")
+hooks {
+    ["check"] {}
+}
+EOF
+    mkdir -p sub packages/a packages/b
+    cat <<EOF > sub/hk.pkl
+amends "$PKL_PATH/Config.pkl"
+env {
+    ["GREETING"] = "hello-from-sub"
+}
+hooks {
+    ["check"] {
+        steps {
+            ["greet"] {
+                glob = "*.txt"
+                check = "echo GREETING=\$GREETING; for f in {{files}}; do echo checked \$f; done; exit 1"
+            }
+        }
+    }
+}
+EOF
+    cat <<EOF > packages/a/hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["pkga"] {
+                glob = "*.txt"
+                check = "echo pkga saw {{files}}; exit 1"
+            }
+        }
+    }
+}
+EOF
+    echo "root" > root.txt
+    echo "sub" > sub/ok.txt
+    echo "a" > packages/a/a.txt
+    echo "b" > packages/b/b.txt
+    git add .
+    git commit -m "initial commit"
+
+    run hk check --all --no-fail-fast -v
+    assert_failure
+    # scoped step names
+    assert_output --partial "sub:greet"
+    assert_output --partial "packages/a:pkga"
+    # subproject env applies to its steps
+    assert_output --partial "GREETING=hello-from-sub"
+    # files are scoped to the subproject dir (and relative to it)
+    assert_output --partial "checked ok.txt"
+    assert_output --partial "pkga saw a.txt"
+    refute_output --partial "checked root.txt"
+    refute_output --partial "checked ../root.txt"
+}
+
+@test "subprojects glob skips directories without an hk config" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+subprojects = List("packages/*")
+hooks {
+    ["check"] {}
+}
+EOF
+    mkdir -p packages/a packages/b
+    cat <<EOF > packages/a/hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["ok"] {
+                glob = "*.txt"
+                check = "true"
+            }
+        }
+    }
+}
+EOF
+    echo "a" > packages/a/a.txt
+    echo "b" > packages/b/b.txt
+    git add .
+    git commit -m "initial commit"
+
+    run hk check --all
+    assert_success
+}
+
+@test "subprojects warns on missing literal directory" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+subprojects = List("does-not-exist")
+hooks {
+    ["check"] {}
+}
+EOF
+    git add hk.pkl
+    git commit -m "initial commit"
+
+    run hk check --all
+    assert_success
+    assert_output --partial "subprojects: directory not found: does-not-exist"
+}
+
+@test "subprojects work in git hooks from the repo root" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+subprojects = List("sub")
+hooks {
+    ["pre-commit"] {}
+}
+EOF
+    mkdir -p sub
+    cat <<EOF > sub/hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["no-todo"] {
+                glob = "*.txt"
+                check = "! grep -H TODO {{files}}"
+            }
+        }
+    }
+}
+EOF
+    git add .
+    git commit -m "initial commit"
+    hk install
+
+    echo "TODO fixme" > sub/bad.txt
+    git add sub/bad.txt
+    run git commit -m "should fail"
+    assert_failure
+    assert_output --partial "sub:no-todo"
+
+    echo "all good" > sub/bad.txt
+    git add sub/bad.txt
+    run git commit -m "should pass"
+    assert_success
+}


### PR DESCRIPTION
## Summary

Two features that together make hk work properly in monorepos (prompted by #1085):

1. **`subprojects`** — each subproject owns its own `hk.pkl` next to its code, merged into the root config scoped to its directory.
2. **Per-dir mise env** — with `HK_MISE=1`, steps with a `dir` get the mise environment of that directory, so subproject-local tools are on PATH. This fixes the actual bug reported in #1085.

```pkl
// hk.pkl (repo root)
subprojects = List("frontend", "packages/*")
hooks {
  ["check"] {}
  ["pre-commit"] { fix = true }
}
```

```pkl
// frontend/hk.pkl
hooks {
  ["check"] {
    steps { ["eslint"] = (Builtins.eslint) { batch = true } }
  }
}
```

## `subprojects` semantics

- Entries are literal directories or globs (`packages/*`). Glob matches without an hk config file are skipped; literal entries warn when missing.
- Each subproject's hooks are merged into the root config, scoped to its directory:
  - Step working directories and glob matching are relative to the subdirectory (reusing the existing `dir` machinery), so `frontend/hk.pkl` only sees files under `frontend/`.
  - Flat step names are prefixed with `<dir>:` (e.g. `packages/web:eslint`) — that's the name for `--step`/`skip_steps`. `depends` references between a subproject's own steps/groups are rewritten to the scoped names; group-internal names are untouched so in-group `depends` keep working.
  - The subproject's `env` applies to its own steps only (step env > subproject hook env > subproject config env) and is not exported to the hk process.
  - Hooks that only exist in a subproject are created on the root config.
- Subproject configs go through the same per-file cache as the root config, but always with path-keyed cache files so they don't thrash the shared `resolved-config.json` slot.
- One level of nesting: a nested `subprojects` field is ignored with a warning.
- Discovery walks only as deep as the glob patterns require (capped at 32 for `**`), skipping hidden dirs, `node_modules`, and symlinks.

## Per-dir mise env semantics

- Gated on the existing `HK_MISE=1` opt-in.
- When a step has a `dir`, hk runs `mise env --json` in that directory and applies the result to the step's commands. Resolved at most once per directory per run (`tokio OnceCell` keyed cache), concurrent steps share the same resolution.
- Explicit step `env` always wins over mise-provided values.
- If mise is missing or errors, the step runs with the inherited env and a warning is logged once per directory.
- Works with structured argv commands too (unlike the `prefix = "mise x --"` workaround, which is rejected for argv commands and pays mise startup per invocation).

## Review feedback addressed

- **Cursor**: `.config/hk.pkl` root configs now resolve subprojects from the project root, not `.config/` (new `project_root_of` helper + unit test)
- **Greptile P1**: `depends` rewriting now includes group siblings, not just flat steps
- **Greptile P2**: `**` glob discovery capped at depth 32 instead of unbounded

## Testing

- 6 Rust unit tests for merge/scoping/discovery/root-resolution logic
- `test/subprojects.bats` (4 tests: dir scoping, env, glob discovery, missing-dir warning, real `git commit` through an installed pre-commit hook)
- `test/mise_env.bats` (3 tests: mise env resolved for step dir, not resolved without HK_MISE, step env precedence)
- `test/config_completeness.bats` updated to treat `subprojects` as structural config (like `hooks`)
- Full `cargo test` passes; `config_*`, `dir*`, `cache_behavior` bats suites pass (`dir.bats` fails in my sandbox for a pre-existing reason: no prettier shim — fails identically on the base commit)

## Follow-ups (not in this PR)

- Auto-derive `subprojects` from mise monorepo `config_roots` when present
- Parallelism across subproject groups (groups currently run sequentially, matching existing Group semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core config loading and step execution env; mistakes could mis-scope hooks or leak/wrong env vars, but behavior is gated and covered by integration tests.
> 
> **Overview**
> Adds **`subprojects`** so the root `hk.pkl` can list literal paths or globs (e.g. `packages/*`); hk discovers nested hk configs, merges their hooks into the root run, and scopes each step to that directory with **`dir:step`** names, rewritten sibling **`depends`**, and subproject **`env`** kept on those steps only (not exported to the hk process). Subproject loads use path-keyed config cache; nested **`subprojects`** are ignored with a warning.
> 
> With **`HK_MISE=1`**, steps that set **`dir`** now get **`mise env --json`** for that directory (cached once per dir per run) before step **`env`** is applied, so monorepo tool paths and vars work when hk is started from the repo root.
> 
> Docs and **`Config.pkl`** describe both features; bats and Rust unit tests cover merge/discovery, mise precedence, and hook integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e530839d48b6f267f494134f9f32df31db49cc63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->