### PR TITLE
perf(hook): skip final status outside debug logging

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1168,8 +1168,8 @@ impl Hook {
                 warn!("Failed to pop stash: {err}");
             }
         }
-        // Capture final git state for diagnostics (counts at debug, names at trace)
-        if log::log_enabled!(log::Level::Debug) {
+        // Capture final git state when its log output or timing span is observable.
+        if log::log_enabled!(log::Level::Debug) || crate::trace::enabled() {
             match repo.lock().await.status(None) {
                 Ok(s) => {
                     debug!(

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1169,19 +1169,21 @@ impl Hook {
             }
         }
         // Capture final git state for diagnostics (counts at debug, names at trace)
-        match repo.lock().await.status(None) {
-            Ok(s) => {
-                debug!(
-                    "final git state: staged={} unstaged={}",
-                    s.staged_files.len(),
-                    s.unstaged_files.len()
-                );
-                trace!(
-                    "final git files: staged={:?} unstaged={:?}",
-                    s.staged_files, s.unstaged_files
-                );
+        if log::log_enabled!(log::Level::Debug) {
+            match repo.lock().await.status(None) {
+                Ok(s) => {
+                    debug!(
+                        "final git state: staged={} unstaged={}",
+                        s.staged_files.len(),
+                        s.unstaged_files.len()
+                    );
+                    trace!(
+                        "final git files: staged={:?} unstaged={:?}",
+                        s.staged_files, s.unstaged_files
+                    );
+                }
+                Err(e) => warn!("failed to read final git status: {e:?}"),
             }
-            Err(e) => warn!("failed to read final git status: {e:?}"),
         }
         if let Err(err) = hook_ctx.timing.write_json() {
             warn!("Failed to write timing JSON: {err}");

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -14,6 +14,10 @@ static TRACE_ENABLED: AtomicBool = AtomicBool::new(false);
 static PROCESS_START: OnceCell<Instant> = OnceCell::new();
 static SPAN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+pub fn enabled() -> bool {
+    TRACE_ENABLED.load(Ordering::Relaxed)
+}
+
 /// Initialize the tracing subscriber
 pub fn init_tracing(json_output: bool) -> Result<()> {
     use tracing_subscriber::prelude::*;

--- a/test/trace.bats
+++ b/test/trace.bats
@@ -80,6 +80,32 @@ EOF
     assert_output --partial '"name":"git.status"'
 }
 
+@test "trace: final git status is only collected for debug logging" {
+    export REAL_GIT="$(command -v git)"
+    export GIT_STATUS_LOG="$TEST_TEMP_DIR/git-status.log"
+    mkdir fake-bin
+    cat >fake-bin/git <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "status" ]]; then
+    printf '%s\n' status >>"$GIT_STATUS_LOG"
+fi
+exec "$REAL_GIT" "$@"
+EOF
+    chmod +x fake-bin/git
+    export PATH="$PWD/fake-bin:$PATH"
+
+    HK_LIBGIT2=false run hk check
+    assert_success
+    info_status_calls="$(wc -l <"$GIT_STATUS_LOG")"
+
+    : >"$GIT_STATUS_LOG"
+    HK_LIBGIT2=false run hk -v check
+    assert_success
+    debug_status_calls="$(wc -l <"$GIT_STATUS_LOG")"
+
+    assert_equal "$debug_status_calls" "$((info_status_calls + 1))"
+}
+
 @test "trace: enabled when HK_LOG=trace" {
     HK_LOG=trace run hk check
     assert_success

--- a/test/trace.bats
+++ b/test/trace.bats
@@ -80,7 +80,7 @@ EOF
     assert_output --partial '"name":"git.status"'
 }
 
-@test "trace: final git status is only collected for debug logging" {
+@test "trace: final git status is only collected for diagnostic modes" {
     export REAL_GIT="$(command -v git)"
     export GIT_STATUS_LOG="$TEST_TEMP_DIR/git-status.log"
     mkdir fake-bin
@@ -103,7 +103,25 @@ EOF
     assert_success
     debug_status_calls="$(wc -l <"$GIT_STATUS_LOG" | tr -d '[:space:]')"
 
+    : >"$GIT_STATUS_LOG"
+    HK_LIBGIT2=false run hk --trace check
+    assert_success
+    cli_trace_status_calls="$(wc -l <"$GIT_STATUS_LOG" | tr -d '[:space:]')"
+
+    : >"$GIT_STATUS_LOG"
+    HK_LIBGIT2=false HK_TRACE=1 run hk check
+    assert_success
+    env_trace_status_calls="$(wc -l <"$GIT_STATUS_LOG" | tr -d '[:space:]')"
+
+    : >"$GIT_STATUS_LOG"
+    HK_LIBGIT2=false HK_TRACE=json run hk check
+    assert_success
+    json_trace_status_calls="$(wc -l <"$GIT_STATUS_LOG" | tr -d '[:space:]')"
+
     assert_equal "$debug_status_calls" "$((info_status_calls + 1))"
+    assert_equal "$cli_trace_status_calls" "$((info_status_calls + 1))"
+    assert_equal "$env_trace_status_calls" "$((info_status_calls + 1))"
+    assert_equal "$json_trace_status_calls" "$((info_status_calls + 1))"
 }
 
 @test "trace: enabled when HK_LOG=trace" {

--- a/test/trace.bats
+++ b/test/trace.bats
@@ -96,12 +96,12 @@ EOF
 
     HK_LIBGIT2=false run hk check
     assert_success
-    info_status_calls="$(wc -l <"$GIT_STATUS_LOG")"
+    info_status_calls="$(wc -l <"$GIT_STATUS_LOG" | tr -d '[:space:]')"
 
     : >"$GIT_STATUS_LOG"
     HK_LIBGIT2=false run hk -v check
     assert_success
-    debug_status_calls="$(wc -l <"$GIT_STATUS_LOG")"
+    debug_status_calls="$(wc -l <"$GIT_STATUS_LOG" | tr -d '[:space:]')"
 
     assert_equal "$debug_status_calls" "$((info_status_calls + 1))"
 }


### PR DESCRIPTION
## Summary

Avoid collecting a final Git status unless debug logging is enabled.

The final status snapshot is used only for debug/trace diagnostics. At normal log levels, hk previously paid for a full repository status scan and discarded the result.

This gates only the final diagnostic snapshot; status reads used for file selection, stashing, and hook behavior are unchanged.

## Benchmark

In Figma’s monorepo, the diagnostic final status scan took approximately 1.3 seconds.

A focused benchmark using the generated 6,156-file repository, with 4,000 files modified and hook work reduced to a no-op, produced:

| Git backend | Before | After | Improvement |
|---|---:|---:|---:|
| libgit2 | 221.07 ms | 131.32 ms | 40.6% |
| shell Git | 223.18 ms | 136.47 ms | 38.9% |

Results are medians from 30 interleaved runs with stashing disabled to isolate status collection.

## Testing

- Added a Bats regression test verifying normal logging performs one fewer Git status call than debug logging.
- `mise run test:cargo` — 200 tests passed
- `test/bats/bin/bats test/trace.bats` — 11 tests passed
- `cargo fmt --check`
- `cargo clippy --bin hk -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary Git status checks during normal operation.
  * Final Git status details are now collected only when verbose/debug logging is enabled.

* **Tests**
  * Added a Bats test to verify the final Git status is only collected for debug/verbose runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->