### PR TITLE
chore(deps): remove unused typescript and dead typescript-eslint

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ docs/.vitepress
 test/bats
 test/data
 test/test_helper
+
+**/aube-lock.yaml

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -150,6 +150,24 @@ packages:
       search-insights:
         optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.21.5':
     resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
@@ -214,6 +232,22 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
@@ -528,6 +562,11 @@ packages:
 
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -979,6 +1018,15 @@ snapshots:
       '@docsearch/css': 3.8.2
       algoliasearch: 5.56.0
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
@@ -1035,6 +1083,15 @@ snapshots:
   '@iconify/types@2.0.0': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
@@ -1287,6 +1344,9 @@ snapshots:
 
   esbuild@0.21.5:
     optionalDependencies:
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
       '@esbuild/linux-x64': 0.21.5
 
   escape-string-regexp@4.0.0: {}
@@ -1382,6 +1442,9 @@ snapshots:
   focus-trap@7.8.0:
     dependencies:
       tabbable: 6.5.0
+
+  fsevents@2.3.3:
+    optional: true
 
   glob-parent@6.0.2:
     dependencies:
@@ -1554,7 +1617,11 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
     optionalDependencies:
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
       '@rollup/rollup-linux-x64-gnu': 4.62.2
+      fsevents: 2.3.3
 
   search-insights@2.17.3: {}
 
@@ -1640,6 +1707,8 @@ snapshots:
       esbuild: 0.21.5
       postcss: 8.5.20
       rollup: 4.62.2
+    optionalDependencies:
+      fsevents: 2.3.3
 
   vitepress@1.6.4(postcss@8.5.20):
     dependencies:

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -4,12 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-time:
-  eslint@10.7.0: 2026-07-10T21:22:48.956Z
-  globals@17.7.0: 2026-06-22T17:20:20.100Z
-  postcss@8.5.20: 2026-07-19T08:44:44.719Z
-  vitepress@1.6.4: 2025-08-05T13:40:31.197Z
-
 importers:
 
   .:
@@ -159,10 +153,8 @@ packages:
   '@esbuild/linux-x64@0.21.5':
     resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -225,12 +217,9 @@ packages:
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
-    os:
-    - linux
-    cpu:
-    - x64
-    libc:
-    - glibc
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
@@ -436,6 +425,8 @@ packages:
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
@@ -970,20 +961,26 @@ snapshots:
 
   '@docsearch/css@3.8.2': {}
 
-  '@docsearch/js@3.8.2(search-insights@2.17.3)':
+  '@docsearch/js@3.8.2':
     dependencies:
-      '@docsearch/react': 3.8.2(search-insights@2.17.3)
+      '@docsearch/react': 3.8.2
       preact: 10.29.7
+    transitivePeerDependencies:
+      - '@types/react'
+      - preact-render-to-string
+      - react
+      - react-dom
+      - search-insights
 
-  '@docsearch/react@3.8.2(search-insights@2.17.3)':
+  '@docsearch/react@3.8.2':
     dependencies:
       '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
       '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
       '@docsearch/css': 3.8.2
       algoliasearch: 5.56.0
-      search-insights: 2.17.3
 
-  '@esbuild/linux-x64@0.21.5': {}
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.7.0)':
     dependencies:
@@ -997,6 +994,8 @@ snapshots:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3
       minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@eslint/config-helpers@0.6.0':
     dependencies:
@@ -1037,7 +1036,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@rollup/rollup-linux-x64-gnu@4.62.2': {}
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
 
   '@shikijs/core@2.5.0':
     dependencies:
@@ -1191,6 +1191,8 @@ snapshots:
       '@vueuse/metadata': 12.8.2
       '@vueuse/shared': 12.8.2
       vue: 3.5.40
+    transitivePeerDependencies:
+      - typescript
 
   '@vueuse/integrations@12.8.2(focus-trap@7.8.0)':
     dependencies:
@@ -1198,12 +1200,16 @@ snapshots:
       '@vueuse/shared': 12.8.2
       focus-trap: 7.8.0
       vue: 3.5.40
+    transitivePeerDependencies:
+      - typescript
 
   '@vueuse/metadata@12.8.2': {}
 
   '@vueuse/shared@12.8.2':
     dependencies:
       vue: 3.5.40
+    transitivePeerDependencies:
+      - typescript
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -1314,7 +1320,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
-      espree: 11.2.0(acorn@8.17.0)
+      espree: 11.2.0
       esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -1328,8 +1334,10 @@ snapshots:
       minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
 
-  espree@11.2.0(acorn@8.17.0):
+  espree@11.2.0:
     dependencies:
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
@@ -1636,7 +1644,7 @@ snapshots:
   vitepress@1.6.4(postcss@8.5.20):
     dependencies:
       '@docsearch/css': 3.8.2
-      '@docsearch/js': 3.8.2(search-insights@2.17.3)
+      '@docsearch/js': 3.8.2
       '@iconify-json/simple-icons': 1.2.91
       '@shikijs/core': 2.5.0
       '@shikijs/transformers': 2.5.0
@@ -1654,6 +1662,32 @@ snapshots:
       shiki: 2.5.0
       vite: 5.4.21
       vue: 3.5.40
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@types/react'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - fuse.js
+      - idb-keyval
+      - jwt-decode
+      - less
+      - lightningcss
+      - nprogress
+      - preact-render-to-string
+      - qrcode
+      - react
+      - react-dom
+      - sass
+      - sass-embedded
+      - search-insights
+      - sortablejs
+      - stylus
+      - sugarss
+      - terser
+      - typescript
+      - universal-cookie
 
   vue@3.5.40:
     dependencies:

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -1,352 +1,153 @@
-lockfileVersion: "9.0"
+lockfileVersion: '9.0'
+
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+
 time:
-  "@algolia/abtesting@1.16.2": 2026-04-14T16:35:13.229Z
-  "@algolia/autocomplete-core@1.17.7": 2024-11-05T15:07:05.611Z
-  "@algolia/autocomplete-plugin-algolia-insights@1.17.7": 2024-11-05T15:07:23.472Z
-  "@algolia/autocomplete-preset-algolia@1.17.7": 2024-11-05T15:08:03.592Z
-  "@algolia/autocomplete-shared@1.17.7": 2024-11-05T15:08:10.663Z
-  "@algolia/client-abtesting@5.50.2": 2026-04-14T16:35:13.673Z
-  "@algolia/client-analytics@5.50.2": 2026-04-14T16:35:13.103Z
-  "@algolia/client-common@5.50.2": 2026-04-14T16:35:05.733Z
-  "@algolia/client-insights@5.50.2": 2026-04-14T16:35:16.104Z
-  "@algolia/client-personalization@5.50.2": 2026-04-14T16:35:17.331Z
-  "@algolia/client-query-suggestions@5.50.2": 2026-04-14T16:35:17.616Z
-  "@algolia/client-search@5.50.2": 2026-04-14T16:35:18.082Z
-  "@algolia/ingestion@1.50.2": 2026-04-14T16:35:21.912Z
-  "@algolia/monitoring@1.50.2": 2026-04-14T16:35:22.250Z
-  "@algolia/recommend@5.50.2": 2026-04-14T16:35:22.424Z
-  "@algolia/requester-browser-xhr@5.50.2": 2026-04-14T16:35:08.842Z
-  "@algolia/requester-fetch@5.50.2": 2026-04-14T16:35:09.130Z
-  "@algolia/requester-node-http@5.50.2": 2026-04-14T16:35:09.050Z
-  "@babel/helper-string-parser@7.27.1": 2025-04-30T15:08:26.501Z
-  "@babel/helper-validator-identifier@7.28.5": 2025-10-23T15:17:38.203Z
-  "@babel/parser@7.29.2": 2026-03-16T22:33:19.657Z
-  "@babel/types@7.29.0": 2026-01-31T17:39:13.578Z
-  "@docsearch/css@3.8.2": 2024-12-17T15:34:33.806Z
-  "@docsearch/js@3.8.2": 2024-12-17T15:34:38.867Z
-  "@docsearch/react@3.8.2": 2024-12-17T15:34:36.229Z
-  "@esbuild/darwin-arm64@0.21.5": 2024-06-09T21:17:13.758Z
-  "@esbuild/darwin-x64@0.21.5": 2024-06-09T21:17:00.976Z
-  "@esbuild/linux-arm64@0.21.5": 2024-06-09T21:17:23.384Z
-  "@esbuild/linux-x64@0.21.5": 2024-06-09T21:17:15.111Z
-  "@eslint-community/eslint-utils@4.9.1": 2025-12-31T14:49:52.066Z
-  "@eslint-community/regexpp@4.12.2": 2025-10-22T11:56:00.818Z
-  "@eslint/config-array@0.23.5": 2026-04-08T09:22:37.796Z
-  "@eslint/config-helpers@0.5.5": 2026-04-08T09:22:40.626Z
-  "@eslint/core@1.2.1": 2026-04-08T09:22:28.287Z
-  "@eslint/object-schema@3.0.5": 2026-04-08T09:22:34.549Z
-  "@eslint/plugin-kit@0.7.1": 2026-04-08T09:22:43.810Z
-  "@humanfs/core@0.19.2": 2026-04-17T20:51:11.882Z
-  "@humanfs/node@0.16.8": 2026-04-17T20:51:26.959Z
-  "@humanfs/types@0.15.0": 2024-09-09T19:44:08.000Z
-  "@humanwhocodes/module-importer@1.0.1": 2022-08-18T17:55:51.038Z
-  "@humanwhocodes/retry@0.4.3": 2025-05-07T14:25:57.372Z
-  "@iconify-json/simple-icons@1.2.78": 2026-04-13T04:57:35.352Z
-  "@iconify/types@2.0.0": 2022-09-08T06:23:03.369Z
-  "@jridgewell/sourcemap-codec@1.5.5": 2025-08-12T06:43:59.139Z
-  "@rollup/rollup-darwin-arm64@4.60.2": 2026-04-18T13:58:27.555Z
-  "@rollup/rollup-darwin-x64@4.60.2": 2026-04-18T13:59:28.701Z
-  "@rollup/rollup-linux-arm64-gnu@4.60.2": 2026-04-18T13:58:41.555Z
-  "@rollup/rollup-linux-arm64-musl@4.60.2": 2026-04-18T13:58:45.162Z
-  "@rollup/rollup-linux-x64-gnu@4.60.2": 2026-04-18T13:59:43.183Z
-  "@rollup/rollup-linux-x64-musl@4.60.2": 2026-04-18T13:59:46.857Z
-  "@shikijs/core@2.5.0": 2025-02-18T09:10:12.142Z
-  "@shikijs/engine-javascript@2.5.0": 2025-02-18T09:09:26.369Z
-  "@shikijs/engine-oniguruma@2.5.0": 2025-02-18T09:09:33.593Z
-  "@shikijs/langs@2.5.0": 2025-02-18T09:09:39.465Z
-  "@shikijs/themes@2.5.0": 2025-02-18T09:10:04.997Z
-  "@shikijs/transformers@2.5.0": 2025-02-18T09:10:36.901Z
-  "@shikijs/types@2.5.0": 2025-02-18T09:09:20.251Z
-  "@shikijs/vscode-textmate@10.0.2": 2025-02-15T16:46:32.096Z
-  "@types/esrecurse@4.3.1": 2025-07-19T03:47:09.775Z
-  "@types/estree@1.0.8": 2025-06-06T00:04:34.692Z
-  "@types/hast@3.0.4": 2024-01-30T22:06:19.288Z
-  "@types/json-schema@7.0.15": 2023-11-07T08:49:23.527Z
-  "@types/linkify-it@5.0.0": 2024-05-01T18:07:46.092Z
-  "@types/markdown-it@14.1.2": 2024-07-25T05:07:30.523Z
-  "@types/mdast@4.0.4": 2024-05-14T07:35:37.616Z
-  "@types/mdurl@2.0.0": 2024-05-01T18:08:10.612Z
-  "@types/unist@3.0.3": 2024-08-15T02:19:16.553Z
-  "@types/web-bluetooth@0.0.21": 2025-02-28T23:32:05.029Z
-  "@typescript-eslint/eslint-plugin@8.58.2": 2026-04-13T17:24:54.947Z
-  "@typescript-eslint/parser@8.58.2": 2026-04-13T17:24:34.854Z
-  "@typescript-eslint/project-service@8.58.2": 2026-04-13T17:24:09.647Z
-  "@typescript-eslint/scope-manager@8.58.2": 2026-04-13T17:24:26.877Z
-  "@typescript-eslint/tsconfig-utils@8.58.2": 2026-04-13T17:24:02.619Z
-  "@typescript-eslint/type-utils@8.58.2": 2026-04-13T17:24:42.060Z
-  "@typescript-eslint/types@8.58.2": 2026-04-13T17:24:03.218Z
-  "@typescript-eslint/typescript-estree@8.58.2": 2026-04-13T17:24:18.409Z
-  "@typescript-eslint/utils@8.58.2": 2026-04-13T17:24:34.297Z
-  "@typescript-eslint/visitor-keys@8.58.2": 2026-04-13T17:24:10.068Z
-  "@ungap/structured-clone@1.3.0": 2025-01-23T14:13:01.275Z
-  "@vitejs/plugin-vue@5.2.4": 2025-05-09T09:47:50.969Z
-  "@vue/compiler-core@3.5.32": 2026-04-03T05:41:04.047Z
-  "@vue/compiler-dom@3.5.32": 2026-04-03T05:41:07.863Z
-  "@vue/compiler-sfc@3.5.32": 2026-04-03T05:41:12.043Z
-  "@vue/compiler-ssr@3.5.32": 2026-04-03T05:41:16.007Z
-  "@vue/devtools-api@7.7.9": 2025-11-17T14:28:13.410Z
-  "@vue/devtools-kit@7.7.9": 2025-11-17T14:28:05.469Z
-  "@vue/devtools-shared@7.7.9": 2025-11-17T14:28:02.466Z
-  "@vue/reactivity@3.5.32": 2026-04-03T05:41:19.887Z
-  "@vue/runtime-core@3.5.32": 2026-04-03T05:41:24.116Z
-  "@vue/runtime-dom@3.5.32": 2026-04-03T05:41:27.865Z
-  "@vue/server-renderer@3.5.32": 2026-04-03T05:41:31.772Z
-  "@vue/shared@3.5.32": 2026-04-03T05:41:35.866Z
-  "@vueuse/core@12.8.2": 2025-03-05T11:39:34.178Z
-  "@vueuse/integrations@12.8.2": 2025-03-05T11:41:34.399Z
-  "@vueuse/metadata@12.8.2": 2025-03-05T11:39:15.362Z
-  "@vueuse/shared@12.8.2": 2025-03-05T11:39:22.947Z
-  acorn-jsx@5.3.2: 2021-07-09T01:15:57.512Z
-  acorn@8.16.0: 2026-02-19T15:06:28.070Z
-  ajv@6.14.0: 2026-02-20T18:09:33.622Z
-  algoliasearch@5.50.2: 2026-04-14T16:35:28.490Z
-  balanced-match@4.0.4: 2026-02-22T11:38:25.951Z
-  birpc@2.9.0: 2025-12-03T06:40:16.657Z
-  brace-expansion@5.0.5: 2026-03-24T17:58:07.554Z
-  ccount@2.0.1: 2021-10-28T09:38:13.774Z
-  character-entities-html4@2.1.0: 2021-10-29T14:28:35.375Z
-  character-entities-legacy@3.0.0: 2021-10-29T12:50:20.435Z
-  comma-separated-tokens@2.0.3: 2022-11-14T09:09:04.761Z
-  copy-anything@4.0.5: 2025-03-24T18:18:23.270Z
-  cross-spawn@7.0.6: 2024-11-18T13:59:52.129Z
-  csstype@3.2.3: 2025-11-17T11:42:27.045Z
-  debug@4.4.3: 2025-09-13T17:25:19.732Z
-  deep-is@0.1.4: 2021-09-04T16:55:20.731Z
-  dequal@2.0.3: 2022-07-11T23:29:04.965Z
-  devlop@1.1.0: 2023-06-29T15:17:11.346Z
-  emoji-regex-xs@1.0.0: 2024-06-28T16:22:28.678Z
-  entities@7.0.1: 2026-01-21T13:46:30.165Z
-  esbuild@0.21.5: 2024-06-09T21:17:41.628Z
-  escape-string-regexp@4.0.0: 2020-04-23T07:31:25.491Z
-  eslint-scope@9.1.2: 2026-03-06T22:32:49.946Z
-  eslint-visitor-keys@3.4.3: 2023-08-11T14:49:54.383Z
-  eslint-visitor-keys@5.0.1: 2026-02-20T14:40:47.824Z
-  eslint@10.2.1: 2026-04-17T20:17:44.852Z
-  espree@11.2.0: 2026-03-06T22:32:40.951Z
-  esquery@1.7.0: 2025-12-31T15:44:57.664Z
-  esrecurse@4.3.0: 2020-08-31T18:21:44.794Z
-  estraverse@5.3.0: 2021-10-25T12:18:17.722Z
-  estree-walker@2.0.2: 2020-12-08T17:07:42.670Z
-  esutils@2.0.3: 2019-07-31T01:10:54.228Z
-  fast-deep-equal@3.1.3: 2020-06-08T07:27:28.474Z
-  fast-json-stable-stringify@2.1.0: 2019-12-14T16:17:57.583Z
-  fast-levenshtein@2.0.6: 2016-12-27T21:15:07.820Z
-  fdir@6.5.0: 2025-08-14T16:56:03.948Z
-  file-entry-cache@8.0.0: 2023-12-18T19:33:58.734Z
-  find-up@5.0.0: 2020-08-11T18:44:24.748Z
-  flat-cache@4.0.1: 2024-03-02T16:09:41.118Z
-  flatted@3.4.2: 2026-03-17T15:03:56.392Z
-  focus-trap@7.8.0: 2026-01-10T22:24:14.284Z
-  fsevents@2.3.3: 2023-08-21T16:24:22.854Z
-  glob-parent@6.0.2: 2021-09-29T22:14:24.467Z
-  globals@17.5.0: 2026-04-12T05:40:14.299Z
-  hast-util-to-html@9.0.5: 2025-02-19T13:34:47.133Z
-  hast-util-whitespace@3.0.0: 2023-07-31T15:52:12.042Z
-  hookable@5.5.3: 2023-03-30T13:33:47.930Z
-  html-void-elements@3.0.0: 2023-05-19T10:17:19.335Z
-  ignore@5.3.2: 2024-08-12T08:51:00.065Z
-  ignore@7.0.5: 2025-05-31T02:18:53.410Z
-  imurmurhash@0.1.4: 2013-08-24T20:45:23.169Z
-  is-extglob@2.1.1: 2016-12-11T04:04:24.390Z
-  is-glob@4.0.3: 2021-09-29T16:52:47.977Z
-  is-what@5.5.0: 2025-09-22T17:10:23.658Z
-  isexe@2.0.0: 2017-03-23T00:53:16.356Z
-  json-buffer@3.0.1: 2018-09-10T19:02:16.381Z
-  json-schema-traverse@0.4.1: 2018-06-10T08:42:05.056Z
-  json-stable-stringify-without-jsonify@1.0.1: 2016-12-15T22:00:35.805Z
-  keyv@4.5.4: 2023-10-07T16:53:54.487Z
-  levn@0.4.1: 2020-04-04T02:05:31.527Z
-  locate-path@6.0.0: 2020-08-10T17:49:10.766Z
-  magic-string@0.30.21: 2025-10-24T00:59:47.122Z
-  mark.js@8.11.1: 2018-01-11T22:55:52.210Z
-  mdast-util-to-hast@13.2.1: 2025-11-23T21:08:34.155Z
-  micromark-util-character@2.1.1: 2024-11-12T11:17:13.750Z
-  micromark-util-encode@2.0.1: 2024-11-12T11:17:34.206Z
-  micromark-util-sanitize-uri@2.0.1: 2024-11-12T11:17:48.745Z
-  micromark-util-symbol@2.0.1: 2024-11-12T11:17:55.709Z
-  micromark-util-types@2.0.2: 2025-02-27T13:55:27.982Z
-  minimatch@10.2.5: 2026-03-30T18:08:07.247Z
-  minisearch@7.2.0: 2025-09-16T12:42:12.453Z
-  mitt@3.0.1: 2023-07-04T17:31:47.638Z
-  ms@2.1.3: 2020-12-08T13:54:35.223Z
-  nanoid@3.3.11: 2025-03-18T23:06:32.923Z
-  natural-compare@1.4.0: 2016-07-22T20:48:12.217Z
-  oniguruma-to-es@3.1.1: 2025-02-20T16:19:37.749Z
-  optionator@0.9.4: 2024-04-26T22:17:51.408Z
-  p-limit@3.1.0: 2020-11-25T07:42:37.364Z
-  p-locate@5.0.0: 2020-08-10T17:42:34.692Z
-  path-exists@4.0.0: 2019-04-04T03:29:16.887Z
-  path-key@3.1.1: 2019-11-22T16:47:18.153Z
-  perfect-debounce@1.0.0: 2023-05-03T23:17:12.783Z
-  picocolors@1.1.1: 2024-10-16T18:20:03.921Z
-  picomatch@4.0.4: 2026-03-23T20:39:47.960Z
-  postcss@8.5.10: 2026-04-15T14:42:53.378Z
-  preact@10.29.1: 2026-04-03T10:43:57.080Z
-  prelude-ls@1.2.1: 2020-04-02T22:53:40.710Z
-  property-information@7.1.0: 2025-05-08T07:00:48.463Z
-  punycode@2.3.1: 2023-10-30T18:28:32.512Z
-  regex-recursion@6.0.2: 2025-02-01T00:57:00.191Z
-  regex-utilities@2.3.0: 2024-08-31T18:40:34.903Z
-  regex@6.1.0: 2025-12-09T01:33:47.153Z
-  rfdc@1.4.1: 2024-06-12T10:18:29.594Z
-  rollup@4.60.2: 2026-04-18T13:59:58.613Z
-  search-insights@2.17.3: 2024-11-18T02:06:21.689Z
-  semver@7.7.4: 2026-02-05T17:23:11.131Z
-  shebang-command@2.0.0: 2019-09-06T14:53:25.901Z
-  shebang-regex@3.0.0: 2019-04-27T10:46:19.256Z
-  shiki@2.5.0: 2025-02-18T09:10:30.900Z
-  source-map-js@1.2.1: 2024-09-08T16:22:55.645Z
-  space-separated-tokens@2.0.2: 2022-11-14T08:54:14.011Z
-  speakingurl@14.0.1: 2017-08-23T06:43:02.759Z
-  stringify-entities@4.0.4: 2024-04-03T13:04:46.263Z
-  superjson@2.2.6: 2025-11-27T13:27:45.738Z
-  tabbable@6.4.0: 2025-12-31T17:29:46.264Z
-  tinyglobby@0.2.16: 2026-04-07T23:37:03.457Z
-  trim-lines@3.0.1: 2022-07-03T12:54:20.493Z
-  ts-api-utils@2.5.0: 2026-03-19T02:50:49.789Z
-  type-check@0.4.0: 2020-04-03T03:02:37.249Z
-  typescript-eslint@8.58.2: 2026-04-13T17:25:02.436Z
-  typescript@6.0.3: 2026-04-16T23:38:27.905Z
-  unist-util-is@6.0.1: 2025-10-16T18:01:47.398Z
-  unist-util-position@5.0.0: 2023-07-07T09:59:34.316Z
-  unist-util-stringify-position@4.0.0: 2023-07-07T10:09:26.763Z
-  unist-util-visit-parents@6.0.2: 2025-10-16T18:20:45.045Z
-  unist-util-visit@5.1.0: 2026-01-22T19:02:58.977Z
-  uri-js@4.4.1: 2021-01-10T00:43:12.666Z
-  vfile-message@4.0.3: 2025-07-26T15:08:12.656Z
-  vfile@6.0.3: 2024-08-27T09:12:42.377Z
-  vite@5.4.21: 2025-10-20T05:32:04.015Z
+  eslint@10.7.0: 2026-07-10T21:22:48.956Z
+  globals@17.7.0: 2026-06-22T17:20:20.100Z
+  postcss@8.5.20: 2026-07-19T08:44:44.719Z
   vitepress@1.6.4: 2025-08-05T13:40:31.197Z
