### PR TITLE
fix(step): unblock dependents after failed dependency

### DIFF
--- a/src/step_group.rs
+++ b/src/step_group.rs
@@ -172,6 +172,7 @@ impl StepGroup {
                 .get(&step.name)
                 .unwrap()
                 .clone();
+            let fail_fast = ctx.fail_fast;
             set.spawn({
                 let step_ctx = step_ctx.clone();
                 let hook_ctx = ctx.hook_ctx.clone();
@@ -179,6 +180,9 @@ impl StepGroup {
                     let result = step.run_all_jobs(step_ctx.clone(), semaphore).await;
                     if let Err(err) = &result {
                         step_ctx.status_errored(&err.to_string());
+                    }
+                    if !fail_fast || result.is_ok() {
+                        step_ctx.depends.mark_done(&step.name)?;
                     }
                     hook_ctx
                         .step_contexts

--- a/src/step_group.rs
+++ b/src/step_group.rs
@@ -181,7 +181,7 @@ impl StepGroup {
                     if let Err(err) = &result {
                         step_ctx.status_errored(&err.to_string());
                     }
-                    if !fail_fast || result.is_ok() {
+                    if !fail_fast && result.is_err() {
                         step_ctx.depends.mark_done(&step.name)?;
                     }
                     hook_ctx

--- a/test/depends.bats
+++ b/test/depends.bats
@@ -62,3 +62,34 @@ EOF
     git commit -m "initial commit"
     hk fix -v
 }
+
+@test "dependent step proceeds when dependency fails and fail_fast is false" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+fail_fast = false
+hooks {
+    ["check"] {
+        steps {
+            ["fail"] {
+                glob = "**/*"
+                check = "echo FAIL && exit 1"
+            }
+            ["should-pass"] {
+                glob = "**/*"
+                depends = List("fail")
+                check = "echo SHOULD_PASS"
+            }
+        }
+    }
+}
+EOF
+    echo "test" > test.txt
+    git add hk.pkl test.txt
+    git commit -m "initial commit"
+
+    run timeout 5s hk check --all
+    assert_failure
+    refute [ "$status" -eq 124 ]
+    assert_output --partial "FAIL"
+    assert_output --partial "SHOULD_PASS"
+}

--- a/test/depends.bats
+++ b/test/depends.bats
@@ -93,3 +93,34 @@ EOF
     assert_output --partial "FAIL"
     assert_output --partial "SHOULD_PASS"
 }
+
+@test "dependent step does not proceed when dependency fails and fail_fast is true" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+fail_fast = true
+hooks {
+    ["check"] {
+        steps {
+            ["fail"] {
+                glob = "**/*"
+                check = "echo FAIL && exit 1"
+            }
+            ["should-not-pass"] {
+                glob = "**/*"
+                depends = List("fail")
+                check = "echo SHOULD_NOT_PASS"
+            }
+        }
+    }
+}
+EOF
+    echo "test" > test.txt
+    git add hk.pkl test.txt
+    git commit -m "initial commit"
+
+    run timeout 5s hk check --all
+    assert_failure
+    refute [ "$status" -eq 124 ]
+    assert_output --partial "FAIL"
+    refute_output --partial "SHOULD_NOT_PASS"
+}

--- a/test/depends.bats
+++ b/test/depends.bats
@@ -2,6 +2,9 @@ setup() {
     load 'test_helper/common_setup'
     _common_setup
 }
+
+export BATS_TEST_TIMEOUT="${BATS_TEST_TIMEOUT:-10}"
+
 teardown() {
     _common_teardown
 }
@@ -87,9 +90,8 @@ EOF
     git add hk.pkl test.txt
     git commit -m "initial commit"
 
-    run timeout 5s hk check --all
+    run hk check --all
     assert_failure
-    refute [ "$status" -eq 124 ]
     assert_output --partial "FAIL"
     assert_output --partial "SHOULD_PASS"
 }
@@ -118,9 +120,8 @@ EOF
     git add hk.pkl test.txt
     git commit -m "initial commit"
 
-    run timeout 5s hk check --all
+    run hk check --all
     assert_failure
-    refute [ "$status" -eq 124 ]
     assert_output --partial "FAIL"
     refute_output --partial "SHOULD_NOT_PASS"
 }


### PR DESCRIPTION
## Summary

- signal step dependencies after terminal failures when `fail_fast = false`
- add a regression test for a failed dependency with a dependent step

## Root Cause

A failed step returned from `run_all_jobs` before marking its dependency watch channel as done. With `fail_fast = false`, the group continued waiting for all step tasks, while dependent steps waited forever for the failed dependency to complete.

## Validation

- `mise run build`
- `./test/bats/bin/bats test/depends.bats`
- `HK_LIBGIT2=0 ./test/bats/bin/bats test/depends.bats`
- `mise run test:cargo`

Related to discussion #1098.

_This PR description was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to step-group error handling with targeted tests; no auth or data-path impact.
> 
> **Overview**
> Fixes a hang where steps with `depends` never ran after a failed upstream step when **`fail_fast = false`**.
> 
> In **`step_group`**, after a step errors, the group now calls **`depends.mark_done`** for that step so dependents are unblocked; successful paths still mark dependencies inside step execution. **`fail_fast = true`** behavior is unchanged—dependents are not signaled on failure.
> 
> Adds BATS coverage for both modes and sets a default **`BATS_TEST_TIMEOUT`** on **`depends.bats`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd957faea8069f4ba575623485aee3c86ef4d256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->