### PR TITLE
perf(config): cache resolved config in-process

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use indexmap::IndexMap;
 use indexmap::IndexSet;
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::path::{Path, PathBuf};
 
@@ -7,8 +8,18 @@ use crate::{Result, cache::CacheManagerBuilder, env, hash, hook::Hook, version};
 use eyre::{WrapErr, bail};
 
 impl Config {
-    #[tracing::instrument(level = "info", name = "config.load")]
+    /// Return the resolved config for this hk invocation.
+    ///
+    /// An hk process handles a single command in a single project, so config
+    /// resolution only needs to happen once. Callers receive a clone so their
+    /// mutations cannot affect later callers.
     pub fn get() -> Result<Self> {
+        static RESOLVED_CONFIG: OnceCell<Config> = OnceCell::new();
+        Ok(RESOLVED_CONFIG.get_or_try_init(Self::load)?.clone())
+    }
+
+    #[tracing::instrument(level = "info", name = "config.load")]
+    fn load() -> Result<Self> {
         let mut config = Self::load_project_config()?;
         config.load_subprojects()?;
         config.apply_hkrc()?;

--- a/test/trace.bats
+++ b/test/trace.bats
@@ -36,6 +36,14 @@ EOF
     assert_output --partial '"type":"span_end"'
 }
 
+@test "trace: resolved config is loaded once per process" {
+    run hk --trace --json check
+    assert_success
+
+    load_count="$(printf '%s\n' "$output" | grep -c '"type":"span_start".*"name":"config.load"')"
+    assert_equal "$load_count" 1
+}
+
 @test "trace: disabled by default" {
     run hk check
     assert_success


### PR DESCRIPTION
## Summary

Cache the fully resolved configuration for the lifetime of the hk process.

The existing disk cache avoids repeated Pkl evaluation, but each `Config::get()` still reapplies subprojects and user configuration, validates the result, and clones the cached representation. A typical command calls it more than once.

hk processes one command for one project, so the resolved config can safely be initialized once. Callers continue receiving clones, preserving the existing API and preventing mutations from affecting later callers.

The `config.load` trace span now surrounds actual resolution rather than cache access.

## Benchmark

Figma’s configuration took approximately 550 ms to resolve each time, making redundant loads visible in hook latency.

A focused release benchmark running `hk validate` against `benchmark/parallel/hk.pkl`, with the existing disk cache warm, produced:

| Before | After | Improvement |
|---:|---:|---:|
| 102.60 ms | 55.21 ms | 46.2% |

Results are medians from 100 interleaved runs. The trace also went from two `config.load` spans per invocation to one.

## Testing

- Added a Bats regression test asserting that configuration is resolved once per process.
- `mise run test:cargo` — 200 tests passed
- `test/bats/bin/bats test/trace.bats` — 11 tests passed
- `cargo fmt --check`
- `cargo clippy --bin hk -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved configuration loading by caching resolved settings for reuse during each process.

* **Observability**
  * Added tracing for configuration loading, making it easier to monitor when settings are resolved.

* **Tests**
  * Added coverage to verify configuration loading is traced only once per process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->