-  vue@3.5.32: 2026-04-03T05:41:39.680Z
-  which@2.0.2: 2019-11-18T22:26:15.325Z
-  word-wrap@1.2.5: 2023-07-22T14:37:38.795Z
-  yocto-queue@0.1.0: 2020-11-24T06:05:35.875Z
-  zwitch@2.0.4: 2022-11-16T09:09:14.038Z
+
 importers:
+
   .:
     dependencies:
-      acorn:
-        specifier: ^6.0.0 || ^7.0.0 || ^8.0.0
-        version: 8.16.0
       eslint:
         specifier: ^10.0.0
-        version: 10.2.1
-      typescript:
-        specifier: ^6.0.0
-        version: 6.0.3
+        version: 10.7.0
     devDependencies:
       globals:
         specifier: ^17.0.0
-        version: 17.5.0
+        version: 17.7.0
+
   docs:
     dependencies:
       eslint:
         specifier: ^10.0.0
-        version: 10.2.1
+        version: 10.7.0
+      postcss:
+        specifier: ^8
+        version: 8.5.20
       vitepress:
         specifier: ^1.6.3
-        version: 1.6.4(postcss@8.5.10)
+        version: 1.6.4(postcss@8.5.20)
     devDependencies:
       globals:
         specifier: ^17.0.0
-        version: 17.5.0
-      typescript-eslint:
-        specifier: ^8.24.1
-        version: 8.58.2(eslint@10.2.1)(typescript@6.0.3)
+        version: 17.7.0
+
 packages:
-  "@algolia/abtesting@1.16.2":
-    resolution:
-      integrity: sha512-n9s6bEV6imdtIEd+BGP7WkA4pEZ5YTdgQ05JQhHwWawHg3hyjpNwC0TShGz6zWhv+jfLDGA/6FFNbySFS0P9cw==
-  "@algolia/autocomplete-core@1.17.7":
-    resolution:
-      integrity: sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==
-  "@algolia/autocomplete-plugin-algolia-insights@1.17.7":
-    resolution:
-      integrity: sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==
+
+  '@algolia/abtesting@1.22.0':
+    resolution: {integrity: sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/autocomplete-core@1.17.7':
+    resolution: {integrity: sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==}
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7':
+    resolution: {integrity: sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==}
     peerDependencies:
-      search-insights: ">= 1 < 3"
-  "@algolia/autocomplete-preset-algolia@1.17.7":
-    resolution:
-      integrity: sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==
+      search-insights: '>= 1 < 3'
+
+  '@algolia/autocomplete-preset-algolia@1.17.7':
+    resolution: {integrity: sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==}
     peerDependencies:
-      "@algolia/client-search": ">= 4.9.1 < 6"
-      algoliasearch: ">= 4.9.1 < 6"
-  "@algolia/autocomplete-shared@1.17.7":
-    resolution:
-      integrity: sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+
+  '@algolia/autocomplete-shared@1.17.7':
+    resolution: {integrity: sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==}
     peerDependencies:
-      "@algolia/client-search": ">= 4.9.1 < 6"
-      algoliasearch: ">= 4.9.1 < 6"
-  "@algolia/client-abtesting@5.50.2":
-    resolution:
-      integrity: sha512-52iq0vHy1sphgnwoZyx5PmbEt8hsh+m7jD123LmBs6qy4GK7LbYZIeKd+nSnSipN2zvKRZ2zScS6h9PW3J7SXg==
-  "@algolia/client-analytics@5.50.2":
-    resolution:
-      integrity: sha512-WpPIUg+cSG2aPUG0gS8Ko9DwRgbRPUZxJkolhL2aCsmSlcEEZT65dILrfg5ovcxtx0Kvr+xtBVsTMtsQWRtPDQ==
-  "@algolia/client-common@5.50.2":
-    resolution:
-      integrity: sha512-Gj2MgtArGcsr82kIqRlo6/dCAFjrs2gLByEqyRENuT7ugrSMFuqg1vDzeBjRL1t3EJEJCFtT0PLX3gB8A6Hq4Q==
-  "@algolia/client-insights@5.50.2":
-    resolution:
-      integrity: sha512-CUqoid5jDpmrc0oK3/xuZXFt6kwT0P9Lw7/nsM14YTr6puvmi+OUKmURpmebQF22S2vCG8L1DAoXXujxQUi/ug==
-  "@algolia/client-personalization@5.50.2":
-    resolution:
-      integrity: sha512-AndZWFoc0gbP5901OeQJ73BazgGgSGiBEba4ohdoJuZwHTO2Gio8Q4L1VLmytMBYcviVigB0iICToMvEJxI4ug==
-  "@algolia/client-query-suggestions@5.50.2":
-    resolution:
-      integrity: sha512-NWoL+psEkz5dIzweaByVXuEB45wS8/rk0E0AhMMnaVJdVs7TcACPH2/OURm+N0xRDITkTHqCna823rd6Uqntdg==
-  "@algolia/client-search@5.50.2":
-    resolution:
-      integrity: sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==
-  "@algolia/ingestion@1.50.2":
-    resolution:
-      integrity: sha512-VlR2FRXLw2bCB94SQo6zxg/Qi+547aOji6Pb+dKE7h1DMCCY317St+OpjpmgzE+bT2O9ALIc0V4nVIBOd7Gy+Q==
-  "@algolia/monitoring@1.50.2":
-    resolution:
-      integrity: sha512-Cmvfp2+qopzQt8OilU97rhLhosq7ZrB6uieok3EwFUqG/aalPg6DgfCmu0yJMrYe+KMC1qRVt1MTRAUwLknUMQ==
-  "@algolia/recommend@5.50.2":
-    resolution:
-      integrity: sha512-jrkuyKoOM7dFWQ/6Y4hQAse2SC3L/RldG6GnPjMvAj65h+7Ubb51S0pKk4ofSStF0xm4LCNe0C4T6XX4nOFDiQ==
-  "@algolia/requester-browser-xhr@5.50.2":
-    resolution:
-      integrity: sha512-4107YLJqCudPiBUlwnk6oTSUVwU7ab+qL1SfQGEDYI8DZH5gsf1ekPt9JykXRKYXf2IfouFL5GiCY/PHTFIjYw==
-  "@algolia/requester-fetch@5.50.2":
-    resolution:
-      integrity: sha512-vOrd3MQpLgmf6wXAueTuZ/cA0W4uRwIHHaxNy3h+a6YcNn6bCV/gFdZuv3F13v593zRU2k5R75NmvRWLenvMrw==
-  "@algolia/requester-node-http@5.50.2":
-    resolution:
-      integrity: sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==
-  "@babel/helper-string-parser@7.27.1":
-    resolution:
-      integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
-  "@babel/helper-validator-identifier@7.28.5":
-    resolution:
-      integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
-  "@babel/parser@7.29.2":
-    resolution:
-      integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==
-  "@babel/types@7.29.0":
-    resolution:
-      integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
-  "@docsearch/css@3.8.2":
-    resolution:
-      integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==
-  "@docsearch/js@3.8.2":
-    resolution:
-      integrity: sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==
-  "@docsearch/react@3.8.2":
-    resolution:
-      integrity: sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+
+  '@algolia/client-abtesting@5.56.0':
+    resolution: {integrity: sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-analytics@5.56.0':
+    resolution: {integrity: sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-common@5.56.0':
+    resolution: {integrity: sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-insights@5.56.0':
+    resolution: {integrity: sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-personalization@5.56.0':
+    resolution: {integrity: sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-query-suggestions@5.56.0':
+    resolution: {integrity: sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-search@5.56.0':
+    resolution: {integrity: sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/ingestion@1.56.0':
+    resolution: {integrity: sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/monitoring@1.56.0':
+    resolution: {integrity: sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/recommend@5.56.0':
+    resolution: {integrity: sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-browser-xhr@5.56.0':
+    resolution: {integrity: sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-fetch@5.56.0':
+    resolution: {integrity: sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-node-http@5.56.0':
+    resolution: {integrity: sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==}
+    engines: {node: '>= 14.0.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@docsearch/css@3.8.2':
+    resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
+
+  '@docsearch/js@3.8.2':
+    resolution: {integrity: sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==}
+
+  '@docsearch/react@3.8.2':
+    resolution: {integrity: sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==}
     peerDependencies:
-      "@types/react": ">= 16.8.0 < 19.0.0"
-      react: ">= 16.8.0 < 19.0.0"
-      react-dom: ">= 16.8.0 < 19.0.0"
-      search-insights: ">= 1 < 3"
+      '@types/react': '>= 16.8.0 < 19.0.0'
+      react: '>= 16.8.0 < 19.0.0'
+      react-dom: '>= 16.8.0 < 19.0.0'
+      search-insights: '>= 1 < 3'
     peerDependenciesMeta:
-      "@types/react":
+      '@types/react':
         optional: true
       react:
         optional: true
@@ -354,287 +155,188 @@ packages:
         optional: true
       search-insights:
         optional: true
-  "@esbuild/darwin-arm64@0.21.5":
-    resolution:
-      integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
     os:
-      - darwin
+    - linux
     cpu:
-      - arm64
-  "@esbuild/darwin-x64@0.21.5":
-    resolution:
-      integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
-    os:
-      - darwin
-    cpu:
-      - x64
-  "@esbuild/linux-arm64@0.21.5":
-    resolution:
-      integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
-    os:
-      - linux
-    cpu:
-      - arm64
-  "@esbuild/linux-x64@0.21.5":
-    resolution:
-      integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
-    os:
-      - linux
-    cpu:
-      - x64
-  "@eslint-community/eslint-utils@4.9.1":
-    resolution:
-      integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
+    - x64
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  "@eslint-community/regexpp@4.12.2":
-    resolution:
-      integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
-  "@eslint/config-array@0.23.5":
-    resolution:
-      integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==
-  "@eslint/config-helpers@0.5.5":
-    resolution:
-      integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==
-  "@eslint/core@1.2.1":
-    resolution:
-      integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==
-  "@eslint/object-schema@3.0.5":
-    resolution:
-      integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==
-  "@eslint/plugin-kit@0.7.1":
-    resolution:
-      integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==
-  "@humanfs/core@0.19.2":
-    resolution:
-      integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==
-  "@humanfs/node@0.16.8":
-    resolution:
-      integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==
-  "@humanfs/types@0.15.0":
-    resolution:
-      integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==
-  "@humanwhocodes/module-importer@1.0.1":
-    resolution:
-      integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
-  "@humanwhocodes/retry@0.4.3":
-    resolution:
-      integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
-  "@iconify-json/simple-icons@1.2.78":
-    resolution:
-      integrity: sha512-I3lkNp0Qu7q2iZWkdcf/I2hqGhzK6qxdILh9T7XqowQrnpmG/BayDsiCf6PktDoWlW0U971xA5g+panm+NFrfQ==
-  "@iconify/types@2.0.0":
-    resolution:
-      integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
-  "@jridgewell/sourcemap-codec@1.5.5":
-    resolution:
-      integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
-  "@rollup/rollup-darwin-arm64@4.60.2":
-    resolution:
-      integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@iconify-json/simple-icons@1.2.91':
+    resolution: {integrity: sha512-plQJHZxzpkIXaeYjJF0Sc9nkzYF32EDX9olx7j1hcKYFaiTrQXbcngZmvzuV0pG6uZPU3ZuA/GIsgxSHOm6jrQ==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     os:
-      - darwin
+    - linux
     cpu:
-      - arm64
-  "@rollup/rollup-darwin-x64@4.60.2":
-    resolution:
-      integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==
-    os:
-      - darwin
-    cpu:
-      - x64
-  "@rollup/rollup-linux-arm64-gnu@4.60.2":
-    resolution:
-      integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==
-    os:
-      - linux
-    cpu:
-      - arm64
+    - x64
     libc:
-      - glibc
-  "@rollup/rollup-linux-arm64-musl@4.60.2":
-    resolution:
-      integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==
-    os:
-      - linux
-    cpu:
-      - arm64
-    libc:
-      - musl
-  "@rollup/rollup-linux-x64-gnu@4.60.2":
-    resolution:
-      integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==
-    os:
-      - linux
-    cpu:
-      - x64
-    libc:
-      - glibc
-  "@rollup/rollup-linux-x64-musl@4.60.2":
-    resolution:
-      integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==
-    os:
-      - linux
-    cpu:
-      - x64
-    libc:
-      - musl
-  "@shikijs/core@2.5.0":
-    resolution:
-      integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==
-  "@shikijs/engine-javascript@2.5.0":
-    resolution:
-      integrity: sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==
-  "@shikijs/engine-oniguruma@2.5.0":
-    resolution:
-      integrity: sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==
-  "@shikijs/langs@2.5.0":
-    resolution:
-      integrity: sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==
-  "@shikijs/themes@2.5.0":
-    resolution:
-      integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==
-  "@shikijs/transformers@2.5.0":
-    resolution:
-      integrity: sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==
-  "@shikijs/types@2.5.0":
-    resolution:
-      integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==
-  "@shikijs/vscode-textmate@10.0.2":
-    resolution:
-      integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==
-  "@types/esrecurse@4.3.1":
-    resolution:
-      integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==
-  "@types/estree@1.0.8":
-    resolution:
-      integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
-  "@types/hast@3.0.4":
-    resolution:
-      integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
-  "@types/json-schema@7.0.15":
-    resolution:
-      integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
-  "@types/linkify-it@5.0.0":
-    resolution:
-      integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==
-  "@types/markdown-it@14.1.2":
-    resolution:
-      integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==
-  "@types/mdast@4.0.4":
-    resolution:
-      integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
-  "@types/mdurl@2.0.0":
-    resolution:
-      integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
-  "@types/unist@3.0.3":
-    resolution:
-      integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
-  "@types/web-bluetooth@0.0.21":
-    resolution:
-      integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==
-  "@typescript-eslint/eslint-plugin@8.58.2":
-    resolution:
-      integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==
-    peerDependencies:
-      "@typescript-eslint/parser": ^8.58.2
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/parser@8.58.2":
-    resolution:
-      integrity: sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/project-service@8.58.2":
-    resolution:
-      integrity: sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/scope-manager@8.58.2":
-    resolution:
-      integrity: sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==
-  "@typescript-eslint/tsconfig-utils@8.58.2":
-    resolution:
-      integrity: sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/type-utils@8.58.2":
-    resolution:
-      integrity: sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/types@8.58.2":
-    resolution:
-      integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==
-  "@typescript-eslint/typescript-estree@8.58.2":
-    resolution:
-      integrity: sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/utils@8.58.2":
-    resolution:
-      integrity: sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/visitor-keys@8.58.2":
-    resolution:
-      integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==
-  "@ungap/structured-clone@1.3.0":
-    resolution:
-      integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
-  "@vitejs/plugin-vue@5.2.4":
-    resolution:
-      integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==
+    - glibc
+
+  '@shikijs/core@2.5.0':
+    resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
+
+  '@shikijs/engine-javascript@2.5.0':
+    resolution: {integrity: sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==}
+
+  '@shikijs/engine-oniguruma@2.5.0':
+    resolution: {integrity: sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==}
+
+  '@shikijs/langs@2.5.0':
+    resolution: {integrity: sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==}
+
+  '@shikijs/themes@2.5.0':
+    resolution: {integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==}
+
+  '@shikijs/transformers@2.5.0':
+    resolution: {integrity: sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==}
+
+  '@shikijs/types@2.5.0':
+    resolution: {integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
-  "@vue/compiler-core@3.5.32":
-    resolution:
-      integrity: sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==
-  "@vue/compiler-dom@3.5.32":
-    resolution:
-      integrity: sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==
-  "@vue/compiler-sfc@3.5.32":
-    resolution:
-      integrity: sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==
-  "@vue/compiler-ssr@3.5.32":
-    resolution:
-      integrity: sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==
-  "@vue/devtools-api@7.7.9":
-    resolution:
-      integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==
-  "@vue/devtools-kit@7.7.9":
-    resolution:
-      integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==
-  "@vue/devtools-shared@7.7.9":
-    resolution:
-      integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==
-  "@vue/reactivity@3.5.32":
-    resolution:
-      integrity: sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==
-  "@vue/runtime-core@3.5.32":
-    resolution:
-      integrity: sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==
-  "@vue/runtime-dom@3.5.32":
-    resolution:
-      integrity: sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==
-  "@vue/server-renderer@3.5.32":
-    resolution:
-      integrity: sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==
-    peerDependencies:
-      vue: 3.5.32
-  "@vue/shared@3.5.32":
-    resolution:
-      integrity: sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==
-  "@vueuse/core@12.8.2":
-    resolution:
-      integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==
-  "@vueuse/integrations@12.8.2":
-    resolution:
-      integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==
+
+  '@vue/compiler-core@3.5.40':
+    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
+
+  '@vue/compiler-dom@3.5.40':
+    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
+
+  '@vue/compiler-sfc@3.5.40':
+    resolution: {integrity: sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==}
+
+  '@vue/compiler-ssr@3.5.40':
+    resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
+
+  '@vue/devtools-api@7.7.10':
+    resolution: {integrity: sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==}
+
+  '@vue/devtools-kit@7.7.10':
+    resolution: {integrity: sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==}
+
+  '@vue/devtools-shared@7.7.10':
+    resolution: {integrity: sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==}
+
+  '@vue/reactivity@3.5.40':
+    resolution: {integrity: sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==}
+
+  '@vue/runtime-core@3.5.40':
+    resolution: {integrity: sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==}
+
+  '@vue/runtime-dom@3.5.40':
+    resolution: {integrity: sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==}
+
+  '@vue/server-renderer@3.5.40':
+    resolution: {integrity: sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==}
+
+  '@vue/shared@3.5.40':
+    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
+
+  '@vueuse/core@12.8.2':
+    resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
+
+  '@vueuse/integrations@12.8.2':
+    resolution: {integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==}
     peerDependencies:
       async-validator: ^4
       axios: ^1
@@ -673,405 +375,427 @@ packages:
         optional: true
       universal-cookie:
         optional: true
-  "@vueuse/metadata@12.8.2":
-    resolution:
-      integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==
-  "@vueuse/shared@12.8.2":
-    resolution:
-      integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==
+
+  '@vueuse/metadata@12.8.2':
+    resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
+
+  '@vueuse/shared@12.8.2':
+    resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
+
   acorn-jsx@5.3.2:
-    resolution:
-      integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-  acorn@8.16.0:
-    resolution:
-      integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
-  ajv@6.14.0:
-    resolution:
-      integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==
-  algoliasearch@5.50.2:
-    resolution:
-      integrity: sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  algoliasearch@5.56.0:
+    resolution: {integrity: sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==}
+    engines: {node: '>= 14.0.0'}
+
   balanced-match@4.0.4:
-    resolution:
-      integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   birpc@2.9.0:
-    resolution:
-      integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==
-  brace-expansion@5.0.5:
-    resolution:
-      integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+    resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
+
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
+
   ccount@2.0.1:
-    resolution:
-      integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   character-entities-html4@2.1.0:
-    resolution:
-      integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
   character-entities-legacy@3.0.0:
-    resolution:
-      integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
   comma-separated-tokens@2.0.3:
-    resolution:
-      integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
   copy-anything@4.0.5:
-    resolution:
-      integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==
+    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
-    resolution:
-      integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   csstype@3.2.3:
-    resolution:
-      integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   debug@4.4.3:
-    resolution:
-      integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
     peerDependenciesMeta:
       supports-color:
         optional: true
+
   deep-is@0.1.4:
-    resolution:
-      integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   dequal@2.0.3:
-    resolution:
-      integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   devlop@1.1.0:
-    resolution:
-      integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
   emoji-regex-xs@1.0.0:
-    resolution:
-      integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
   entities@7.0.1:
-    resolution:
-      integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   esbuild@0.21.5:
-    resolution:
-      integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   escape-string-regexp@4.0.0:
-    resolution:
-      integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
   eslint-scope@9.1.2:
-    resolution:
-      integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint-visitor-keys@3.4.3:
-    resolution:
-      integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   eslint-visitor-keys@5.0.1:
-    resolution:
-      integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
-  eslint@10.2.1:
-    resolution:
-      integrity: sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.7.0:
+    resolution: {integrity: sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
     peerDependencies:
-      jiti: "*"
+      jiti: '*'
     peerDependenciesMeta:
       jiti:
         optional: true
+
   espree@11.2.0:
-    resolution:
-      integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   esquery@1.7.0:
-    resolution:
-      integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
   esrecurse@4.3.0:
-    resolution:
-      integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
   estraverse@5.3.0:
-    resolution:
-      integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@2.0.2:
-    resolution:
-      integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   esutils@2.0.3:
-    resolution:
-      integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
   fast-deep-equal@3.1.3:
-    resolution:
-      integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-json-stable-stringify@2.1.0:
-    resolution:
-      integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
   fast-levenshtein@2.0.6:
-    resolution:
-      integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
-  fdir@6.5.0:
-    resolution:
-      integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   file-entry-cache@8.0.0:
-    resolution:
-      integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   find-up@5.0.0:
-    resolution:
-      integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   flat-cache@4.0.1:
-    resolution:
-      integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
   flatted@3.4.2:
-    resolution:
-      integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
   focus-trap@7.8.0:
-    resolution:
-      integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==
-  fsevents@2.3.3:
-    resolution:
-      integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-    os:
-      - darwin
+    resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+
   glob-parent@6.0.2:
-    resolution:
-      integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
-  globals@17.5.0:
-    resolution:
-      integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@17.7.0:
+    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
+    engines: {node: '>=18'}
+
   hast-util-to-html@9.0.5:
-    resolution:
-      integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-whitespace@3.0.0:
-    resolution:
-      integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hookable@5.5.3:
-    resolution:
-      integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
   html-void-elements@3.0.0:
-    resolution:
-      integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
   ignore@5.3.2:
-    resolution:
-      integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
-  ignore@7.0.5:
-    resolution:
-      integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
   imurmurhash@0.1.4:
-    resolution:
-      integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   is-extglob@2.1.1:
-    resolution:
-      integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-glob@4.0.3:
-    resolution:
-      integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
   is-what@5.5.0:
-    resolution:
-      integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
+
   isexe@2.0.0:
-    resolution:
-      integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   json-buffer@3.0.1:
-    resolution:
-      integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
   json-schema-traverse@0.4.1:
-    resolution:
-      integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
   json-stable-stringify-without-jsonify@1.0.1:
-    resolution:
-      integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
   keyv@4.5.4:
-    resolution:
-      integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   levn@0.4.1:
-    resolution:
-      integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
   locate-path@6.0.0:
-    resolution:
-      integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   magic-string@0.30.21:
-    resolution:
-      integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   mark.js@8.11.1:
-    resolution:
-      integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==
+    resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
+
   mdast-util-to-hast@13.2.1:
-    resolution:
-      integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
   micromark-util-character@2.1.1:
-    resolution:
-      integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
   micromark-util-encode@2.0.1:
-    resolution:
-      integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
   micromark-util-sanitize-uri@2.0.1:
-    resolution:
-      integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
   micromark-util-symbol@2.0.1:
-    resolution:
-      integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
   micromark-util-types@2.0.2:
-    resolution:
-      integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
   minimatch@10.2.5:
-    resolution:
-      integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minisearch@7.2.0:
-    resolution:
-      integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
+
   mitt@3.0.1:
-    resolution:
-      integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   ms@2.1.3:
-    resolution:
-      integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-  nanoid@3.3.11:
-    resolution:
-      integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
-    resolution:
-      integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   oniguruma-to-es@3.1.1:
-    resolution:
-      integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==
+    resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
+
   optionator@0.9.4:
-    resolution:
-      integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
   p-limit@3.1.0:
-    resolution:
-      integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
   p-locate@5.0.0:
-    resolution:
-      integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
   path-exists@4.0.0:
-    resolution:
-      integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
   path-key@3.1.1:
-    resolution:
-      integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   perfect-debounce@1.0.0:
-    resolution:
-      integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
   picocolors@1.1.1:
-    resolution:
-      integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
-  picomatch@4.0.4:
-    resolution:
-      integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
-  postcss@8.5.10:
-    resolution:
-      integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
-  preact@10.29.1:
-    resolution:
-      integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.20:
+    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  preact@10.29.7:
+    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
   prelude-ls@1.2.1:
-    resolution:
-      integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
-  property-information@7.1.0:
-    resolution:
-      integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   punycode@2.3.1:
-    resolution:
-      integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   regex-recursion@6.0.2:
-    resolution:
-      integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
   regex-utilities@2.3.0:
-    resolution:
-      integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
   regex@6.1.0:
-    resolution:
-      integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   rfdc@1.4.1:
-    resolution:
-      integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
-  rollup@4.60.2:
-    resolution:
-      integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   search-insights@2.17.3:
-    resolution:
-      integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==
-  semver@7.7.4:
-    resolution:
-      integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+    resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
+
   shebang-command@2.0.0:
-    resolution:
-      integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
   shebang-regex@3.0.0:
-    resolution:
-      integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   shiki@2.5.0:
-    resolution:
-      integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==
+    resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
+
   source-map-js@1.2.1:
-    resolution:
-      integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   space-separated-tokens@2.0.2:
-    resolution:
-      integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   speakingurl@14.0.1:
-    resolution:
-      integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==
+    resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
+    engines: {node: '>=0.10.0'}
+
   stringify-entities@4.0.4:
-    resolution:
-      integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   superjson@2.2.6:
-    resolution:
-      integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==
-  tabbable@6.4.0:
-    resolution:
-      integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==
-  tinyglobby@0.2.16:
-    resolution:
-      integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
+
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
+
   trim-lines@3.0.1:
-    resolution:
-      integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
-  ts-api-utils@2.5.0:
-    resolution:
-      integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
-    peerDependencies:
-      typescript: ">=4.8.4"
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   type-check@0.4.0:
-    resolution:
-      integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
-  typescript-eslint@8.58.2:
-    resolution:
-      integrity: sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-  typescript@6.0.3:
-    resolution:
-      integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   unist-util-is@6.0.1:
-    resolution:
-      integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
   unist-util-position@5.0.0:
-    resolution:
-      integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
   unist-util-stringify-position@4.0.0:
-    resolution:
-      integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
   unist-util-visit-parents@6.0.2:
-    resolution:
-      integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
   unist-util-visit@5.1.0:
-    resolution:
-      integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   uri-js@4.4.1:
-    resolution:
-      integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
   vfile-message@4.0.3:
-    resolution:
-      integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
   vfile@6.0.3:
-    resolution:
-      integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
   vite@5.4.21:
-    resolution:
-      integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
     peerDependencies:
-      "@types/node": ^18.0.0 || >=20.0.0
-      less: "*"
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
       lightningcss: ^1.21.0
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
       terser: ^5.4.0
     peerDependenciesMeta:
-      "@types/node":
+      '@types/node':
         optional: true
       less:
         optional: true
@@ -1087,9 +811,10 @@ packages:
         optional: true
       terser:
         optional: true
+
   vitepress@1.6.4:
-    resolution:
-      integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==
+    resolution: {integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==}
+    hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
       postcss: ^8
@@ -1098,469 +823,498 @@ packages:
         optional: true
       postcss:
         optional: true
-  vue@3.5.32:
-    resolution:
-      integrity: sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==
+
+  vue@3.5.40:
+    resolution: {integrity: sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==}
     peerDependencies:
-      typescript: "*"
+      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
+
   which@2.0.2:
-    resolution:
-      integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   word-wrap@1.2.5:
-    resolution:
-      integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   yocto-queue@0.1.0:
-    resolution:
-      integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
   zwitch@2.0.4:
-    resolution:
-      integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
-  "@algolia/abtesting@1.16.2":
+
+  '@algolia/abtesting@1.22.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/autocomplete-core@1.17.7":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/autocomplete-core@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)':
     dependencies:
-      "@algolia/autocomplete-plugin-algolia-insights": 1.17.7(search-insights@2.17.3)
-      "@algolia/autocomplete-shared": 1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)
-  "@algolia/autocomplete-plugin-algolia-insights@1.17.7(search-insights@2.17.3)":
+      '@algolia/autocomplete-plugin-algolia-insights': 1.17.7(search-insights@2.17.3)
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7(search-insights@2.17.3)':
     dependencies:
-      "@algolia/autocomplete-shared": 1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
       search-insights: 2.17.3
-  "@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)":
+
+  '@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)':
     dependencies:
-      "@algolia/autocomplete-shared": 1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)
-      "@algolia/client-search": 5.50.2
-      algoliasearch: 5.50.2
-  "@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)":
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
+      '@algolia/client-search': 5.56.0
+      algoliasearch: 5.56.0
+
+  '@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)':
     dependencies:
-      "@algolia/client-search": 5.50.2
-      algoliasearch: 5.50.2
-  "@algolia/client-abtesting@5.50.2":
+      '@algolia/client-search': 5.56.0
+      algoliasearch: 5.56.0
+
+  '@algolia/client-abtesting@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/client-analytics@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-analytics@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/client-common@5.50.2": {}
-  "@algolia/client-insights@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-common@5.56.0': {}
+
+  '@algolia/client-insights@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/client-personalization@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-personalization@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/client-query-suggestions@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-query-suggestions@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/client-search@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-search@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/ingestion@1.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/ingestion@1.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/monitoring@1.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/monitoring@1.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/recommend@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/recommend@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/requester-browser-xhr@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/requester-browser-xhr@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-  "@algolia/requester-fetch@5.50.2":
+      '@algolia/client-common': 5.56.0
+
+  '@algolia/requester-fetch@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-  "@algolia/requester-node-http@5.50.2":
+      '@algolia/client-common': 5.56.0
+
+  '@algolia/requester-node-http@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-  "@babel/helper-string-parser@7.27.1": {}
-  "@babel/helper-validator-identifier@7.28.5": {}
-  "@babel/parser@7.29.2":
+      '@algolia/client-common': 5.56.0
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
     dependencies:
-      "@babel/types": 7.29.0
-  "@babel/types@7.29.0":
+      '@babel/types': 7.29.7
+
+  '@babel/types@7.29.7':
     dependencies:
-      "@babel/helper-string-parser": 7.27.1
-      "@babel/helper-validator-identifier": 7.28.5
-  "@docsearch/css@3.8.2": {}
-  "@docsearch/js@3.8.2":
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@docsearch/css@3.8.2': {}
+
+  '@docsearch/js@3.8.2(search-insights@2.17.3)':
     dependencies:
-      "@docsearch/react": 3.8.2(search-insights@2.17.3)
-      preact: 10.29.1
-  "@docsearch/react@3.8.2(search-insights@2.17.3)":
+      '@docsearch/react': 3.8.2(search-insights@2.17.3)
+      preact: 10.29.7
+
+  '@docsearch/react@3.8.2(search-insights@2.17.3)':
     dependencies:
-      "@algolia/autocomplete-core": 1.17.7
-      "@algolia/autocomplete-preset-algolia": 1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)
-      "@docsearch/css": 3.8.2
-      algoliasearch: 5.50.2
+      '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
+      '@docsearch/css': 3.8.2
+      algoliasearch: 5.56.0
       search-insights: 2.17.3
-  "@esbuild/darwin-arm64@0.21.5": {}
-  "@esbuild/darwin-x64@0.21.5": {}
-  "@esbuild/linux-arm64@0.21.5": {}
-  "@esbuild/linux-x64@0.21.5": {}
-  "@eslint-community/eslint-utils@4.9.1(eslint@10.2.1)":
+
+  '@esbuild/linux-x64@0.21.5': {}
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.7.0)':
     dependencies:
-      eslint: 10.2.1
+      eslint: 10.7.0
       eslint-visitor-keys: 3.4.3
-  "@eslint-community/regexpp@4.12.2": {}
-  "@eslint/config-array@0.23.5":
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
     dependencies:
-      "@eslint/object-schema": 3.0.5
+      '@eslint/object-schema': 3.0.5
       debug: 4.4.3
       minimatch: 10.2.5
-  "@eslint/config-helpers@0.5.5":
+
+  '@eslint/config-helpers@0.6.0':
     dependencies:
-      "@eslint/core": 1.2.1
-  "@eslint/core@1.2.1":
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
     dependencies:
-      "@types/json-schema": 7.0.15
-  "@eslint/object-schema@3.0.5": {}
-  "@eslint/plugin-kit@0.7.1":
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
     dependencies:
-      "@eslint/core": 1.2.1
+      '@eslint/core': 1.2.1
       levn: 0.4.1
-  "@humanfs/core@0.19.2":
+
+  '@humanfs/core@0.19.2':
     dependencies:
-      "@humanfs/types": 0.15.0
-  "@humanfs/node@0.16.8":
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
     dependencies:
-      "@humanfs/core": 0.19.2
-      "@humanfs/types": 0.15.0
-      "@humanwhocodes/retry": 0.4.3
-  "@humanfs/types@0.15.0": {}
-  "@humanwhocodes/module-importer@1.0.1": {}
-  "@humanwhocodes/retry@0.4.3": {}
-  "@iconify-json/simple-icons@1.2.78":
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify-json/simple-icons@1.2.91':
     dependencies:
-      "@iconify/types": 2.0.0
-  "@iconify/types@2.0.0": {}
-  "@jridgewell/sourcemap-codec@1.5.5": {}
-  "@rollup/rollup-darwin-arm64@4.60.2": {}
-  "@rollup/rollup-darwin-x64@4.60.2": {}
-  "@rollup/rollup-linux-arm64-gnu@4.60.2": {}
-  "@rollup/rollup-linux-arm64-musl@4.60.2": {}
-  "@rollup/rollup-linux-x64-gnu@4.60.2": {}
-  "@rollup/rollup-linux-x64-musl@4.60.2": {}
-  "@shikijs/core@2.5.0":
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2': {}
+
+  '@shikijs/core@2.5.0':
     dependencies:
-      "@shikijs/engine-javascript": 2.5.0
-      "@shikijs/engine-oniguruma": 2.5.0
-      "@shikijs/types": 2.5.0
-      "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
       hast-util-to-html: 9.0.5
-  "@shikijs/engine-javascript@2.5.0":
+
+  '@shikijs/engine-javascript@2.5.0':
     dependencies:
-      "@shikijs/types": 2.5.0
-      "@shikijs/vscode-textmate": 10.0.2
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 3.1.1
-  "@shikijs/engine-oniguruma@2.5.0":
+
+  '@shikijs/engine-oniguruma@2.5.0':
     dependencies:
-      "@shikijs/types": 2.5.0
-      "@shikijs/vscode-textmate": 10.0.2
-  "@shikijs/langs@2.5.0":
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@2.5.0':
     dependencies:
-      "@shikijs/types": 2.5.0
-  "@shikijs/themes@2.5.0":
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/themes@2.5.0':
     dependencies:
-      "@shikijs/types": 2.5.0
-  "@shikijs/transformers@2.5.0":
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/transformers@2.5.0':
     dependencies:
-      "@shikijs/core": 2.5.0
-      "@shikijs/types": 2.5.0
-  "@shikijs/types@2.5.0":
+      '@shikijs/core': 2.5.0
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/types@2.5.0':
     dependencies:
-      "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
-  "@shikijs/vscode-textmate@10.0.2": {}
-  "@types/esrecurse@4.3.1": {}
-  "@types/estree@1.0.8": {}
-  "@types/hast@3.0.4":
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@types/esrecurse@4.3.1': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/hast@3.0.5':
     dependencies:
-      "@types/unist": 3.0.3
-  "@types/json-schema@7.0.15": {}
-  "@types/linkify-it@5.0.0": {}
-  "@types/markdown-it@14.1.2":
+      '@types/unist': 3.0.3
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
     dependencies:
-      "@types/linkify-it": 5.0.0
-      "@types/mdurl": 2.0.0
-  "@types/mdast@4.0.4":
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdast@4.0.4':
     dependencies:
-      "@types/unist": 3.0.3
-  "@types/mdurl@2.0.0": {}
-  "@types/unist@3.0.3": {}
-  "@types/web-bluetooth@0.0.21": {}
-  "@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3)":
-    dependencies:
-      "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      "@typescript-eslint/scope-manager": 8.58.2
-      "@typescript-eslint/type-utils": 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      "@typescript-eslint/visitor-keys": 8.58.2
-      eslint: 10.2.1
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-  "@typescript-eslint/parser@8.58.2(eslint@10.2.1)(typescript@6.0.3)":
-    dependencies:
-      "@typescript-eslint/scope-manager": 8.58.2
-      "@typescript-eslint/types": 8.58.2
-      "@typescript-eslint/typescript-estree": 8.58.2(typescript@6.0.3)
-      "@typescript-eslint/visitor-keys": 8.58.2
-      debug: 4.4.3
-      eslint: 10.2.1
-      typescript: 6.0.3
-  "@typescript-eslint/project-service@8.58.2(typescript@6.0.3)":
-    dependencies:
-      "@typescript-eslint/tsconfig-utils": 8.58.2(typescript@6.0.3)
-      "@typescript-eslint/types": 8.58.2
-      debug: 4.4.3
-      typescript: 6.0.3
-  "@typescript-eslint/scope-manager@8.58.2":
-    dependencies:
-      "@typescript-eslint/types": 8.58.2
-      "@typescript-eslint/visitor-keys": 8.58.2
-  "@typescript-eslint/tsconfig-utils@8.58.2(typescript@6.0.3)":
-    dependencies:
-      typescript: 6.0.3
-  "@typescript-eslint/type-utils@8.58.2(eslint@10.2.1)(typescript@6.0.3)":
-    dependencies:
-      "@typescript-eslint/types": 8.58.2
-      "@typescript-eslint/typescript-estree": 8.58.2(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      debug: 4.4.3
-      eslint: 10.2.1
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-  "@typescript-eslint/types@8.58.2": {}
-  "@typescript-eslint/typescript-estree@8.58.2(typescript@6.0.3)":
-    dependencies:
-      "@typescript-eslint/project-service": 8.58.2(typescript@6.0.3)
-      "@typescript-eslint/tsconfig-utils": 8.58.2(typescript@6.0.3)
-      "@typescript-eslint/types": 8.58.2
-      "@typescript-eslint/visitor-keys": 8.58.2
-      debug: 4.4.3
-      minimatch: 10.2.5
-      semver: 7.7.4
-      tinyglobby: 0.2.16
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-  "@typescript-eslint/utils@8.58.2(eslint@10.2.1)(typescript@6.0.3)":
-    dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@10.2.1)
-      "@typescript-eslint/scope-manager": 8.58.2
-      "@typescript-eslint/types": 8.58.2
-      "@typescript-eslint/typescript-estree": 8.58.2(typescript@6.0.3)
-      eslint: 10.2.1
-      typescript: 6.0.3
-  "@typescript-eslint/visitor-keys@8.58.2":
-    dependencies:
-      "@typescript-eslint/types": 8.58.2
-      eslint-visitor-keys: 5.0.1
-  "@ungap/structured-clone@1.3.0": {}
-  "@vitejs/plugin-vue@5.2.4(vite@5.4.21)(vue@3.5.32(typescript@6.0.3))":
+      '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@types/web-bluetooth@0.0.21': {}
+
+  '@ungap/structured-clone@1.3.3': {}
+
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21)(vue@3.5.40)':
     dependencies:
       vite: 5.4.21
-      vue: 3.5.32(typescript@6.0.3)
-  "@vue/compiler-core@3.5.32":
+      vue: 3.5.40
+
+  '@vue/compiler-core@3.5.40':
     dependencies:
-      "@babel/parser": 7.29.2
-      "@vue/shared": 3.5.32
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.40
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
-  "@vue/compiler-dom@3.5.32":
+
+  '@vue/compiler-dom@3.5.40':
     dependencies:
-      "@vue/compiler-core": 3.5.32
-      "@vue/shared": 3.5.32
-  "@vue/compiler-sfc@3.5.32":
+      '@vue/compiler-core': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/compiler-sfc@3.5.40':
     dependencies:
-      "@babel/parser": 7.29.2
-      "@vue/compiler-core": 3.5.32
-      "@vue/compiler-dom": 3.5.32
-      "@vue/compiler-ssr": 3.5.32
-      "@vue/shared": 3.5.32
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.40
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/shared': 3.5.40
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.10
+      postcss: 8.5.20
       source-map-js: 1.2.1
-  "@vue/compiler-ssr@3.5.32":
+
+  '@vue/compiler-ssr@3.5.40':
     dependencies:
-      "@vue/compiler-dom": 3.5.32
-      "@vue/shared": 3.5.32
-  "@vue/devtools-api@7.7.9":
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/devtools-api@7.7.10':
     dependencies:
-      "@vue/devtools-kit": 7.7.9
-  "@vue/devtools-kit@7.7.9":
+      '@vue/devtools-kit': 7.7.10
+
+  '@vue/devtools-kit@7.7.10':
     dependencies:
-      "@vue/devtools-shared": 7.7.9
+      '@vue/devtools-shared': 7.7.10
       birpc: 2.9.0
       hookable: 5.5.3
       mitt: 3.0.1
       perfect-debounce: 1.0.0
       speakingurl: 14.0.1
       superjson: 2.2.6
-  "@vue/devtools-shared@7.7.9":
+
+  '@vue/devtools-shared@7.7.10':
     dependencies:
       rfdc: 1.4.1
-  "@vue/reactivity@3.5.32":
+
+  '@vue/reactivity@3.5.40':
     dependencies:
-      "@vue/shared": 3.5.32
-  "@vue/runtime-core@3.5.32":
+      '@vue/shared': 3.5.40
+
+  '@vue/runtime-core@3.5.40':
     dependencies:
-      "@vue/reactivity": 3.5.32
-      "@vue/shared": 3.5.32
-  "@vue/runtime-dom@3.5.32":
+      '@vue/reactivity': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/runtime-dom@3.5.40':
     dependencies:
-      "@vue/reactivity": 3.5.32
-      "@vue/runtime-core": 3.5.32
-      "@vue/shared": 3.5.32
+      '@vue/reactivity': 3.5.40
+      '@vue/runtime-core': 3.5.40
+      '@vue/shared': 3.5.40
       csstype: 3.2.3
-  "@vue/server-renderer@3.5.32(vue@3.5.32(typescript@6.0.3))":
+
+  '@vue/server-renderer@3.5.40':
     dependencies:
-      "@vue/compiler-ssr": 3.5.32
-      "@vue/shared": 3.5.32
-      vue: 3.5.32(typescript@6.0.3)
-  "@vue/shared@3.5.32": {}
-  "@vueuse/core@12.8.2":
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/runtime-dom': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/shared@3.5.40': {}
+
+  '@vueuse/core@12.8.2':
     dependencies:
-      "@types/web-bluetooth": 0.0.21
-      "@vueuse/metadata": 12.8.2
-      "@vueuse/shared": 12.8.2
-      vue: 3.5.32(typescript@6.0.3)
-  "@vueuse/integrations@12.8.2(focus-trap@7.8.0)":
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 12.8.2
+      '@vueuse/shared': 12.8.2
+      vue: 3.5.40
+
+  '@vueuse/integrations@12.8.2(focus-trap@7.8.0)':
     dependencies:
-      "@vueuse/core": 12.8.2
-      "@vueuse/shared": 12.8.2
+      '@vueuse/core': 12.8.2
+      '@vueuse/shared': 12.8.2
       focus-trap: 7.8.0
-      vue: 3.5.32(typescript@6.0.3)
-  "@vueuse/metadata@12.8.2": {}
-  "@vueuse/shared@12.8.2":
+      vue: 3.5.40
+
+  '@vueuse/metadata@12.8.2': {}
+
+  '@vueuse/shared@12.8.2':
     dependencies:
-      vue: 3.5.32(typescript@6.0.3)
-  acorn-jsx@5.3.2(acorn@8.16.0):
+      vue: 3.5.40
+
+  acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
-  acorn@8.16.0: {}
-  ajv@6.14.0:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-  algoliasearch@5.50.2:
+
+  algoliasearch@5.56.0:
     dependencies:
-      "@algolia/abtesting": 1.16.2
-      "@algolia/client-abtesting": 5.50.2
-      "@algolia/client-analytics": 5.50.2
-      "@algolia/client-common": 5.50.2
-      "@algolia/client-insights": 5.50.2
-      "@algolia/client-personalization": 5.50.2
-      "@algolia/client-query-suggestions": 5.50.2
-      "@algolia/client-search": 5.50.2
-      "@algolia/ingestion": 1.50.2
-      "@algolia/monitoring": 1.50.2
-      "@algolia/recommend": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
+      '@algolia/abtesting': 1.22.0
+      '@algolia/client-abtesting': 5.56.0
+      '@algolia/client-analytics': 5.56.0
+      '@algolia/client-common': 5.56.0
+      '@algolia/client-insights': 5.56.0
+      '@algolia/client-personalization': 5.56.0
+      '@algolia/client-query-suggestions': 5.56.0
+      '@algolia/client-search': 5.56.0
+      '@algolia/ingestion': 1.56.0
+      '@algolia/monitoring': 1.56.0
+      '@algolia/recommend': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
   balanced-match@4.0.4: {}
+
   birpc@2.9.0: {}
-  brace-expansion@5.0.5:
+
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
+
   ccount@2.0.1: {}
+
   character-entities-html4@2.1.0: {}
+
   character-entities-legacy@3.0.0: {}
+
   comma-separated-tokens@2.0.3: {}
+
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
   csstype@3.2.3: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
   deep-is@0.1.4: {}
+
   dequal@2.0.3: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
   emoji-regex-xs@1.0.0: {}
+
   entities@7.0.1: {}
+
   esbuild@0.21.5:
     optionalDependencies:
-      "@esbuild/darwin-arm64": 0.21.5
-      "@esbuild/darwin-x64": 0.21.5
-      "@esbuild/linux-arm64": 0.21.5
-      "@esbuild/linux-x64": 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+
   escape-string-regexp@4.0.0: {}
+
   eslint-scope@9.1.2:
     dependencies:
-      "@types/esrecurse": 4.3.1
-      "@types/estree": 1.0.8
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
       esrecurse: 4.3.0
       estraverse: 5.3.0
+
   eslint-visitor-keys@3.4.3: {}
+
   eslint-visitor-keys@5.0.1: {}
-  eslint@10.2.1:
+
+  eslint@10.7.0:
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@10.2.1)
-      "@eslint-community/regexpp": 4.12.2
-      "@eslint/config-array": 0.23.5
-      "@eslint/config-helpers": 0.5.5
-      "@eslint/core": 1.2.1
-      "@eslint/plugin-kit": 0.7.1
-      "@humanfs/node": 0.16.8
-      "@humanwhocodes/module-importer": 1.0.1
-      "@humanwhocodes/retry": 0.4.3
-      "@types/estree": 1.0.8
-      ajv: 6.14.0
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
       cross-spawn: 7.0.6
       debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
+      espree: 11.2.0(acorn@8.17.0)
       esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -1574,126 +1328,169 @@ snapshots:
       minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
-  espree@11.2.0:
+
+  espree@11.2.0(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
+
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
+
   estraverse@5.3.0: {}
+
   estree-walker@2.0.2: {}
+
   esutils@2.0.3: {}
+
   fast-deep-equal@3.1.3: {}
+
   fast-json-stable-stringify@2.1.0: {}
+
   fast-levenshtein@2.0.6: {}
-  fdir@6.5.0(picomatch@4.0.4):
-    dependencies:
-      picomatch: 4.0.4
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.4.2
       keyv: 4.5.4
+
   flatted@3.4.2: {}
+
   focus-trap@7.8.0:
     dependencies:
-      tabbable: 6.4.0
-  fsevents@2.3.3: {}
+      tabbable: 6.5.0
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-  globals@17.5.0: {}
+
+  globals@17.7.0: {}
+
   hast-util-to-html@9.0.5:
     dependencies:
-      "@types/hast": 3.0.4
-      "@types/unist": 3.0.3
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
       ccount: 2.0.1
       comma-separated-tokens: 2.0.3
       hast-util-whitespace: 3.0.0
       html-void-elements: 3.0.0
       mdast-util-to-hast: 13.2.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
-      "@types/hast": 3.0.4
+      '@types/hast': 3.0.5
+
   hookable@5.5.3: {}
+
   html-void-elements@3.0.0: {}
+
   ignore@5.3.2: {}
-  ignore@7.0.5: {}
+
   imurmurhash@0.1.4: {}
+
   is-extglob@2.1.1: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
   is-what@5.5.0: {}
+
   isexe@2.0.0: {}
+
   json-buffer@3.0.1: {}
+
   json-schema-traverse@0.4.1: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
   magic-string@0.30.21:
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   mark.js@8.11.1: {}
+
   mdast-util-to-hast@13.2.1:
     dependencies:
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
-      "@ungap/structured-clone": 1.3.0
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+
   micromark-util-character@2.1.1:
     dependencies:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
+
   micromark-util-encode@2.0.1: {}
+
   micromark-util-sanitize-uri@2.0.1:
     dependencies:
       micromark-util-character: 2.1.1
       micromark-util-encode: 2.0.1
       micromark-util-symbol: 2.0.1
+
   micromark-util-symbol@2.0.1: {}
+
   micromark-util-types@2.0.2: {}
+
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.7
+
   minisearch@7.2.0: {}
+
   mitt@3.0.1: {}
+
   ms@2.1.3: {}
-  nanoid@3.3.11: {}
+
+  nanoid@3.3.16: {}
+
   natural-compare@1.4.0: {}
+
   oniguruma-to-es@3.1.1:
     dependencies:
       emoji-regex-xs: 1.0.0
       regex: 6.1.0
       regex-recursion: 6.0.2
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -1702,160 +1499,176 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
   path-exists@4.0.0: {}
+
   path-key@3.1.1: {}
+
   perfect-debounce@1.0.0: {}
+
   picocolors@1.1.1: {}
-  picomatch@4.0.4: {}
-  postcss@8.5.10:
+
+  postcss@8.5.20:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
-  preact@10.29.1: {}
+
+  preact@10.29.7: {}
+
   prelude-ls@1.2.1: {}
-  property-information@7.1.0: {}
+
+  property-information@7.2.0: {}
+
   punycode@2.3.1: {}
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
+
   regex-utilities@2.3.0: {}
+
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
   rfdc@1.4.1: {}
-  rollup@4.60.2:
+
+  rollup@4.62.2:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.9
     optionalDependencies:
-      "@rollup/rollup-darwin-arm64": 4.60.2
-      "@rollup/rollup-darwin-x64": 4.60.2
-      "@rollup/rollup-linux-arm64-gnu": 4.60.2
-      "@rollup/rollup-linux-arm64-musl": 4.60.2
-      "@rollup/rollup-linux-x64-gnu": 4.60.2
-      "@rollup/rollup-linux-x64-musl": 4.60.2
-      fsevents: 2.3.3
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+
   search-insights@2.17.3: {}
-  semver@7.7.4: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
+
   shebang-regex@3.0.0: {}
+
   shiki@2.5.0:
     dependencies:
-      "@shikijs/core": 2.5.0
-      "@shikijs/engine-javascript": 2.5.0
-      "@shikijs/engine-oniguruma": 2.5.0
-      "@shikijs/langs": 2.5.0
-      "@shikijs/themes": 2.5.0
-      "@shikijs/types": 2.5.0
-      "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
+      '@shikijs/core': 2.5.0
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/langs': 2.5.0
+      '@shikijs/themes': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
   source-map-js@1.2.1: {}
+
   space-separated-tokens@2.0.2: {}
+
   speakingurl@14.0.1: {}
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
-  tabbable@6.4.0: {}
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+
+  tabbable@6.5.0: {}
+
   trim-lines@3.0.1: {}
-  ts-api-utils@2.5.0(typescript@6.0.3):
-    dependencies:
-      typescript: 6.0.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-  typescript-eslint@8.58.2(eslint@10.2.1)(typescript@6.0.3):
-    dependencies:
-      "@typescript-eslint/eslint-plugin": 8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3)
-      "@typescript-eslint/parser": 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      "@typescript-eslint/typescript-estree": 8.58.2(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      eslint: 10.2.1
-      typescript: 6.0.3
-  typescript@6.0.3: {}
+
   unist-util-is@6.0.1:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
+
   unist-util-position@5.0.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
+
   unist-util-stringify-position@4.0.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
+
   unist-util-visit-parents@6.0.2:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.1
+
   unist-util-visit@5.1.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
   vfile-message@4.0.3:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
+
   vfile@6.0.3:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
   vite@5.4.21:
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.10
-      rollup: 4.60.2
-    optionalDependencies:
-      fsevents: 2.3.3
-  vitepress@1.6.4(postcss@8.5.10):
+      postcss: 8.5.20
+      rollup: 4.62.2
+
+  vitepress@1.6.4(postcss@8.5.20):
     dependencies:
-      "@docsearch/css": 3.8.2
-      "@docsearch/js": 3.8.2
-      "@iconify-json/simple-icons": 1.2.78
-      "@shikijs/core": 2.5.0
-      "@shikijs/transformers": 2.5.0
-      "@shikijs/types": 2.5.0
-      "@types/markdown-it": 14.1.2
-      "@vitejs/plugin-vue": 5.2.4(vite@5.4.21)(vue@3.5.32(typescript@6.0.3))
-      "@vue/devtools-api": 7.7.9
-      "@vue/shared": 3.5.32
-      "@vueuse/core": 12.8.2
-      "@vueuse/integrations": 12.8.2(focus-trap@7.8.0)
+      '@docsearch/css': 3.8.2
+      '@docsearch/js': 3.8.2(search-insights@2.17.3)
+      '@iconify-json/simple-icons': 1.2.91
+      '@shikijs/core': 2.5.0
+      '@shikijs/transformers': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@types/markdown-it': 14.1.2
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21)(vue@3.5.40)
+      '@vue/devtools-api': 7.7.10
+      '@vue/shared': 3.5.40
+      '@vueuse/core': 12.8.2
+      '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)
       focus-trap: 7.8.0
       mark.js: 8.11.1
       minisearch: 7.2.0
-      postcss: 8.5.10
+      postcss: 8.5.20
       shiki: 2.5.0
       vite: 5.4.21
-      vue: 3.5.32(typescript@6.0.3)
-  vue@3.5.32(typescript@6.0.3):
+      vue: 3.5.40
+
+  vue@3.5.40:
     dependencies:
-      "@vue/compiler-dom": 3.5.32
-      "@vue/compiler-sfc": 3.5.32
-      "@vue/runtime-dom": 3.5.32
-      "@vue/server-renderer": 3.5.32(vue@3.5.32(typescript@6.0.3))
-      "@vue/shared": 3.5.32
-      typescript: 6.0.3
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-sfc': 3.5.40
+      '@vue/runtime-dom': 3.5.40
+      '@vue/server-renderer': 3.5.40
+      '@vue/shared': 3.5.40
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
   word-wrap@1.2.5: {}
+
   yocto-queue@0.1.0: {}
+
   zwitch@2.0.4: {}

--- a/docs/aube-lock.yaml
+++ b/docs/aube-lock.yaml
@@ -140,6 +140,24 @@ packages:
       search-insights:
         optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.21.5':
     resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
@@ -204,6 +222,22 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
@@ -518,6 +552,11 @@ packages:
 
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -969,6 +1008,15 @@ snapshots:
       '@docsearch/css': 3.8.2
       algoliasearch: 5.56.0
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
@@ -1025,6 +1073,15 @@ snapshots:
   '@iconify/types@2.0.0': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
@@ -1277,6 +1334,9 @@ snapshots:
 
   esbuild@0.21.5:
     optionalDependencies:
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
       '@esbuild/linux-x64': 0.21.5
 
   escape-string-regexp@4.0.0: {}
@@ -1372,6 +1432,9 @@ snapshots:
   focus-trap@7.8.0:
     dependencies:
       tabbable: 6.5.0
+
+  fsevents@2.3.3:
+    optional: true
 
   glob-parent@6.0.2:
     dependencies:
@@ -1544,7 +1607,11 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
     optionalDependencies:
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
       '@rollup/rollup-linux-x64-gnu': 4.62.2
+      fsevents: 2.3.3
 
   search-insights@2.17.3: {}
 
@@ -1630,6 +1697,8 @@ snapshots:
       esbuild: 0.21.5
       postcss: 8.5.20
       rollup: 4.62.2
+    optionalDependencies:
+      fsevents: 2.3.3
 
   vitepress@1.6.4(postcss@8.5.20):
     dependencies:

--- a/docs/aube-lock.yaml
+++ b/docs/aube-lock.yaml
@@ -4,12 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-time:
-  eslint@10.7.0: 2026-07-10T21:22:48.956Z
-  globals@17.7.0: 2026-06-22T17:20:20.100Z
-  postcss@8.5.20: 2026-07-19T08:44:44.719Z
-  vitepress@1.6.4: 2025-08-05T13:40:31.197Z
-
 importers:
 
   .:
@@ -149,10 +143,8 @@ packages:
   '@esbuild/linux-x64@0.21.5':
     resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
-    os:
-    - linux
-    cpu:
-    - x64
+    cpu: [x64]
+    os: [linux]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -215,12 +207,9 @@ packages:
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
-    os:
-    - linux
-    cpu:
-    - x64
-    libc:
-    - glibc
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
@@ -426,6 +415,8 @@ packages:
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
@@ -960,20 +951,26 @@ snapshots:
 
   '@docsearch/css@3.8.2': {}
 
-  '@docsearch/js@3.8.2(search-insights@2.17.3)':
+  '@docsearch/js@3.8.2':
     dependencies:
-      '@docsearch/react': 3.8.2(search-insights@2.17.3)
+      '@docsearch/react': 3.8.2
       preact: 10.29.7
+    transitivePeerDependencies:
+      - '@types/react'
+      - preact-render-to-string
+      - react
+      - react-dom
+      - search-insights
 
-  '@docsearch/react@3.8.2(search-insights@2.17.3)':
+  '@docsearch/react@3.8.2':
     dependencies:
       '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
       '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
       '@docsearch/css': 3.8.2
       algoliasearch: 5.56.0
-      search-insights: 2.17.3
 
-  '@esbuild/linux-x64@0.21.5': {}
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.7.0)':
     dependencies:
@@ -987,6 +984,8 @@ snapshots:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3
       minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@eslint/config-helpers@0.6.0':
     dependencies:
@@ -1027,7 +1026,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@rollup/rollup-linux-x64-gnu@4.62.2': {}
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
 
   '@shikijs/core@2.5.0':
     dependencies:
@@ -1181,6 +1181,8 @@ snapshots:
       '@vueuse/metadata': 12.8.2
       '@vueuse/shared': 12.8.2
       vue: 3.5.40
+    transitivePeerDependencies:
+      - typescript
 
   '@vueuse/integrations@12.8.2(focus-trap@7.8.0)':
     dependencies:
@@ -1188,12 +1190,16 @@ snapshots:
       '@vueuse/shared': 12.8.2
       focus-trap: 7.8.0
       vue: 3.5.40
+    transitivePeerDependencies:
+      - typescript
 
   '@vueuse/metadata@12.8.2': {}
 
   '@vueuse/shared@12.8.2':
     dependencies:
       vue: 3.5.40
+    transitivePeerDependencies:
+      - typescript
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -1304,7 +1310,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
-      espree: 11.2.0(acorn@8.17.0)
+      espree: 11.2.0
       esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -1318,8 +1324,10 @@ snapshots:
       minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
 
-  espree@11.2.0(acorn@8.17.0):
+  espree@11.2.0:
     dependencies:
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
@@ -1626,7 +1634,7 @@ snapshots:
   vitepress@1.6.4(postcss@8.5.20):
     dependencies:
       '@docsearch/css': 3.8.2
-      '@docsearch/js': 3.8.2(search-insights@2.17.3)
+      '@docsearch/js': 3.8.2
       '@iconify-json/simple-icons': 1.2.91
       '@shikijs/core': 2.5.0
       '@shikijs/transformers': 2.5.0
@@ -1644,6 +1652,32 @@ snapshots:
       shiki: 2.5.0
       vite: 5.4.21
       vue: 3.5.40
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@types/react'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - fuse.js
+      - idb-keyval
+      - jwt-decode
+      - less
+      - lightningcss
+      - nprogress
+      - preact-render-to-string
+      - qrcode
+      - react
+      - react-dom
+      - sass
+      - sass-embedded
+      - search-insights
+      - sortablejs
+      - stylus
+      - sugarss
+      - terser
+      - typescript
+      - universal-cookie
 
   vue@3.5.40:
     dependencies:

--- a/docs/aube-lock.yaml
+++ b/docs/aube-lock.yaml
@@ -1,370 +1,143 @@
-lockfileVersion: "9.0"
+lockfileVersion: '9.0'
+
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+
 time:
-  "@algolia/abtesting@1.16.2": 2026-04-14T16:35:13.229Z
-  "@algolia/autocomplete-core@1.17.7": 2024-11-05T15:07:05.611Z
-  "@algolia/autocomplete-plugin-algolia-insights@1.17.7": 2024-11-05T15:07:23.472Z
-  "@algolia/autocomplete-preset-algolia@1.17.7": 2024-11-05T15:08:03.592Z
-  "@algolia/autocomplete-shared@1.17.7": 2024-11-05T15:08:10.663Z
-  "@algolia/client-abtesting@5.50.2": 2026-04-14T16:35:13.673Z
-  "@algolia/client-analytics@5.50.2": 2026-04-14T16:35:13.103Z
-  "@algolia/client-common@5.50.2": 2026-04-14T16:35:05.733Z
-  "@algolia/client-insights@5.50.2": 2026-04-14T16:35:16.104Z
-  "@algolia/client-personalization@5.50.2": 2026-04-14T16:35:17.331Z
-  "@algolia/client-query-suggestions@5.50.2": 2026-04-14T16:35:17.616Z
-  "@algolia/client-search@5.50.2": 2026-04-14T16:35:18.082Z
-  "@algolia/ingestion@1.50.2": 2026-04-14T16:35:21.912Z
-  "@algolia/monitoring@1.50.2": 2026-04-14T16:35:22.250Z
-  "@algolia/recommend@5.50.2": 2026-04-14T16:35:22.424Z
-  "@algolia/requester-browser-xhr@5.50.2": 2026-04-14T16:35:08.842Z
-  "@algolia/requester-fetch@5.50.2": 2026-04-14T16:35:09.130Z
-  "@algolia/requester-node-http@5.50.2": 2026-04-14T16:35:09.050Z
-  "@babel/helper-string-parser@7.27.1": 2025-04-30T15:08:26.501Z
-  "@babel/helper-validator-identifier@7.28.5": 2025-10-23T15:17:38.203Z
-  "@babel/parser@7.29.2": 2026-03-16T22:33:19.657Z
-  "@babel/types@7.29.0": 2026-01-31T17:39:13.578Z
-  "@docsearch/css@3.8.2": 2024-12-17T15:34:33.806Z
-  "@docsearch/js@3.8.2": 2024-12-17T15:34:38.867Z
-  "@docsearch/react@3.8.2": 2024-12-17T15:34:36.229Z
-  "@esbuild/darwin-arm64@0.21.5": 2024-06-09T21:17:13.758Z
-  "@esbuild/darwin-x64@0.21.5": 2024-06-09T21:17:00.976Z
-  "@esbuild/linux-arm64@0.21.5": 2024-06-09T21:17:23.384Z
-  "@esbuild/linux-x64@0.21.5": 2024-06-09T21:17:15.111Z
-  "@eslint-community/eslint-utils@4.9.1": 2025-12-31T14:49:52.066Z
-  "@eslint-community/regexpp@4.12.2": 2025-10-22T11:56:00.818Z
-  "@eslint/config-array@0.23.5": 2026-04-08T09:22:37.796Z
-  "@eslint/config-helpers@0.5.5": 2026-04-08T09:22:40.626Z
-  "@eslint/core@1.2.1": 2026-04-08T09:22:28.287Z
-  "@eslint/object-schema@3.0.5": 2026-04-08T09:22:34.549Z
-  "@eslint/plugin-kit@0.7.1": 2026-04-08T09:22:43.810Z
-  "@humanfs/core@0.19.2": 2026-04-17T20:51:11.882Z
-  "@humanfs/node@0.16.8": 2026-04-17T20:51:26.959Z
-  "@humanfs/types@0.15.0": 2024-09-09T19:44:08.000Z
-  "@humanwhocodes/module-importer@1.0.1": 2022-08-18T17:55:51.038Z
-  "@humanwhocodes/retry@0.4.3": 2025-05-07T14:25:57.372Z
-  "@iconify-json/simple-icons@1.2.78": 2026-04-13T04:57:35.352Z
-  "@iconify/types@2.0.0": 2022-09-08T06:23:03.369Z
-  "@jridgewell/sourcemap-codec@1.5.5": 2025-08-12T06:43:59.139Z
-  "@rollup/rollup-darwin-arm64@4.60.2": 2026-04-18T13:58:27.555Z
-  "@rollup/rollup-darwin-x64@4.60.2": 2026-04-18T13:59:28.701Z
-  "@rollup/rollup-linux-arm64-gnu@4.60.2": 2026-04-18T13:58:41.555Z
-  "@rollup/rollup-linux-arm64-musl@4.60.2": 2026-04-18T13:58:45.162Z
-  "@rollup/rollup-linux-x64-gnu@4.60.2": 2026-04-18T13:59:43.183Z
-  "@rollup/rollup-linux-x64-musl@4.60.2": 2026-04-18T13:59:46.857Z
-  "@shikijs/core@2.5.0": 2025-02-18T09:10:12.142Z
-  "@shikijs/engine-javascript@2.5.0": 2025-02-18T09:09:26.369Z
-  "@shikijs/engine-oniguruma@2.5.0": 2025-02-18T09:09:33.593Z
-  "@shikijs/langs@2.5.0": 2025-02-18T09:09:39.465Z
-  "@shikijs/themes@2.5.0": 2025-02-18T09:10:04.997Z
-  "@shikijs/transformers@2.5.0": 2025-02-18T09:10:36.901Z
-  "@shikijs/types@2.5.0": 2025-02-18T09:09:20.251Z
-  "@shikijs/vscode-textmate@10.0.2": 2025-02-15T16:46:32.096Z
-  "@types/esrecurse@4.3.1": 2025-07-19T03:47:09.775Z
-  "@types/estree@1.0.8": 2025-06-06T00:04:34.692Z
-  "@types/hast@3.0.4": 2024-01-30T22:06:19.288Z
-  "@types/json-schema@7.0.15": 2023-11-07T08:49:23.527Z
-  "@types/linkify-it@5.0.0": 2024-05-01T18:07:46.092Z
-  "@types/markdown-it@14.1.2": 2024-07-25T05:07:30.523Z
-  "@types/mdast@4.0.4": 2024-05-14T07:35:37.616Z
-  "@types/mdurl@2.0.0": 2024-05-01T18:08:10.612Z
-  "@types/unist@3.0.3": 2024-08-15T02:19:16.553Z
-  "@types/web-bluetooth@0.0.21": 2025-02-28T23:32:05.029Z
-  "@typescript-eslint/eslint-plugin@8.58.2": 2026-04-13T17:24:54.947Z
-  "@typescript-eslint/parser@8.58.2": 2026-04-13T17:24:34.854Z
-  "@typescript-eslint/project-service@8.58.2": 2026-04-13T17:24:09.647Z
-  "@typescript-eslint/scope-manager@8.58.2": 2026-04-13T17:24:26.877Z
-  "@typescript-eslint/tsconfig-utils@8.58.2": 2026-04-13T17:24:02.619Z
-  "@typescript-eslint/type-utils@8.58.2": 2026-04-13T17:24:42.060Z
-  "@typescript-eslint/types@8.58.2": 2026-04-13T17:24:03.218Z
-  "@typescript-eslint/typescript-estree@8.58.2": 2026-04-13T17:24:18.409Z
-  "@typescript-eslint/utils@8.58.2": 2026-04-13T17:24:34.297Z
-  "@typescript-eslint/visitor-keys@8.58.2": 2026-04-13T17:24:10.068Z
-  "@ungap/structured-clone@1.3.0": 2025-01-23T14:13:01.275Z
-  "@vitejs/plugin-vue@5.2.4": 2025-05-09T09:47:50.969Z
-  "@vue/compiler-core@3.5.32": 2026-04-03T05:41:04.047Z
-  "@vue/compiler-dom@3.5.32": 2026-04-03T05:41:07.863Z
-  "@vue/compiler-sfc@3.5.32": 2026-04-03T05:41:12.043Z
-  "@vue/compiler-ssr@3.5.32": 2026-04-03T05:41:16.007Z
-  "@vue/devtools-api@7.7.9": 2025-11-17T14:28:13.410Z
-  "@vue/devtools-kit@7.7.9": 2025-11-17T14:28:05.469Z
-  "@vue/devtools-shared@7.7.9": 2025-11-17T14:28:02.466Z
-  "@vue/reactivity@3.5.32": 2026-04-03T05:41:19.887Z
-  "@vue/runtime-core@3.5.32": 2026-04-03T05:41:24.116Z
-  "@vue/runtime-dom@3.5.32": 2026-04-03T05:41:27.865Z
-  "@vue/server-renderer@3.5.32": 2026-04-03T05:41:31.772Z
-  "@vue/shared@3.5.32": 2026-04-03T05:41:35.866Z
-  "@vueuse/core@12.8.2": 2025-03-05T11:39:34.178Z
-  "@vueuse/integrations@12.8.2": 2025-03-05T11:41:34.399Z
-  "@vueuse/metadata@12.8.2": 2025-03-05T11:39:15.362Z
-  "@vueuse/shared@12.8.2": 2025-03-05T11:39:22.947Z
-  acorn-jsx@5.3.2: 2021-07-09T01:15:57.512Z
-  acorn@8.16.0: 2026-02-19T15:06:28.070Z
-  ajv@6.14.0: 2026-02-20T18:09:33.622Z
-  algoliasearch@5.50.2: 2026-04-14T16:35:28.490Z
-  balanced-match@4.0.4: 2026-02-22T11:38:25.951Z
-  birpc@2.9.0: 2025-12-03T06:40:16.657Z
-  brace-expansion@5.0.5: 2026-03-24T17:58:07.554Z
-  ccount@2.0.1: 2021-10-28T09:38:13.774Z
-  character-entities-html4@2.1.0: 2021-10-29T14:28:35.375Z
-  character-entities-legacy@3.0.0: 2021-10-29T12:50:20.435Z
-  comma-separated-tokens@2.0.3: 2022-11-14T09:09:04.761Z
-  copy-anything@4.0.5: 2025-03-24T18:18:23.270Z
-  cross-spawn@7.0.6: 2024-11-18T13:59:52.129Z
-  csstype@3.2.3: 2025-11-17T11:42:27.045Z
-  debug@4.4.3: 2025-09-13T17:25:19.732Z
-  deep-is@0.1.4: 2021-09-04T16:55:20.731Z
-  dequal@2.0.3: 2022-07-11T23:29:04.965Z
-  devlop@1.1.0: 2023-06-29T15:17:11.346Z
-  emoji-regex-xs@1.0.0: 2024-06-28T16:22:28.678Z
-  entities@7.0.1: 2026-01-21T13:46:30.165Z
-  esbuild@0.21.5: 2024-06-09T21:17:41.628Z
-  escape-string-regexp@4.0.0: 2020-04-23T07:31:25.491Z
-  eslint-scope@9.1.2: 2026-03-06T22:32:49.946Z
-  eslint-visitor-keys@3.4.3: 2023-08-11T14:49:54.383Z
-  eslint-visitor-keys@5.0.1: 2026-02-20T14:40:47.824Z
-  eslint@10.2.1: 2026-04-17T20:17:44.852Z
-  espree@11.2.0: 2026-03-06T22:32:40.951Z
-  esquery@1.7.0: 2025-12-31T15:44:57.664Z
-  esrecurse@4.3.0: 2020-08-31T18:21:44.794Z
-  estraverse@5.3.0: 2021-10-25T12:18:17.722Z
-  estree-walker@2.0.2: 2020-12-08T17:07:42.670Z
-  esutils@2.0.3: 2019-07-31T01:10:54.228Z
-  fast-deep-equal@3.1.3: 2020-06-08T07:27:28.474Z
-  fast-json-stable-stringify@2.1.0: 2019-12-14T16:17:57.583Z
-  fast-levenshtein@2.0.6: 2016-12-27T21:15:07.820Z
-  fdir@6.5.0: 2025-08-14T16:56:03.948Z
-  file-entry-cache@8.0.0: 2023-12-18T19:33:58.734Z
-  find-up@5.0.0: 2020-08-11T18:44:24.748Z
-  flat-cache@4.0.1: 2024-03-02T16:09:41.118Z
-  flatted@3.4.2: 2026-03-17T15:03:56.392Z
-  focus-trap@7.8.0: 2026-01-10T22:24:14.284Z
-  fsevents@2.3.3: 2023-08-21T16:24:22.854Z
-  glob-parent@6.0.2: 2021-09-29T22:14:24.467Z
-  globals@17.5.0: 2026-04-12T05:40:14.299Z
-  hast-util-to-html@9.0.5: 2025-02-19T13:34:47.133Z
-  hast-util-whitespace@3.0.0: 2023-07-31T15:52:12.042Z
-  hookable@5.5.3: 2023-03-30T13:33:47.930Z
-  html-void-elements@3.0.0: 2023-05-19T10:17:19.335Z
-  ignore@5.3.2: 2024-08-12T08:51:00.065Z
-  ignore@7.0.5: 2025-05-31T02:18:53.410Z
-  imurmurhash@0.1.4: 2013-08-24T20:45:23.169Z
-  is-extglob@2.1.1: 2016-12-11T04:04:24.390Z
-  is-glob@4.0.3: 2021-09-29T16:52:47.977Z
-  is-what@5.5.0: 2025-09-22T17:10:23.658Z
-  isexe@2.0.0: 2017-03-23T00:53:16.356Z
-  json-buffer@3.0.1: 2018-09-10T19:02:16.381Z
-  json-schema-traverse@0.4.1: 2018-06-10T08:42:05.056Z
-  json-stable-stringify-without-jsonify@1.0.1: 2016-12-15T22:00:35.805Z
-  keyv@4.5.4: 2023-10-07T16:53:54.487Z
-  levn@0.4.1: 2020-04-04T02:05:31.527Z
-  locate-path@6.0.0: 2020-08-10T17:49:10.766Z
-  magic-string@0.30.21: 2025-10-24T00:59:47.122Z
-  mark.js@8.11.1: 2018-01-11T22:55:52.210Z
-  mdast-util-to-hast@13.2.1: 2025-11-23T21:08:34.155Z
-  micromark-util-character@2.1.1: 2024-11-12T11:17:13.750Z
-  micromark-util-encode@2.0.1: 2024-11-12T11:17:34.206Z
-  micromark-util-sanitize-uri@2.0.1: 2024-11-12T11:17:48.745Z
-  micromark-util-symbol@2.0.1: 2024-11-12T11:17:55.709Z
-  micromark-util-types@2.0.2: 2025-02-27T13:55:27.982Z
-  minimatch@10.2.5: 2026-03-30T18:08:07.247Z
-  minisearch@7.2.0: 2025-09-16T12:42:12.453Z
-  mitt@3.0.1: 2023-07-04T17:31:47.638Z
-  ms@2.1.3: 2020-12-08T13:54:35.223Z
-  nanoid@3.3.11: 2025-03-18T23:06:32.923Z
-  natural-compare@1.4.0: 2016-07-22T20:48:12.217Z
-  oniguruma-to-es@3.1.1: 2025-02-20T16:19:37.749Z
-  optionator@0.9.4: 2024-04-26T22:17:51.408Z
-  p-limit@3.1.0: 2020-11-25T07:42:37.364Z
-  p-locate@5.0.0: 2020-08-10T17:42:34.692Z
-  path-exists@4.0.0: 2019-04-04T03:29:16.887Z
-  path-key@3.1.1: 2019-11-22T16:47:18.153Z
-  perfect-debounce@1.0.0: 2023-05-03T23:17:12.783Z
-  picocolors@1.1.1: 2024-10-16T18:20:03.921Z
-  picomatch@4.0.4: 2026-03-23T20:39:47.960Z
-  postcss@8.5.10: 2026-04-15T14:42:53.378Z
-  preact@10.29.1: 2026-04-03T10:43:57.080Z
-  prelude-ls@1.2.1: 2020-04-02T22:53:40.710Z
-  property-information@7.1.0: 2025-05-08T07:00:48.463Z
-  punycode@2.3.1: 2023-10-30T18:28:32.512Z
-  regex-recursion@6.0.2: 2025-02-01T00:57:00.191Z
-  regex-utilities@2.3.0: 2024-08-31T18:40:34.903Z
-  regex@6.1.0: 2025-12-09T01:33:47.153Z
-  rfdc@1.4.1: 2024-06-12T10:18:29.594Z
-  rollup@4.60.2: 2026-04-18T13:59:58.613Z
-  search-insights@2.17.3: 2024-11-18T02:06:21.689Z
-  semver@7.7.4: 2026-02-05T17:23:11.131Z
-  shebang-command@2.0.0: 2019-09-06T14:53:25.901Z
-  shebang-regex@3.0.0: 2019-04-27T10:46:19.256Z
-  shiki@2.5.0: 2025-02-18T09:10:30.900Z
-  source-map-js@1.2.1: 2024-09-08T16:22:55.645Z
-  space-separated-tokens@2.0.2: 2022-11-14T08:54:14.011Z
-  speakingurl@14.0.1: 2017-08-23T06:43:02.759Z
-  stringify-entities@4.0.4: 2024-04-03T13:04:46.263Z
-  superjson@2.2.6: 2025-11-27T13:27:45.738Z
-  tabbable@6.4.0: 2025-12-31T17:29:46.264Z
-  tinyglobby@0.2.16: 2026-04-07T23:37:03.457Z
-  trim-lines@3.0.1: 2022-07-03T12:54:20.493Z
-  ts-api-utils@2.5.0: 2026-03-19T02:50:49.789Z
-  type-check@0.4.0: 2020-04-03T03:02:37.249Z
-  typescript-eslint@8.58.2: 2026-04-13T17:25:02.436Z
-  typescript@6.0.3: 2026-04-16T23:38:27.905Z
-  unist-util-is@6.0.1: 2025-10-16T18:01:47.398Z
-  unist-util-position@5.0.0: 2023-07-07T09:59:34.316Z
-  unist-util-stringify-position@4.0.0: 2023-07-07T10:09:26.763Z
-  unist-util-visit-parents@6.0.2: 2025-10-16T18:20:45.045Z
-  unist-util-visit@5.1.0: 2026-01-22T19:02:58.977Z
-  uri-js@4.4.1: 2021-01-10T00:43:12.666Z
-  vfile-message@4.0.3: 2025-07-26T15:08:12.656Z
-  vfile@6.0.3: 2024-08-27T09:12:42.377Z
-  vite@5.4.21: 2025-10-20T05:32:04.015Z
+  eslint@10.7.0: 2026-07-10T21:22:48.956Z
+  globals@17.7.0: 2026-06-22T17:20:20.100Z
+  postcss@8.5.20: 2026-07-19T08:44:44.719Z
   vitepress@1.6.4: 2025-08-05T13:40:31.197Z
-  vue@3.5.32: 2026-04-03T05:41:39.680Z
-  which@2.0.2: 2019-11-18T22:26:15.325Z
-  word-wrap@1.2.5: 2023-07-22T14:37:38.795Z
-  yocto-queue@0.1.0: 2020-11-24T06:05:35.875Z
-  zwitch@2.0.4: 2022-11-16T09:09:14.038Z
+
 importers:
+
   .:
     dependencies:
-      "@algolia/client-search":
-        specifier: ">= 4.9.1 < 6"
-        version: 5.50.2
-      "@typescript-eslint/parser":
-        specifier: ^8.58.2
-        version: 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      acorn:
-        specifier: ^6.0.0 || ^7.0.0 || ^8.0.0
-        version: 8.16.0
-      algoliasearch:
-        specifier: ">= 4.9.1 < 6"
-        version: 5.50.2
       eslint:
         specifier: ^10.0.0
-        version: 10.2.1
-      focus-trap:
-        specifier: ^7
-        version: 7.8.0
-      picomatch:
-        specifier: ^3 || ^4
-        version: 4.0.4
+        version: 10.7.0
       postcss:
         specifier: ^8
-        version: 8.5.10
-      search-insights:
-        specifier: ">= 1 < 3"
-        version: 2.17.3
-      typescript:
-        specifier: ">=4.8.4 <6.1.0"
-        version: 6.0.3
-      vite:
-        specifier: ^5.0.0 || ^6.0.0
-        version: 5.4.21
+        version: 8.5.20
       vitepress:
         specifier: ^1.6.3
-        version: 1.6.4(postcss@8.5.10)
-      vue:
-        specifier: ^3.2.25
-        version: 3.5.32(typescript@6.0.3)
+        version: 1.6.4(postcss@8.5.20)
     devDependencies:
       globals:
         specifier: ^17.0.0
-        version: 17.5.0
-      typescript-eslint:
-        specifier: ^8.24.1
-        version: 8.58.2(eslint@10.2.1)(typescript@6.0.3)
+        version: 17.7.0
+
 packages:
-  "@algolia/abtesting@1.16.2":
-    resolution:
-      integrity: sha512-n9s6bEV6imdtIEd+BGP7WkA4pEZ5YTdgQ05JQhHwWawHg3hyjpNwC0TShGz6zWhv+jfLDGA/6FFNbySFS0P9cw==
-  "@algolia/autocomplete-core@1.17.7":
-    resolution:
-      integrity: sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==
-  "@algolia/autocomplete-plugin-algolia-insights@1.17.7":
-    resolution:
-      integrity: sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==
+
+  '@algolia/abtesting@1.22.0':
+    resolution: {integrity: sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/autocomplete-core@1.17.7':
+    resolution: {integrity: sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==}
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7':
+    resolution: {integrity: sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==}
     peerDependencies:
-      search-insights: ">= 1 < 3"
-  "@algolia/autocomplete-preset-algolia@1.17.7":
-    resolution:
-      integrity: sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==
+      search-insights: '>= 1 < 3'
+
+  '@algolia/autocomplete-preset-algolia@1.17.7':
+    resolution: {integrity: sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==}
     peerDependencies:
-      "@algolia/client-search": ">= 4.9.1 < 6"
-      algoliasearch: ">= 4.9.1 < 6"
-  "@algolia/autocomplete-shared@1.17.7":
-    resolution:
-      integrity: sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+
+  '@algolia/autocomplete-shared@1.17.7':
+    resolution: {integrity: sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==}
     peerDependencies:
-      "@algolia/client-search": ">= 4.9.1 < 6"
-      algoliasearch: ">= 4.9.1 < 6"
-  "@algolia/client-abtesting@5.50.2":
-    resolution:
-      integrity: sha512-52iq0vHy1sphgnwoZyx5PmbEt8hsh+m7jD123LmBs6qy4GK7LbYZIeKd+nSnSipN2zvKRZ2zScS6h9PW3J7SXg==
-  "@algolia/client-analytics@5.50.2":
-    resolution:
-      integrity: sha512-WpPIUg+cSG2aPUG0gS8Ko9DwRgbRPUZxJkolhL2aCsmSlcEEZT65dILrfg5ovcxtx0Kvr+xtBVsTMtsQWRtPDQ==
-  "@algolia/client-common@5.50.2":
-    resolution:
-      integrity: sha512-Gj2MgtArGcsr82kIqRlo6/dCAFjrs2gLByEqyRENuT7ugrSMFuqg1vDzeBjRL1t3EJEJCFtT0PLX3gB8A6Hq4Q==
-  "@algolia/client-insights@5.50.2":
-    resolution:
-      integrity: sha512-CUqoid5jDpmrc0oK3/xuZXFt6kwT0P9Lw7/nsM14YTr6puvmi+OUKmURpmebQF22S2vCG8L1DAoXXujxQUi/ug==
-  "@algolia/client-personalization@5.50.2":
-    resolution:
-      integrity: sha512-AndZWFoc0gbP5901OeQJ73BazgGgSGiBEba4ohdoJuZwHTO2Gio8Q4L1VLmytMBYcviVigB0iICToMvEJxI4ug==
-  "@algolia/client-query-suggestions@5.50.2":
-    resolution:
-      integrity: sha512-NWoL+psEkz5dIzweaByVXuEB45wS8/rk0E0AhMMnaVJdVs7TcACPH2/OURm+N0xRDITkTHqCna823rd6Uqntdg==
-  "@algolia/client-search@5.50.2":
-    resolution:
-      integrity: sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==
-  "@algolia/ingestion@1.50.2":
-    resolution:
-      integrity: sha512-VlR2FRXLw2bCB94SQo6zxg/Qi+547aOji6Pb+dKE7h1DMCCY317St+OpjpmgzE+bT2O9ALIc0V4nVIBOd7Gy+Q==
-  "@algolia/monitoring@1.50.2":
-    resolution:
-      integrity: sha512-Cmvfp2+qopzQt8OilU97rhLhosq7ZrB6uieok3EwFUqG/aalPg6DgfCmu0yJMrYe+KMC1qRVt1MTRAUwLknUMQ==
-  "@algolia/recommend@5.50.2":
-    resolution:
-      integrity: sha512-jrkuyKoOM7dFWQ/6Y4hQAse2SC3L/RldG6GnPjMvAj65h+7Ubb51S0pKk4ofSStF0xm4LCNe0C4T6XX4nOFDiQ==
-  "@algolia/requester-browser-xhr@5.50.2":
-    resolution:
-      integrity: sha512-4107YLJqCudPiBUlwnk6oTSUVwU7ab+qL1SfQGEDYI8DZH5gsf1ekPt9JykXRKYXf2IfouFL5GiCY/PHTFIjYw==
-  "@algolia/requester-fetch@5.50.2":
-    resolution:
-      integrity: sha512-vOrd3MQpLgmf6wXAueTuZ/cA0W4uRwIHHaxNy3h+a6YcNn6bCV/gFdZuv3F13v593zRU2k5R75NmvRWLenvMrw==
-  "@algolia/requester-node-http@5.50.2":
-    resolution:
-      integrity: sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==
-  "@babel/helper-string-parser@7.27.1":
-    resolution:
-      integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
-  "@babel/helper-validator-identifier@7.28.5":
-    resolution:
-      integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
-  "@babel/parser@7.29.2":
-    resolution:
-      integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==
-  "@babel/types@7.29.0":
-    resolution:
-      integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
-  "@docsearch/css@3.8.2":
-    resolution:
-      integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==
-  "@docsearch/js@3.8.2":
-    resolution:
-      integrity: sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==
-  "@docsearch/react@3.8.2":
-    resolution:
-      integrity: sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+
+  '@algolia/client-abtesting@5.56.0':
+    resolution: {integrity: sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-analytics@5.56.0':
+    resolution: {integrity: sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-common@5.56.0':
+    resolution: {integrity: sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-insights@5.56.0':
+    resolution: {integrity: sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-personalization@5.56.0':
+    resolution: {integrity: sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-query-suggestions@5.56.0':
+    resolution: {integrity: sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-search@5.56.0':
+    resolution: {integrity: sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/ingestion@1.56.0':
+    resolution: {integrity: sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/monitoring@1.56.0':
+    resolution: {integrity: sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/recommend@5.56.0':
+    resolution: {integrity: sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-browser-xhr@5.56.0':
+    resolution: {integrity: sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-fetch@5.56.0':
+    resolution: {integrity: sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-node-http@5.56.0':
+    resolution: {integrity: sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==}
+    engines: {node: '>= 14.0.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@docsearch/css@3.8.2':
+    resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
+
+  '@docsearch/js@3.8.2':
+    resolution: {integrity: sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==}
+
+  '@docsearch/react@3.8.2':
+    resolution: {integrity: sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==}
     peerDependencies:
-      "@types/react": ">= 16.8.0 < 19.0.0"
-      react: ">= 16.8.0 < 19.0.0"
-      react-dom: ">= 16.8.0 < 19.0.0"
-      search-insights: ">= 1 < 3"
+      '@types/react': '>= 16.8.0 < 19.0.0'
+      react: '>= 16.8.0 < 19.0.0'
+      react-dom: '>= 16.8.0 < 19.0.0'
+      search-insights: '>= 1 < 3'
     peerDependenciesMeta:
-      "@types/react":
+      '@types/react':
         optional: true
       react:
         optional: true
@@ -372,287 +145,188 @@ packages:
         optional: true
       search-insights:
         optional: true
-  "@esbuild/darwin-arm64@0.21.5":
-    resolution:
-      integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
     os:
-      - darwin
+    - linux
     cpu:
-      - arm64
-  "@esbuild/darwin-x64@0.21.5":
-    resolution:
-      integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
-    os:
-      - darwin
-    cpu:
-      - x64
-  "@esbuild/linux-arm64@0.21.5":
-    resolution:
-      integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
-    os:
-      - linux
-    cpu:
-      - arm64
-  "@esbuild/linux-x64@0.21.5":
-    resolution:
-      integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
-    os:
-      - linux
-    cpu:
-      - x64
-  "@eslint-community/eslint-utils@4.9.1":
-    resolution:
-      integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
+    - x64
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  "@eslint-community/regexpp@4.12.2":
-    resolution:
-      integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
-  "@eslint/config-array@0.23.5":
-    resolution:
-      integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==
-  "@eslint/config-helpers@0.5.5":
-    resolution:
-      integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==
-  "@eslint/core@1.2.1":
-    resolution:
-      integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==
-  "@eslint/object-schema@3.0.5":
-    resolution:
-      integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==
-  "@eslint/plugin-kit@0.7.1":
-    resolution:
-      integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==
-  "@humanfs/core@0.19.2":
-    resolution:
-      integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==
-  "@humanfs/node@0.16.8":
-    resolution:
-      integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==
-  "@humanfs/types@0.15.0":
-    resolution:
-      integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==
-  "@humanwhocodes/module-importer@1.0.1":
-    resolution:
-      integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
-  "@humanwhocodes/retry@0.4.3":
-    resolution:
-      integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
-  "@iconify-json/simple-icons@1.2.78":
-    resolution:
-      integrity: sha512-I3lkNp0Qu7q2iZWkdcf/I2hqGhzK6qxdILh9T7XqowQrnpmG/BayDsiCf6PktDoWlW0U971xA5g+panm+NFrfQ==
-  "@iconify/types@2.0.0":
-    resolution:
-      integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
-  "@jridgewell/sourcemap-codec@1.5.5":
-    resolution:
-      integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
-  "@rollup/rollup-darwin-arm64@4.60.2":
-    resolution:
-      integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@iconify-json/simple-icons@1.2.91':
+    resolution: {integrity: sha512-plQJHZxzpkIXaeYjJF0Sc9nkzYF32EDX9olx7j1hcKYFaiTrQXbcngZmvzuV0pG6uZPU3ZuA/GIsgxSHOm6jrQ==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     os:
-      - darwin
+    - linux
     cpu:
-      - arm64
-  "@rollup/rollup-darwin-x64@4.60.2":
-    resolution:
-      integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==
-    os:
-      - darwin
-    cpu:
-      - x64
-  "@rollup/rollup-linux-arm64-gnu@4.60.2":
-    resolution:
-      integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==
-    os:
-      - linux
-    cpu:
-      - arm64
+    - x64
     libc:
-      - glibc
-  "@rollup/rollup-linux-arm64-musl@4.60.2":
-    resolution:
-      integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==
-    os:
-      - linux
-    cpu:
-      - arm64
-    libc:
-      - musl
-  "@rollup/rollup-linux-x64-gnu@4.60.2":
-    resolution:
-      integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==
-    os:
-      - linux
-    cpu:
-      - x64
-    libc:
-      - glibc
-  "@rollup/rollup-linux-x64-musl@4.60.2":
-    resolution:
-      integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==
-    os:
-      - linux
-    cpu:
-      - x64
-    libc:
-      - musl
-  "@shikijs/core@2.5.0":
-    resolution:
-      integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==
-  "@shikijs/engine-javascript@2.5.0":
-    resolution:
-      integrity: sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==
-  "@shikijs/engine-oniguruma@2.5.0":
-    resolution:
-      integrity: sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==
-  "@shikijs/langs@2.5.0":
-    resolution:
-      integrity: sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==
-  "@shikijs/themes@2.5.0":
-    resolution:
-      integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==
-  "@shikijs/transformers@2.5.0":
-    resolution:
-      integrity: sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==
-  "@shikijs/types@2.5.0":
-    resolution:
-      integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==
-  "@shikijs/vscode-textmate@10.0.2":
-    resolution:
-      integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==
-  "@types/esrecurse@4.3.1":
-    resolution:
-      integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==
-  "@types/estree@1.0.8":
-    resolution:
-      integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
-  "@types/hast@3.0.4":
-    resolution:
-      integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==
-  "@types/json-schema@7.0.15":
-    resolution:
-      integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
-  "@types/linkify-it@5.0.0":
-    resolution:
-      integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==
-  "@types/markdown-it@14.1.2":
-    resolution:
-      integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==
-  "@types/mdast@4.0.4":
-    resolution:
-      integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==
-  "@types/mdurl@2.0.0":
-    resolution:
-      integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
-  "@types/unist@3.0.3":
-    resolution:
-      integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
-  "@types/web-bluetooth@0.0.21":
-    resolution:
-      integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==
-  "@typescript-eslint/eslint-plugin@8.58.2":
-    resolution:
-      integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==
-    peerDependencies:
-      "@typescript-eslint/parser": ^8.58.2
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/parser@8.58.2":
-    resolution:
-      integrity: sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/project-service@8.58.2":
-    resolution:
-      integrity: sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/scope-manager@8.58.2":
-    resolution:
-      integrity: sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==
-  "@typescript-eslint/tsconfig-utils@8.58.2":
-    resolution:
-      integrity: sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/type-utils@8.58.2":
-    resolution:
-      integrity: sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/types@8.58.2":
-    resolution:
-      integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==
-  "@typescript-eslint/typescript-estree@8.58.2":
-    resolution:
-      integrity: sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/utils@8.58.2":
-    resolution:
-      integrity: sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-  "@typescript-eslint/visitor-keys@8.58.2":
-    resolution:
-      integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==
-  "@ungap/structured-clone@1.3.0":
-    resolution:
-      integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
-  "@vitejs/plugin-vue@5.2.4":
-    resolution:
-      integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==
+    - glibc
+
+  '@shikijs/core@2.5.0':
+    resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
+
+  '@shikijs/engine-javascript@2.5.0':
+    resolution: {integrity: sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==}
+
+  '@shikijs/engine-oniguruma@2.5.0':
+    resolution: {integrity: sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==}
+
+  '@shikijs/langs@2.5.0':
+    resolution: {integrity: sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==}
+
+  '@shikijs/themes@2.5.0':
+    resolution: {integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==}
+
+  '@shikijs/transformers@2.5.0':
+    resolution: {integrity: sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==}
+
+  '@shikijs/types@2.5.0':
+    resolution: {integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
-  "@vue/compiler-core@3.5.32":
-    resolution:
-      integrity: sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==
-  "@vue/compiler-dom@3.5.32":
-    resolution:
-      integrity: sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==
-  "@vue/compiler-sfc@3.5.32":
-    resolution:
-      integrity: sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==
-  "@vue/compiler-ssr@3.5.32":
-    resolution:
-      integrity: sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==
-  "@vue/devtools-api@7.7.9":
-    resolution:
-      integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==
-  "@vue/devtools-kit@7.7.9":
-    resolution:
-      integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==
-  "@vue/devtools-shared@7.7.9":
-    resolution:
-      integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==
-  "@vue/reactivity@3.5.32":
-    resolution:
-      integrity: sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==
-  "@vue/runtime-core@3.5.32":
-    resolution:
-      integrity: sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==
-  "@vue/runtime-dom@3.5.32":
-    resolution:
-      integrity: sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==
-  "@vue/server-renderer@3.5.32":
-    resolution:
-      integrity: sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==
-    peerDependencies:
-      vue: 3.5.32
-  "@vue/shared@3.5.32":
-    resolution:
-      integrity: sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==
-  "@vueuse/core@12.8.2":
-    resolution:
-      integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==
-  "@vueuse/integrations@12.8.2":
-    resolution:
-      integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==
+
+  '@vue/compiler-core@3.5.40':
+    resolution: {integrity: sha512-39E8IgOhTbVDnoJFMKc2DvYnypcZwUqgUhQkccva/0m6FUwtIKSGV7n1hpVmYcFaoRAwf9pBcwnKlCEsN63ZEQ==}
+
+  '@vue/compiler-dom@3.5.40':
+    resolution: {integrity: sha512-pwkx4vqlqOspFstrcmzwkKLePVMD3PT65imRzLhanU2V1Fj4K13g6OXjanOyzw3aTAuRk84BOmY8f3rEHqPaVA==}
+
+  '@vue/compiler-sfc@3.5.40':
+    resolution: {integrity: sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==}
+
+  '@vue/compiler-ssr@3.5.40':
+    resolution: {integrity: sha512-rrE5xiXG663+vHCHa3J9p2z5OcBRjXmoqenprJxAFQxg5pSshzeBiCE6pu46axapRJ2Adk0YDA2BRZVjiHXnhg==}
+
+  '@vue/devtools-api@7.7.10':
+    resolution: {integrity: sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==}
+
+  '@vue/devtools-kit@7.7.10':
+    resolution: {integrity: sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==}
+
+  '@vue/devtools-shared@7.7.10':
+    resolution: {integrity: sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==}
+
+  '@vue/reactivity@3.5.40':
+    resolution: {integrity: sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==}
+
+  '@vue/runtime-core@3.5.40':
+    resolution: {integrity: sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==}
+
+  '@vue/runtime-dom@3.5.40':
+    resolution: {integrity: sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==}
+
+  '@vue/server-renderer@3.5.40':
+    resolution: {integrity: sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==}
+
+  '@vue/shared@3.5.40':
+    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
+
+  '@vueuse/core@12.8.2':
+    resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
+
+  '@vueuse/integrations@12.8.2':
+    resolution: {integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==}
     peerDependencies:
       async-validator: ^4
       axios: ^1
@@ -691,405 +365,427 @@ packages:
         optional: true
       universal-cookie:
         optional: true
-  "@vueuse/metadata@12.8.2":
-    resolution:
-      integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==
-  "@vueuse/shared@12.8.2":
-    resolution:
-      integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==
+
+  '@vueuse/metadata@12.8.2':
+    resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
+
+  '@vueuse/shared@12.8.2':
+    resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
+
   acorn-jsx@5.3.2:
-    resolution:
-      integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-  acorn@8.16.0:
-    resolution:
-      integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
-  ajv@6.14.0:
-    resolution:
-      integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==
-  algoliasearch@5.50.2:
-    resolution:
-      integrity: sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  algoliasearch@5.56.0:
+    resolution: {integrity: sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==}
+    engines: {node: '>= 14.0.0'}
+
   balanced-match@4.0.4:
-    resolution:
-      integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   birpc@2.9.0:
-    resolution:
-      integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==
-  brace-expansion@5.0.5:
-    resolution:
-      integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+    resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
+
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
+
   ccount@2.0.1:
-    resolution:
-      integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   character-entities-html4@2.1.0:
-    resolution:
-      integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
   character-entities-legacy@3.0.0:
-    resolution:
-      integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
   comma-separated-tokens@2.0.3:
-    resolution:
-      integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
   copy-anything@4.0.5:
-    resolution:
-      integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==
+    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
-    resolution:
-      integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   csstype@3.2.3:
-    resolution:
-      integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   debug@4.4.3:
-    resolution:
-      integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
     peerDependenciesMeta:
       supports-color:
         optional: true
+
   deep-is@0.1.4:
-    resolution:
-      integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   dequal@2.0.3:
-    resolution:
-      integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   devlop@1.1.0:
-    resolution:
-      integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
   emoji-regex-xs@1.0.0:
-    resolution:
-      integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
   entities@7.0.1:
-    resolution:
-      integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   esbuild@0.21.5:
-    resolution:
-      integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   escape-string-regexp@4.0.0:
-    resolution:
-      integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
   eslint-scope@9.1.2:
-    resolution:
-      integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint-visitor-keys@3.4.3:
-    resolution:
-      integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   eslint-visitor-keys@5.0.1:
-    resolution:
-      integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
-  eslint@10.2.1:
-    resolution:
-      integrity: sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.7.0:
+    resolution: {integrity: sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
     peerDependencies:
-      jiti: "*"
+      jiti: '*'
     peerDependenciesMeta:
       jiti:
         optional: true
+
   espree@11.2.0:
-    resolution:
-      integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   esquery@1.7.0:
-    resolution:
-      integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
   esrecurse@4.3.0:
-    resolution:
-      integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
   estraverse@5.3.0:
-    resolution:
-      integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@2.0.2:
-    resolution:
-      integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   esutils@2.0.3:
-    resolution:
-      integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
   fast-deep-equal@3.1.3:
-    resolution:
-      integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-json-stable-stringify@2.1.0:
-    resolution:
-      integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
   fast-levenshtein@2.0.6:
-    resolution:
-      integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
-  fdir@6.5.0:
-    resolution:
-      integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   file-entry-cache@8.0.0:
-    resolution:
-      integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   find-up@5.0.0:
-    resolution:
-      integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   flat-cache@4.0.1:
-    resolution:
-      integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
   flatted@3.4.2:
-    resolution:
-      integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
   focus-trap@7.8.0:
-    resolution:
-      integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==
-  fsevents@2.3.3:
-    resolution:
-      integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-    os:
-      - darwin
+    resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+
   glob-parent@6.0.2:
-    resolution:
-      integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
-  globals@17.5.0:
-    resolution:
-      integrity: sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@17.7.0:
+    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
+    engines: {node: '>=18'}
+
   hast-util-to-html@9.0.5:
-    resolution:
-      integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-whitespace@3.0.0:
-    resolution:
-      integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hookable@5.5.3:
-    resolution:
-      integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
   html-void-elements@3.0.0:
-    resolution:
-      integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
   ignore@5.3.2:
-    resolution:
-      integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
-  ignore@7.0.5:
-    resolution:
-      integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
   imurmurhash@0.1.4:
-    resolution:
-      integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   is-extglob@2.1.1:
-    resolution:
-      integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-glob@4.0.3:
-    resolution:
-      integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
   is-what@5.5.0:
-    resolution:
-      integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
+
   isexe@2.0.0:
-    resolution:
-      integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   json-buffer@3.0.1:
-    resolution:
-      integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
   json-schema-traverse@0.4.1:
-    resolution:
-      integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
   json-stable-stringify-without-jsonify@1.0.1:
-    resolution:
-      integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
   keyv@4.5.4:
-    resolution:
-      integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   levn@0.4.1:
-    resolution:
-      integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
   locate-path@6.0.0:
-    resolution:
-      integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   magic-string@0.30.21:
-    resolution:
-      integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   mark.js@8.11.1:
-    resolution:
-      integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==
+    resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
+
   mdast-util-to-hast@13.2.1:
-    resolution:
-      integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
   micromark-util-character@2.1.1:
-    resolution:
-      integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
   micromark-util-encode@2.0.1:
-    resolution:
-      integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
   micromark-util-sanitize-uri@2.0.1:
-    resolution:
-      integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
   micromark-util-symbol@2.0.1:
-    resolution:
-      integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
   micromark-util-types@2.0.2:
-    resolution:
-      integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
   minimatch@10.2.5:
-    resolution:
-      integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minisearch@7.2.0:
-    resolution:
-      integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
+
   mitt@3.0.1:
-    resolution:
-      integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   ms@2.1.3:
-    resolution:
-      integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-  nanoid@3.3.11:
-    resolution:
-      integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
-    resolution:
-      integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   oniguruma-to-es@3.1.1:
-    resolution:
-      integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==
+    resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
+
   optionator@0.9.4:
-    resolution:
-      integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
   p-limit@3.1.0:
-    resolution:
-      integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
   p-locate@5.0.0:
-    resolution:
-      integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
   path-exists@4.0.0:
-    resolution:
-      integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
   path-key@3.1.1:
-    resolution:
-      integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   perfect-debounce@1.0.0:
-    resolution:
-      integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
   picocolors@1.1.1:
-    resolution:
-      integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
-  picomatch@4.0.4:
-    resolution:
-      integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
-  postcss@8.5.10:
-    resolution:
-      integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
-  preact@10.29.1:
-    resolution:
-      integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.20:
+    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  preact@10.29.7:
+    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
   prelude-ls@1.2.1:
-    resolution:
-      integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
-  property-information@7.1.0:
-    resolution:
-      integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   punycode@2.3.1:
-    resolution:
-      integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   regex-recursion@6.0.2:
-    resolution:
-      integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
   regex-utilities@2.3.0:
-    resolution:
-      integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
   regex@6.1.0:
-    resolution:
-      integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   rfdc@1.4.1:
-    resolution:
-      integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
-  rollup@4.60.2:
-    resolution:
-      integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   search-insights@2.17.3:
-    resolution:
-      integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==
-  semver@7.7.4:
-    resolution:
-      integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+    resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
+
   shebang-command@2.0.0:
-    resolution:
-      integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
   shebang-regex@3.0.0:
-    resolution:
-      integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   shiki@2.5.0:
-    resolution:
-      integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==
+    resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
+
   source-map-js@1.2.1:
-    resolution:
-      integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   space-separated-tokens@2.0.2:
-    resolution:
-      integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   speakingurl@14.0.1:
-    resolution:
-      integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==
+    resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
+    engines: {node: '>=0.10.0'}
+
   stringify-entities@4.0.4:
-    resolution:
-      integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   superjson@2.2.6:
-    resolution:
-      integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==
-  tabbable@6.4.0:
-    resolution:
-      integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==
-  tinyglobby@0.2.16:
-    resolution:
-      integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
+
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
+
   trim-lines@3.0.1:
-    resolution:
-      integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
-  ts-api-utils@2.5.0:
-    resolution:
-      integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
-    peerDependencies:
-      typescript: ">=4.8.4"
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   type-check@0.4.0:
-    resolution:
-      integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
-  typescript-eslint@8.58.2:
-    resolution:
-      integrity: sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-  typescript@6.0.3:
-    resolution:
-      integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   unist-util-is@6.0.1:
-    resolution:
-      integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
   unist-util-position@5.0.0:
-    resolution:
-      integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
   unist-util-stringify-position@4.0.0:
-    resolution:
-      integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
   unist-util-visit-parents@6.0.2:
-    resolution:
-      integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
   unist-util-visit@5.1.0:
-    resolution:
-      integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   uri-js@4.4.1:
-    resolution:
-      integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
   vfile-message@4.0.3:
-    resolution:
-      integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
   vfile@6.0.3:
-    resolution:
-      integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
   vite@5.4.21:
-    resolution:
-      integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
     peerDependencies:
-      "@types/node": ^18.0.0 || >=20.0.0
-      less: "*"
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
       lightningcss: ^1.21.0
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
       terser: ^5.4.0
     peerDependenciesMeta:
-      "@types/node":
+      '@types/node':
         optional: true
       less:
         optional: true
@@ -1105,9 +801,10 @@ packages:
         optional: true
       terser:
         optional: true
+
   vitepress@1.6.4:
-    resolution:
-      integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==
+    resolution: {integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==}
+    hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
       postcss: ^8
@@ -1116,469 +813,498 @@ packages:
         optional: true
       postcss:
         optional: true
-  vue@3.5.32:
-    resolution:
-      integrity: sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==
+
+  vue@3.5.40:
+    resolution: {integrity: sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==}
     peerDependencies:
-      typescript: "*"
+      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
+
   which@2.0.2:
-    resolution:
-      integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   word-wrap@1.2.5:
-    resolution:
-      integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   yocto-queue@0.1.0:
-    resolution:
-      integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
   zwitch@2.0.4:
-    resolution:
-      integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
-  "@algolia/abtesting@1.16.2":
+
+  '@algolia/abtesting@1.22.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/autocomplete-core@1.17.7":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/autocomplete-core@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)':
     dependencies:
-      "@algolia/autocomplete-plugin-algolia-insights": 1.17.7(search-insights@2.17.3)
-      "@algolia/autocomplete-shared": 1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)
-  "@algolia/autocomplete-plugin-algolia-insights@1.17.7(search-insights@2.17.3)":
+      '@algolia/autocomplete-plugin-algolia-insights': 1.17.7(search-insights@2.17.3)
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7(search-insights@2.17.3)':
     dependencies:
-      "@algolia/autocomplete-shared": 1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
       search-insights: 2.17.3
-  "@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)":
+
+  '@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)':
     dependencies:
-      "@algolia/autocomplete-shared": 1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)
-      "@algolia/client-search": 5.50.2
-      algoliasearch: 5.50.2
-  "@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)":
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
+      '@algolia/client-search': 5.56.0
+      algoliasearch: 5.56.0
+
+  '@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)':
     dependencies:
-      "@algolia/client-search": 5.50.2
-      algoliasearch: 5.50.2
-  "@algolia/client-abtesting@5.50.2":
+      '@algolia/client-search': 5.56.0
+      algoliasearch: 5.56.0
+
+  '@algolia/client-abtesting@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/client-analytics@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-analytics@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/client-common@5.50.2": {}
-  "@algolia/client-insights@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-common@5.56.0': {}
+
+  '@algolia/client-insights@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/client-personalization@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-personalization@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/client-query-suggestions@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-query-suggestions@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/client-search@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/client-search@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/ingestion@1.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/ingestion@1.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/monitoring@1.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/monitoring@1.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/recommend@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/recommend@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
-  "@algolia/requester-browser-xhr@5.50.2":
+      '@algolia/client-common': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
+  '@algolia/requester-browser-xhr@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-  "@algolia/requester-fetch@5.50.2":
+      '@algolia/client-common': 5.56.0
+
+  '@algolia/requester-fetch@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-  "@algolia/requester-node-http@5.50.2":
+      '@algolia/client-common': 5.56.0
+
+  '@algolia/requester-node-http@5.56.0':
     dependencies:
-      "@algolia/client-common": 5.50.2
-  "@babel/helper-string-parser@7.27.1": {}
-  "@babel/helper-validator-identifier@7.28.5": {}
-  "@babel/parser@7.29.2":
+      '@algolia/client-common': 5.56.0
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
     dependencies:
-      "@babel/types": 7.29.0
-  "@babel/types@7.29.0":
+      '@babel/types': 7.29.7
+
+  '@babel/types@7.29.7':
     dependencies:
-      "@babel/helper-string-parser": 7.27.1
-      "@babel/helper-validator-identifier": 7.28.5
-  "@docsearch/css@3.8.2": {}
-  "@docsearch/js@3.8.2":
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@docsearch/css@3.8.2': {}
+
+  '@docsearch/js@3.8.2(search-insights@2.17.3)':
     dependencies:
-      "@docsearch/react": 3.8.2(search-insights@2.17.3)
-      preact: 10.29.1
-  "@docsearch/react@3.8.2(search-insights@2.17.3)":
+      '@docsearch/react': 3.8.2(search-insights@2.17.3)
+      preact: 10.29.7
+
+  '@docsearch/react@3.8.2(search-insights@2.17.3)':
     dependencies:
-      "@algolia/autocomplete-core": 1.17.7
-      "@algolia/autocomplete-preset-algolia": 1.17.7(@algolia/client-search@5.50.2)(algoliasearch@5.50.2)
-      "@docsearch/css": 3.8.2
-      algoliasearch: 5.50.2
+      '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
+      '@docsearch/css': 3.8.2
+      algoliasearch: 5.56.0
       search-insights: 2.17.3
-  "@esbuild/darwin-arm64@0.21.5": {}
-  "@esbuild/darwin-x64@0.21.5": {}
-  "@esbuild/linux-arm64@0.21.5": {}
-  "@esbuild/linux-x64@0.21.5": {}
-  "@eslint-community/eslint-utils@4.9.1(eslint@10.2.1)":
+
+  '@esbuild/linux-x64@0.21.5': {}
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.7.0)':
     dependencies:
-      eslint: 10.2.1
+      eslint: 10.7.0
       eslint-visitor-keys: 3.4.3
-  "@eslint-community/regexpp@4.12.2": {}
-  "@eslint/config-array@0.23.5":
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
     dependencies:
-      "@eslint/object-schema": 3.0.5
+      '@eslint/object-schema': 3.0.5
       debug: 4.4.3
       minimatch: 10.2.5
-  "@eslint/config-helpers@0.5.5":
+
+  '@eslint/config-helpers@0.6.0':
     dependencies:
-      "@eslint/core": 1.2.1
-  "@eslint/core@1.2.1":
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
     dependencies:
-      "@types/json-schema": 7.0.15
-  "@eslint/object-schema@3.0.5": {}
-  "@eslint/plugin-kit@0.7.1":
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
     dependencies:
-      "@eslint/core": 1.2.1
+      '@eslint/core': 1.2.1
       levn: 0.4.1
-  "@humanfs/core@0.19.2":
+
+  '@humanfs/core@0.19.2':
     dependencies:
-      "@humanfs/types": 0.15.0
-  "@humanfs/node@0.16.8":
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
     dependencies:
-      "@humanfs/core": 0.19.2
-      "@humanfs/types": 0.15.0
-      "@humanwhocodes/retry": 0.4.3
-  "@humanfs/types@0.15.0": {}
-  "@humanwhocodes/module-importer@1.0.1": {}
-  "@humanwhocodes/retry@0.4.3": {}
-  "@iconify-json/simple-icons@1.2.78":
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify-json/simple-icons@1.2.91':
     dependencies:
-      "@iconify/types": 2.0.0
-  "@iconify/types@2.0.0": {}
-  "@jridgewell/sourcemap-codec@1.5.5": {}
-  "@rollup/rollup-darwin-arm64@4.60.2": {}
-  "@rollup/rollup-darwin-x64@4.60.2": {}
-  "@rollup/rollup-linux-arm64-gnu@4.60.2": {}
-  "@rollup/rollup-linux-arm64-musl@4.60.2": {}
-  "@rollup/rollup-linux-x64-gnu@4.60.2": {}
-  "@rollup/rollup-linux-x64-musl@4.60.2": {}
-  "@shikijs/core@2.5.0":
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2': {}
+
+  '@shikijs/core@2.5.0':
     dependencies:
-      "@shikijs/engine-javascript": 2.5.0
-      "@shikijs/engine-oniguruma": 2.5.0
-      "@shikijs/types": 2.5.0
-      "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
       hast-util-to-html: 9.0.5
-  "@shikijs/engine-javascript@2.5.0":
+
+  '@shikijs/engine-javascript@2.5.0':
     dependencies:
-      "@shikijs/types": 2.5.0
-      "@shikijs/vscode-textmate": 10.0.2
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 3.1.1
-  "@shikijs/engine-oniguruma@2.5.0":
+
+  '@shikijs/engine-oniguruma@2.5.0':
     dependencies:
-      "@shikijs/types": 2.5.0
-      "@shikijs/vscode-textmate": 10.0.2
-  "@shikijs/langs@2.5.0":
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@2.5.0':
     dependencies:
-      "@shikijs/types": 2.5.0
-  "@shikijs/themes@2.5.0":
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/themes@2.5.0':
     dependencies:
-      "@shikijs/types": 2.5.0
-  "@shikijs/transformers@2.5.0":
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/transformers@2.5.0':
     dependencies:
-      "@shikijs/core": 2.5.0
-      "@shikijs/types": 2.5.0
-  "@shikijs/types@2.5.0":
+      '@shikijs/core': 2.5.0
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/types@2.5.0':
     dependencies:
-      "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
-  "@shikijs/vscode-textmate@10.0.2": {}
-  "@types/esrecurse@4.3.1": {}
-  "@types/estree@1.0.8": {}
-  "@types/hast@3.0.4":
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@types/esrecurse@4.3.1': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/hast@3.0.5':
     dependencies:
-      "@types/unist": 3.0.3
-  "@types/json-schema@7.0.15": {}
-  "@types/linkify-it@5.0.0": {}
-  "@types/markdown-it@14.1.2":
+      '@types/unist': 3.0.3
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
     dependencies:
-      "@types/linkify-it": 5.0.0
-      "@types/mdurl": 2.0.0
-  "@types/mdast@4.0.4":
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdast@4.0.4':
     dependencies:
-      "@types/unist": 3.0.3
-  "@types/mdurl@2.0.0": {}
-  "@types/unist@3.0.3": {}
-  "@types/web-bluetooth@0.0.21": {}
-  "@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3)":
-    dependencies:
-      "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      "@typescript-eslint/scope-manager": 8.58.2
-      "@typescript-eslint/type-utils": 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      "@typescript-eslint/visitor-keys": 8.58.2
-      eslint: 10.2.1
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-  "@typescript-eslint/parser@8.58.2(eslint@10.2.1)(typescript@6.0.3)":
-    dependencies:
-      "@typescript-eslint/scope-manager": 8.58.2
-      "@typescript-eslint/types": 8.58.2
-      "@typescript-eslint/typescript-estree": 8.58.2(typescript@6.0.3)
-      "@typescript-eslint/visitor-keys": 8.58.2
-      debug: 4.4.3
-      eslint: 10.2.1
-      typescript: 6.0.3
-  "@typescript-eslint/project-service@8.58.2(typescript@6.0.3)":
-    dependencies:
-      "@typescript-eslint/tsconfig-utils": 8.58.2(typescript@6.0.3)
-      "@typescript-eslint/types": 8.58.2
-      debug: 4.4.3
-      typescript: 6.0.3
-  "@typescript-eslint/scope-manager@8.58.2":
-    dependencies:
-      "@typescript-eslint/types": 8.58.2
-      "@typescript-eslint/visitor-keys": 8.58.2
-  "@typescript-eslint/tsconfig-utils@8.58.2(typescript@6.0.3)":
-    dependencies:
-      typescript: 6.0.3
-  "@typescript-eslint/type-utils@8.58.2(eslint@10.2.1)(typescript@6.0.3)":
-    dependencies:
-      "@typescript-eslint/types": 8.58.2
-      "@typescript-eslint/typescript-estree": 8.58.2(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      debug: 4.4.3
-      eslint: 10.2.1
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-  "@typescript-eslint/types@8.58.2": {}
-  "@typescript-eslint/typescript-estree@8.58.2(typescript@6.0.3)":
-    dependencies:
-      "@typescript-eslint/project-service": 8.58.2(typescript@6.0.3)
-      "@typescript-eslint/tsconfig-utils": 8.58.2(typescript@6.0.3)
-      "@typescript-eslint/types": 8.58.2
-      "@typescript-eslint/visitor-keys": 8.58.2
-      debug: 4.4.3
-      minimatch: 10.2.5
-      semver: 7.7.4
-      tinyglobby: 0.2.16
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-  "@typescript-eslint/utils@8.58.2(eslint@10.2.1)(typescript@6.0.3)":
-    dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@10.2.1)
-      "@typescript-eslint/scope-manager": 8.58.2
-      "@typescript-eslint/types": 8.58.2
-      "@typescript-eslint/typescript-estree": 8.58.2(typescript@6.0.3)
-      eslint: 10.2.1
-      typescript: 6.0.3
-  "@typescript-eslint/visitor-keys@8.58.2":
-    dependencies:
-      "@typescript-eslint/types": 8.58.2
-      eslint-visitor-keys: 5.0.1
-  "@ungap/structured-clone@1.3.0": {}
-  "@vitejs/plugin-vue@5.2.4(vite@5.4.21)(vue@3.5.32(typescript@6.0.3))":
+      '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@types/web-bluetooth@0.0.21': {}
+
+  '@ungap/structured-clone@1.3.3': {}
+
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21)(vue@3.5.40)':
     dependencies:
       vite: 5.4.21
-      vue: 3.5.32(typescript@6.0.3)
-  "@vue/compiler-core@3.5.32":
+      vue: 3.5.40
+
+  '@vue/compiler-core@3.5.40':
     dependencies:
-      "@babel/parser": 7.29.2
-      "@vue/shared": 3.5.32
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.40
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
-  "@vue/compiler-dom@3.5.32":
+
+  '@vue/compiler-dom@3.5.40':
     dependencies:
-      "@vue/compiler-core": 3.5.32
-      "@vue/shared": 3.5.32
-  "@vue/compiler-sfc@3.5.32":
+      '@vue/compiler-core': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/compiler-sfc@3.5.40':
     dependencies:
-      "@babel/parser": 7.29.2
-      "@vue/compiler-core": 3.5.32
-      "@vue/compiler-dom": 3.5.32
-      "@vue/compiler-ssr": 3.5.32
-      "@vue/shared": 3.5.32
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.40
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/shared': 3.5.40
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.10
+      postcss: 8.5.20
       source-map-js: 1.2.1
-  "@vue/compiler-ssr@3.5.32":
+
+  '@vue/compiler-ssr@3.5.40':
     dependencies:
-      "@vue/compiler-dom": 3.5.32
-      "@vue/shared": 3.5.32
-  "@vue/devtools-api@7.7.9":
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/devtools-api@7.7.10':
     dependencies:
-      "@vue/devtools-kit": 7.7.9
-  "@vue/devtools-kit@7.7.9":
+      '@vue/devtools-kit': 7.7.10
+
+  '@vue/devtools-kit@7.7.10':
     dependencies:
-      "@vue/devtools-shared": 7.7.9
+      '@vue/devtools-shared': 7.7.10
       birpc: 2.9.0
       hookable: 5.5.3
       mitt: 3.0.1
       perfect-debounce: 1.0.0
       speakingurl: 14.0.1
       superjson: 2.2.6
-  "@vue/devtools-shared@7.7.9":
+
+  '@vue/devtools-shared@7.7.10':
     dependencies:
       rfdc: 1.4.1
-  "@vue/reactivity@3.5.32":
+
+  '@vue/reactivity@3.5.40':
     dependencies:
-      "@vue/shared": 3.5.32
-  "@vue/runtime-core@3.5.32":
+      '@vue/shared': 3.5.40
+
+  '@vue/runtime-core@3.5.40':
     dependencies:
-      "@vue/reactivity": 3.5.32
-      "@vue/shared": 3.5.32
-  "@vue/runtime-dom@3.5.32":
+      '@vue/reactivity': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/runtime-dom@3.5.40':
     dependencies:
-      "@vue/reactivity": 3.5.32
-      "@vue/runtime-core": 3.5.32
-      "@vue/shared": 3.5.32
+      '@vue/reactivity': 3.5.40
+      '@vue/runtime-core': 3.5.40
+      '@vue/shared': 3.5.40
       csstype: 3.2.3
-  "@vue/server-renderer@3.5.32(vue@3.5.32(typescript@6.0.3))":
+
+  '@vue/server-renderer@3.5.40':
     dependencies:
-      "@vue/compiler-ssr": 3.5.32
-      "@vue/shared": 3.5.32
-      vue: 3.5.32(typescript@6.0.3)
-  "@vue/shared@3.5.32": {}
-  "@vueuse/core@12.8.2":
+      '@vue/compiler-ssr': 3.5.40
+      '@vue/runtime-dom': 3.5.40
+      '@vue/shared': 3.5.40
+
+  '@vue/shared@3.5.40': {}
+
+  '@vueuse/core@12.8.2':
     dependencies:
-      "@types/web-bluetooth": 0.0.21
-      "@vueuse/metadata": 12.8.2
-      "@vueuse/shared": 12.8.2
-      vue: 3.5.32(typescript@6.0.3)
-  "@vueuse/integrations@12.8.2(focus-trap@7.8.0)":
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 12.8.2
+      '@vueuse/shared': 12.8.2
+      vue: 3.5.40
+
+  '@vueuse/integrations@12.8.2(focus-trap@7.8.0)':
     dependencies:
-      "@vueuse/core": 12.8.2
-      "@vueuse/shared": 12.8.2
+      '@vueuse/core': 12.8.2
+      '@vueuse/shared': 12.8.2
       focus-trap: 7.8.0
-      vue: 3.5.32(typescript@6.0.3)
-  "@vueuse/metadata@12.8.2": {}
-  "@vueuse/shared@12.8.2":
+      vue: 3.5.40
+
+  '@vueuse/metadata@12.8.2': {}
+
+  '@vueuse/shared@12.8.2':
     dependencies:
-      vue: 3.5.32(typescript@6.0.3)
-  acorn-jsx@5.3.2(acorn@8.16.0):
+      vue: 3.5.40
+
+  acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
-  acorn@8.16.0: {}
-  ajv@6.14.0:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-  algoliasearch@5.50.2:
+
+  algoliasearch@5.56.0:
     dependencies:
-      "@algolia/abtesting": 1.16.2
-      "@algolia/client-abtesting": 5.50.2
-      "@algolia/client-analytics": 5.50.2
-      "@algolia/client-common": 5.50.2
-      "@algolia/client-insights": 5.50.2
-      "@algolia/client-personalization": 5.50.2
-      "@algolia/client-query-suggestions": 5.50.2
-      "@algolia/client-search": 5.50.2
-      "@algolia/ingestion": 1.50.2
-      "@algolia/monitoring": 1.50.2
-      "@algolia/recommend": 5.50.2
-      "@algolia/requester-browser-xhr": 5.50.2
-      "@algolia/requester-fetch": 5.50.2
-      "@algolia/requester-node-http": 5.50.2
+      '@algolia/abtesting': 1.22.0
+      '@algolia/client-abtesting': 5.56.0
+      '@algolia/client-analytics': 5.56.0
+      '@algolia/client-common': 5.56.0
+      '@algolia/client-insights': 5.56.0
+      '@algolia/client-personalization': 5.56.0
+      '@algolia/client-query-suggestions': 5.56.0
+      '@algolia/client-search': 5.56.0
+      '@algolia/ingestion': 1.56.0
+      '@algolia/monitoring': 1.56.0
+      '@algolia/recommend': 5.56.0
+      '@algolia/requester-browser-xhr': 5.56.0
+      '@algolia/requester-fetch': 5.56.0
+      '@algolia/requester-node-http': 5.56.0
+
   balanced-match@4.0.4: {}
+
   birpc@2.9.0: {}
-  brace-expansion@5.0.5:
+
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
+
   ccount@2.0.1: {}
+
   character-entities-html4@2.1.0: {}
+
   character-entities-legacy@3.0.0: {}
+
   comma-separated-tokens@2.0.3: {}
+
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
   csstype@3.2.3: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
   deep-is@0.1.4: {}
+
   dequal@2.0.3: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
   emoji-regex-xs@1.0.0: {}
+
   entities@7.0.1: {}
+
   esbuild@0.21.5:
     optionalDependencies:
-      "@esbuild/darwin-arm64": 0.21.5
-      "@esbuild/darwin-x64": 0.21.5
-      "@esbuild/linux-arm64": 0.21.5
-      "@esbuild/linux-x64": 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+
   escape-string-regexp@4.0.0: {}
+
   eslint-scope@9.1.2:
     dependencies:
-      "@types/esrecurse": 4.3.1
-      "@types/estree": 1.0.8
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
       esrecurse: 4.3.0
       estraverse: 5.3.0
+
   eslint-visitor-keys@3.4.3: {}
+
   eslint-visitor-keys@5.0.1: {}
-  eslint@10.2.1:
+
+  eslint@10.7.0:
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@10.2.1)
-      "@eslint-community/regexpp": 4.12.2
-      "@eslint/config-array": 0.23.5
-      "@eslint/config-helpers": 0.5.5
-      "@eslint/core": 1.2.1
-      "@eslint/plugin-kit": 0.7.1
-      "@humanfs/node": 0.16.8
-      "@humanwhocodes/module-importer": 1.0.1
-      "@humanwhocodes/retry": 0.4.3
-      "@types/estree": 1.0.8
-      ajv: 6.14.0
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.7.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
       cross-spawn: 7.0.6
       debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
+      espree: 11.2.0(acorn@8.17.0)
       esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -1592,126 +1318,169 @@ snapshots:
       minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
-  espree@11.2.0:
+
+  espree@11.2.0(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
+
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
+
   estraverse@5.3.0: {}
+
   estree-walker@2.0.2: {}
+
   esutils@2.0.3: {}
+
   fast-deep-equal@3.1.3: {}
+
   fast-json-stable-stringify@2.1.0: {}
+
   fast-levenshtein@2.0.6: {}
-  fdir@6.5.0(picomatch@4.0.4):
-    dependencies:
-      picomatch: 4.0.4
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.4.2
       keyv: 4.5.4
+
   flatted@3.4.2: {}
+
   focus-trap@7.8.0:
     dependencies:
-      tabbable: 6.4.0
-  fsevents@2.3.3: {}
+      tabbable: 6.5.0
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-  globals@17.5.0: {}
+
+  globals@17.7.0: {}
+
   hast-util-to-html@9.0.5:
     dependencies:
-      "@types/hast": 3.0.4
-      "@types/unist": 3.0.3
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
       ccount: 2.0.1
       comma-separated-tokens: 2.0.3
       hast-util-whitespace: 3.0.0
       html-void-elements: 3.0.0
       mdast-util-to-hast: 13.2.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
-      "@types/hast": 3.0.4
+      '@types/hast': 3.0.5
+
   hookable@5.5.3: {}
+
   html-void-elements@3.0.0: {}
+
   ignore@5.3.2: {}
-  ignore@7.0.5: {}
+
   imurmurhash@0.1.4: {}
+
   is-extglob@2.1.1: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
   is-what@5.5.0: {}
+
   isexe@2.0.0: {}
+
   json-buffer@3.0.1: {}
+
   json-schema-traverse@0.4.1: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
   magic-string@0.30.21:
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   mark.js@8.11.1: {}
+
   mdast-util-to-hast@13.2.1:
     dependencies:
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
-      "@ungap/structured-clone": 1.3.0
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+
   micromark-util-character@2.1.1:
     dependencies:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
+
   micromark-util-encode@2.0.1: {}
+
   micromark-util-sanitize-uri@2.0.1:
     dependencies:
       micromark-util-character: 2.1.1
       micromark-util-encode: 2.0.1
       micromark-util-symbol: 2.0.1
+
   micromark-util-symbol@2.0.1: {}
+
   micromark-util-types@2.0.2: {}
+
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.7
+
   minisearch@7.2.0: {}
+
   mitt@3.0.1: {}
+
   ms@2.1.3: {}
-  nanoid@3.3.11: {}
+
+  nanoid@3.3.16: {}
+
   natural-compare@1.4.0: {}
+
   oniguruma-to-es@3.1.1:
     dependencies:
       emoji-regex-xs: 1.0.0
       regex: 6.1.0
       regex-recursion: 6.0.2
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -1720,160 +1489,176 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
   path-exists@4.0.0: {}
+
   path-key@3.1.1: {}
+
   perfect-debounce@1.0.0: {}
+
   picocolors@1.1.1: {}
-  picomatch@4.0.4: {}
-  postcss@8.5.10:
+
+  postcss@8.5.20:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
-  preact@10.29.1: {}
+
+  preact@10.29.7: {}
+
   prelude-ls@1.2.1: {}
-  property-information@7.1.0: {}
+
+  property-information@7.2.0: {}
+
   punycode@2.3.1: {}
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
+
   regex-utilities@2.3.0: {}
+
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
   rfdc@1.4.1: {}
-  rollup@4.60.2:
+
+  rollup@4.62.2:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.9
     optionalDependencies:
-      "@rollup/rollup-darwin-arm64": 4.60.2
-      "@rollup/rollup-darwin-x64": 4.60.2
-      "@rollup/rollup-linux-arm64-gnu": 4.60.2
-      "@rollup/rollup-linux-arm64-musl": 4.60.2
-      "@rollup/rollup-linux-x64-gnu": 4.60.2
-      "@rollup/rollup-linux-x64-musl": 4.60.2
-      fsevents: 2.3.3
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+
   search-insights@2.17.3: {}
-  semver@7.7.4: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
+
   shebang-regex@3.0.0: {}
+
   shiki@2.5.0:
     dependencies:
-      "@shikijs/core": 2.5.0
-      "@shikijs/engine-javascript": 2.5.0
-      "@shikijs/engine-oniguruma": 2.5.0
-      "@shikijs/langs": 2.5.0
-      "@shikijs/themes": 2.5.0
-      "@shikijs/types": 2.5.0
-      "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
+      '@shikijs/core': 2.5.0
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/langs': 2.5.0
+      '@shikijs/themes': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
   source-map-js@1.2.1: {}
+
   space-separated-tokens@2.0.2: {}
+
   speakingurl@14.0.1: {}
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
-  tabbable@6.4.0: {}
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+
+  tabbable@6.5.0: {}
+
   trim-lines@3.0.1: {}
-  ts-api-utils@2.5.0(typescript@6.0.3):
-    dependencies:
-      typescript: 6.0.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-  typescript-eslint@8.58.2(eslint@10.2.1)(typescript@6.0.3):
-    dependencies:
-      "@typescript-eslint/eslint-plugin": 8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.1)(typescript@6.0.3))(eslint@10.2.1)(typescript@6.0.3)
-      "@typescript-eslint/parser": 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      "@typescript-eslint/typescript-estree": 8.58.2(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.58.2(eslint@10.2.1)(typescript@6.0.3)
-      eslint: 10.2.1
-      typescript: 6.0.3
-  typescript@6.0.3: {}
+
   unist-util-is@6.0.1:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
+
   unist-util-position@5.0.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
+
   unist-util-stringify-position@4.0.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
+
   unist-util-visit-parents@6.0.2:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.1
+
   unist-util-visit@5.1.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
   vfile-message@4.0.3:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
+
   vfile@6.0.3:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
   vite@5.4.21:
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.10
-      rollup: 4.60.2
-    optionalDependencies:
-      fsevents: 2.3.3
-  vitepress@1.6.4(postcss@8.5.10):
+      postcss: 8.5.20
+      rollup: 4.62.2
+
+  vitepress@1.6.4(postcss@8.5.20):
     dependencies:
-      "@docsearch/css": 3.8.2
-      "@docsearch/js": 3.8.2
-      "@iconify-json/simple-icons": 1.2.78
-      "@shikijs/core": 2.5.0
-      "@shikijs/transformers": 2.5.0
-      "@shikijs/types": 2.5.0
-      "@types/markdown-it": 14.1.2
-      "@vitejs/plugin-vue": 5.2.4(vite@5.4.21)(vue@3.5.32(typescript@6.0.3))
-      "@vue/devtools-api": 7.7.9
-      "@vue/shared": 3.5.32
-      "@vueuse/core": 12.8.2
-      "@vueuse/integrations": 12.8.2(focus-trap@7.8.0)
+      '@docsearch/css': 3.8.2
+      '@docsearch/js': 3.8.2(search-insights@2.17.3)
+      '@iconify-json/simple-icons': 1.2.91
+      '@shikijs/core': 2.5.0
+      '@shikijs/transformers': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@types/markdown-it': 14.1.2
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21)(vue@3.5.40)
+      '@vue/devtools-api': 7.7.10
+      '@vue/shared': 3.5.40
+      '@vueuse/core': 12.8.2
+      '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)
       focus-trap: 7.8.0
       mark.js: 8.11.1
       minisearch: 7.2.0
-      postcss: 8.5.10
+      postcss: 8.5.20
       shiki: 2.5.0
       vite: 5.4.21
-      vue: 3.5.32(typescript@6.0.3)
-  vue@3.5.32(typescript@6.0.3):
+      vue: 3.5.40
+
+  vue@3.5.40:
     dependencies:
-      "@vue/compiler-dom": 3.5.32
-      "@vue/compiler-sfc": 3.5.32
-      "@vue/runtime-dom": 3.5.32
-      "@vue/server-renderer": 3.5.32(vue@3.5.32(typescript@6.0.3))
-      "@vue/shared": 3.5.32
-      typescript: 6.0.3
+      '@vue/compiler-dom': 3.5.40
+      '@vue/compiler-sfc': 3.5.40
+      '@vue/runtime-dom': 3.5.40
+      '@vue/server-renderer': 3.5.40
+      '@vue/shared': 3.5.40
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
   word-wrap@1.2.5: {}
+
   yocto-queue@0.1.0: {}
+
   zwitch@2.0.4: {}

--- a/docs/eslint.config.mjs
+++ b/docs/eslint.config.mjs
@@ -1,11 +1,9 @@
 import globals from "globals";
-import tseslint from "typescript-eslint";
 
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
+  {files: ["**/*.{js,mjs,cjs}"]},
   {ignores: [".vitepress/**/*"]},
   {languageOptions: { globals: globals.browser }},
-  ...tseslint.configs.recommended,
 ];

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,15 +18,14 @@
   "pnpm": {
     "supportedArchitectures": {
       "os": [
-        "current",
-        "linux"
+        "linux",
+        "darwin"
       ],
       "cpu": [
-        "current",
-        "x64"
+        "x64",
+        "arm64"
       ],
       "libc": [
-        "current",
         "glibc"
       ]
     }

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,8 +13,7 @@
     "vitepress": "^1.6.3"
   },
   "devDependencies": {
-    "globals": "^17.0.0",
-    "typescript-eslint": "^8.24.1"
+    "globals": "^17.0.0"
   },
   "pnpm": {
     "supportedArchitectures": {

--- a/mise.lock
+++ b/mise.lock
@@ -65,67 +65,67 @@ url = "https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1
 url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/221573260"
 
 [[tools.aube]]
-version = "1.18.2"
+version = "1.29.1"
 backend = "aqua:endevco/aube"
 
 [tools.aube."platforms.linux-arm64"]
-checksum = "sha256:5a12d8be39fd553bd7d27a4217cd12e9e7fb2bc1eb1ac5d12506f5e5613af974"
-url = "https://github.com/jdx/aube/releases/download/v1.18.2/aube-v1.18.2-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/442328155"
+checksum = "sha256:b1084f4fd7d48e47941bdf321ffb4c65817c557f55a24de58d9dfb62952fdad9"
+url = "https://github.com/jdx/aube/releases/download/v1.29.1/aube-v1.29.1-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/479782673"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-arm64-musl"]
-checksum = "sha256:4f1b8a5c63645e9cd7e9ca42becd80763a47ebd2cefb2ff764bf4a95a19c87d1"
-url = "https://github.com/jdx/aube/releases/download/v1.18.2/aube-v1.18.2-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/442302292"
+checksum = "sha256:86496c2b78c8c23f7723954f7b668c38641b855243c1f6b0987766240fc680de"
+url = "https://github.com/jdx/aube/releases/download/v1.29.1/aube-v1.29.1-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/479754360"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64"]
-checksum = "sha256:2e0b27169c51c77498ccd470da1b59e4d34a4eba8c590fbdd4ba2cfe388a912d"
-url = "https://github.com/jdx/aube/releases/download/v1.18.2/aube-v1.18.2-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/442312841"
+checksum = "sha256:8cf887ae950cec3e42e3e18f91163f0a11992713c9756da7c67524251e4ff785"
+url = "https://github.com/jdx/aube/releases/download/v1.29.1/aube-v1.29.1-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/479761526"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-baseline"]
-checksum = "sha256:2e0b27169c51c77498ccd470da1b59e4d34a4eba8c590fbdd4ba2cfe388a912d"
-url = "https://github.com/jdx/aube/releases/download/v1.18.2/aube-v1.18.2-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/442312841"
+checksum = "sha256:8cf887ae950cec3e42e3e18f91163f0a11992713c9756da7c67524251e4ff785"
+url = "https://github.com/jdx/aube/releases/download/v1.29.1/aube-v1.29.1-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/479761526"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl"]
-checksum = "sha256:0a1e01d7cce84215b188494df38cd806f816557d573fb07f7644cc34aedab1cd"
-url = "https://github.com/jdx/aube/releases/download/v1.18.2/aube-v1.18.2-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/442314620"
+checksum = "sha256:9cc524b64b6f0506d2184b227c52e7aaa07ccd799715a1d23dbd9d3d88f334be"
+url = "https://github.com/jdx/aube/releases/download/v1.29.1/aube-v1.29.1-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/479763791"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:0a1e01d7cce84215b188494df38cd806f816557d573fb07f7644cc34aedab1cd"
-url = "https://github.com/jdx/aube/releases/download/v1.18.2/aube-v1.18.2-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/442314620"
+checksum = "sha256:9cc524b64b6f0506d2184b227c52e7aaa07ccd799715a1d23dbd9d3d88f334be"
+url = "https://github.com/jdx/aube/releases/download/v1.29.1/aube-v1.29.1-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/479763791"
 provenance = "github-attestations"
 
 [tools.aube."platforms.macos-arm64"]
-checksum = "sha256:75886599a4580902a23509e0f1dfd4ec454c738c3df1876f2420072610a087c9"
-url = "https://github.com/jdx/aube/releases/download/v1.18.2/aube-v1.18.2-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/442350963"
+checksum = "sha256:191d0d2725aa24291b3eaa551cd16743d0980104508a8feae057d945067578f5"
+url = "https://github.com/jdx/aube/releases/download/v1.29.1/aube-v1.29.1-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/479812346"
 provenance = "github-attestations"
 
 [tools.aube."platforms.windows-arm64"]
-checksum = "sha256:1e30ca59841ff896ee2d2d5bd502d284d96ce4c4642357a8a046665d81fad5b5"
-url = "https://github.com/jdx/aube/releases/download/v1.18.2/aube-v1.18.2-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/442312793"
+checksum = "sha256:866da5c9ce8dde415ea59e16b72db8b47e2f893d622c1d843438468c886e5cd4"
+url = "https://github.com/jdx/aube/releases/download/v1.29.1/aube-v1.29.1-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/479769076"
 provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64"]
-checksum = "sha256:e0f13610dfded343b74f3babe53893c57e960cfb95d5b09977f3b0a0dbcb4c5b"
-url = "https://github.com/jdx/aube/releases/download/v1.18.2/aube-v1.18.2-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/442313811"
+checksum = "sha256:b505b85f66e95bca72c88b81e239917b0db425430448032ec100ad88fe6e4839"
+url = "https://github.com/jdx/aube/releases/download/v1.29.1/aube-v1.29.1-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/479769257"
 provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64-baseline"]
-checksum = "sha256:e0f13610dfded343b74f3babe53893c57e960cfb95d5b09977f3b0a0dbcb4c5b"
-url = "https://github.com/jdx/aube/releases/download/v1.18.2/aube-v1.18.2-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/aube/releases/assets/442313811"
+checksum = "sha256:b505b85f66e95bca72c88b81e239917b0db425430448032ec100ad88fe6e4839"
+url = "https://github.com/jdx/aube/releases/download/v1.29.1/aube-v1.29.1-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/aube/releases/assets/479769257"
 provenance = "github-attestations"
 
 [[tools.cargo-binstall]]

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   },
   "homepage": "https://github.com/jdx/hk#readme",
   "dependencies": {
-    "eslint": "^10.0.0",
-    "typescript": "^6.0.0"
+    "eslint": "^10.0.0"
   },
   "devDependencies": {
     "globals": "^17.0.0"

--- a/package.json
+++ b/package.json
@@ -32,15 +32,14 @@
   "pnpm": {
     "supportedArchitectures": {
       "os": [
-        "current",
-        "linux"
+        "linux",
+        "darwin"
       ],
       "cpu": [
-        "current",
-        "x64"
+        "x64",
+        "arm64"
       ],
       "libc": [
-        "current",
         "glibc"
       ]
     }

--- a/test/builtin_tool_stubs/tsc
+++ b/test/builtin_tool_stubs/tsc
@@ -1,0 +1,5 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "7.0.2"
+tool = "npm:typescript"
+bin = "tsc"

--- a/test/builtin_tool_stubs/tsc
+++ b/test/builtin_tool_stubs/tsc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S mise tool-stub
 
-version = "7.0.2"
+version = "6.0.3"
 tool = "npm:typescript"
 bin = "tsc"

--- a/test/builtins_tests.bats
+++ b/test/builtins_tests.bats
@@ -21,7 +21,9 @@ hooks {
 }
 PKL
 
-    PATH="$PATH":"$PROJECT_ROOT"/test/builtin_tool_stubs
+    # Prepend so stub-pinned tools take precedence over any ambient tools
+    # preinstalled on the runner (e.g. ubuntu-latest ships a global tsc).
+    PATH="$PROJECT_ROOT/test/builtin_tool_stubs:$PATH"
     run hk test
     assert_success
     # At least the newlines builtin has a test


### PR DESCRIPTION
## Why

Renovate's typescript v6→v7 bump ([#1084](https://github.com/jdx/hk/pull/1084)) broke `ci-other` at the eslint step:

```
eslint – TypeError: Cannot read properties of undefined (reading 'Cjs')
  at @typescript-eslint/typescript-estree@8.64.0_typescript@7.0.2/.../shared.js:59
```

Digging in, both packages turned out to be dead weight:

- **`typescript` (root `package.json`)** — a direct dependency nothing uses: no `tsconfig.json`, no `tsc` task, no `import ... from "typescript"` anywhere. It's only ever touched by Renovate, which is the entire origin of #1084.
- **`typescript-eslint` (docs)** — configured only in `docs/eslint.config.mjs`, but that same config `ignores: [".vitepress/**/*"]`, which is where **all three** of the repo's `.ts` files live (`stars.data.ts`, `theme/banner.ts`, `theme/index.ts`). So it lints **zero** TypeScript files — its only real effect was pulling in a parser that crashes on TypeScript 7.

## What

- Remove `typescript` from root `package.json`.
- Remove `typescript-eslint` from `docs/package.json`, and drop the now-unused `tseslint` import + `.ts` glob from `docs/eslint.config.mjs`.
- Regenerate `aube-lock.yaml` and `docs/aube-lock.yaml`.

## Verification (local)

- `aube install --frozen-lockfile` passes for both root and docs.
- The eslint step that was crashing now runs clean (0 errors).
- No `typescript-eslint` references remain in any tracked file.

## Supersedes #1084

This removes the dependency that #1084 was trying to bump, so that PR can be closed — TypeScript 7 isn't consumable yet anyway (typescript-eslint doesn't support it), and nothing here needs TypeScript.

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only dependency and lint-config cleanup with no runtime or application code changes; main risk is docs lint covering slightly less (TS rules removed).
> 
> **Overview**
> Removes unused **TypeScript** (root) and **typescript-eslint** (docs) so CI ESLint no longer pulls in `@typescript-eslint/typescript-estree`, which was failing on TypeScript 7 peer resolution. Docs ESLint is adjusted to drop TypeScript-specific rules that never ran anyway because `.vitepress` is ignored.
> 
> **`aube-lock.yaml`** is regenerated: direct `typescript` and the whole `@typescript-eslint/*` tree are gone; **eslint** moves to **10.7.0**, docs gains an explicit **postcss** dependency for VitePress, and remaining docs deps resolve without a workspace TypeScript install (e.g. **Vue 3.5.40**).
> 
> **`.prettierignore`** now includes `**/aube-lock.yaml` so lockfile churn is not reformatted by Prettier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5cd40b5f09946e617139ed035fa02b5b9a7a20f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tooling**
  - Updated development tooling dependencies and regenerated lockfiles for more consistent installs.
  - Local `tsc` now runs using a pinned TypeScript version (6.0.3).
  - Expanded supported platforms to include Linux and macOS on x64 and ARM64.

- **Documentation**
  - Documentation linting now targets JavaScript module files only, removing TypeScript-specific lint rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->