### PR TITLE
fix(hook): don't stash when a hook has no steps to run

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -134,6 +134,8 @@ pub struct Git {
     stashed_paths: Option<BTreeSet<PathBuf>>,
     saved_index: Option<Vec<(u32, String, PathBuf)>>,
     saved_worktree: Option<std::collections::HashMap<PathBuf, String>>,
+    // Path of the most recent stash patch backup, surfaced if restore fails
+    last_patch_path: Option<PathBuf>,
 }
 
 enum StashType {
@@ -217,6 +219,7 @@ impl Git {
             stashed_paths: None,
             saved_index: None,
             saved_worktree: None,
+            last_patch_path: None,
         })
     }
 
@@ -272,7 +275,7 @@ impl Git {
     }
 
     /// Save a patch backup of the stash
-    fn save_stash_patch(&self, stash_ref: &str) {
+    fn save_stash_patch(&mut self, stash_ref: &str) {
         // If backup_count is 0, skip patch backup entirely
         let backup_count = Settings::get().stash_backup_count;
         if backup_count == 0 {
@@ -333,6 +336,7 @@ impl Git {
             return;
         }
         debug!("Saved stash patch: {}", patch_path.display());
+        self.last_patch_path = Some(patch_path);
 
         // Rotate old patches based on configured backup count
         if let Err(e) = self.rotate_patch_files(backup_count) {
@@ -983,6 +987,11 @@ impl Git {
         self.saved_index = Some(entries);
         self.saved_worktree = Some(wt_map);
         Ok(())
+    }
+
+    /// Path of the most recent stash patch backup, if one was written.
+    pub fn last_patch_path(&self) -> Option<&PathBuf> {
+        self.last_patch_path.as_ref()
     }
 
     pub fn pop_stash(&mut self) -> Result<()> {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1013,6 +1013,14 @@ impl Hook {
         let groups = self.get_step_groups(&opts);
         let stash_method = self.resolve_stash_method_for_opts(&opts);
         let total_steps: usize = groups.iter().map(|g| g.steps.len()).sum();
+        // Exit before any side effects (notably stashing) when there are no steps to run.
+        // Stashing here would strip the working tree, and the early return below used to
+        // happen *after* the stash was created but *before* pop_stash ran, leaving a
+        // dangling stash and a stripped worktree. See #1105.
+        if total_steps == 0 {
+            info!("no steps to run");
+            return Ok(());
+        }
         let hk_progress = self.start_hk_progress(run_type, total_steps);
         let file_progress = ProgressJobBuilder::new().body(
             "{{spinner()}} files - {{message}}{% if files is defined %} ({{files}} file{{files|pluralize}}){% endif %}"
@@ -1082,10 +1090,6 @@ impl Hook {
             }
         }
 
-        if hook_ctx.groups.is_empty() {
-            info!("no steps to run");
-            return Ok(());
-        }
         // Snapshot file content hashes before running groups so fail_on_fix can detect
         // which files were actually modified by fixers (ignoring pre-existing changes).
         let pre_file_hashes: std::collections::HashMap<PathBuf, u64> =
@@ -1161,11 +1165,20 @@ impl Hook {
             }
         }
 
-        if let Err(err) = repo.lock().await.pop_stash() {
-            if result.is_ok() {
-                result = Err(err);
-            } else {
-                warn!("Failed to pop stash: {err}");
+        {
+            let mut repo = repo.lock().await;
+            if let Err(err) = repo.pop_stash() {
+                // The stashed content is also backed up as a patch; surface it so the
+                // user can recover manually if the automatic restore failed.
+                let patch_hint = repo
+                    .last_patch_path()
+                    .map(|p| format!(" (a backup of the stashed changes is at {})", p.display()))
+                    .unwrap_or_default();
+                if result.is_ok() {
+                    result = Err(err.wrap_err(format!("failed to restore stash{patch_hint}")));
+                } else {
+                    warn!("Failed to pop stash: {err}{patch_hint}");
+                }
             }
         }
         // Capture final git state for diagnostics (counts at debug, names at trace)

--- a/test/stash_no_steps_to_run.bats
+++ b/test/stash_no_steps_to_run.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+
+# Regression test for https://github.com/jdx/hk/discussions/1105
+#
+# When a hook resolves to zero steps but the worktree has unstaged/untracked
+# changes, hk used to stash those changes and then return early *before*
+# restoring the stash, leaving the working tree stripped and a dangling stash.
+# It should not stash at all when there is nothing to run.
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+    export HK_STASH_UNTRACKED=true
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "no stash created when hook has no steps to run" {
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+    steps = new Mapping<String, Step> {}
+  }
+}
+PKL
+    git add hk.pkl
+    git commit -m 'init'
+
+    # A staged change, an unstaged change, and an untracked file
+    echo 'original' > tracked.txt
+    git add tracked.txt
+    git commit -m 'add tracked'
+
+    echo 'staged change' > tracked.txt
+    git add tracked.txt
+    echo 'unstaged change' > tracked.txt
+    echo 'untracked content' > untracked.txt
+
+    stash_count_before=$(git stash list | wc -l)
+
+    run hk run pre-commit
+    assert_success
+    assert_output --partial "no steps to run"
+    refute_output --partial "Stashed unstaged changes"
+
+    # No stash should have been left behind
+    stash_count_after=$(git stash list | wc -l)
+    assert_equal "$stash_count_before" "$stash_count_after"
+
+    # Working tree must be intact
+    run test -f untracked.txt
+    assert_success
+    run cat untracked.txt
+    assert_output 'untracked content'
+    run cat tracked.txt
+    assert_output 'unstaged change'
+}
+
+@test "no steps to run leaves worktree intact through git commit" {
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+    steps = new Mapping<String, Step> {}
+  }
+  ["commit-msg"] {
+    steps {
+      ["always-fail"] { check = "false" }
+    }
+  }
+}
+PKL
+    git add hk.pkl
+    git commit -m 'init'
+
+    echo 'a' > a.md
+    git add a.md
+    git commit -m 'add a'
+
+    # Install hooks only after setup so the always-fail commit-msg does not
+    # block the setup commits above.
+    hk install
+
+    git mv a.md b.md          # staged rename
+    echo 'untracked' > u.md   # untracked file
+
+    stash_count_before=$(git stash list | wc -l)
+
+    # commit-msg fails on purpose, aborting the commit
+    run git commit -m 'test'
+    assert_failure
+
+    # Even though the commit aborted, the pre-commit hook must not have left a
+    # dangling stash or stripped the working tree.
+    stash_count_after=$(git stash list | wc -l)
+    assert_equal "$stash_count_before" "$stash_count_after"
+
+    run test -f u.md
+    assert_success
+    run test -f b.md
+    assert_success
+    run cat u.md
+    assert_output 'untracked'
+}


### PR DESCRIPTION
## Problem

Reported in #1105. When a hook resolves to **zero steps** but the worktree has unstaged or untracked changes, hk stashes those changes and then returns early — *before* `pop_stash()` runs. The result is a dangling stash and a working tree stripped of every unstaged change and untracked file.

The classic trigger is a `hk init` config (empty `linters` in `pre-commit`, `stash = "git"`) combined with anything that later aborts the commit (e.g. a failing `commit-msg` step). But the bug does not actually depend on the later hook: the `pre-commit` invocation stashed and returned without ever scheduling a restore, so even a *successful* commit left the tree stripped. Each retry created another dangling stash.

## Root cause

In `Hook::run` the stash was created at the top of the run, but the `if hook_ctx.groups.is_empty() { return Ok(()) }` guard sat *between* the stash and `pop_stash()`. That early-return path was the only exit that skipped the restore.

## Fix

- Move the "no steps to run" guard **above** all side effects (stashing, and the full-worktree untracked scan). If there are no steps, there is nothing that could modify files, so there is nothing to stash — matching suggestion #1 in the report.
- On a stash restore failure, surface the `~/.local/state/hk/patches/*.patch` backup path in the error/warning so users can recover manually (suggestion #4).

## Tests

New `test/stash_no_steps_to_run.bats`:
1. `hk run pre-commit` with an empty step map creates no stash and leaves the worktree (staged + unstaged + untracked) intact.
2. Full `git commit` where `pre-commit` has no steps and `commit-msg` fails — the aborted commit leaves no dangling stash and no stripped files (the exact repro from the discussion).

Verified the existing stash suite still passes (`stash_default`, `stash_preservation_on_error`, `stash_current_behavior`, `patch_backup`, `stash_robustness`, `pre_commit_does_not_stash_staged_only_files`).

## Not addressed here (follow-ups)

- **`.gitignore` for untracked collection** (report #3): couldn't reproduce from the code path — `git stash --include-untracked` (not `--all`) and libgit2 status both exclude ignored files. The most likely explanation is a cascade of *this* bug: a prior failed attempt stashed the untracked `.gitignore` away, so retries no longer saw the ignore rules. Worth a separate look.
- A `Drop`/`finally`-style restore guard (report #2) for panic/kill robustness — this fix removes the only normal-execution leak, so that becomes defense-in-depth for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when stashing runs and how stash-restore errors are reported—core pre-commit behavior—but the fix is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes **#1105**: when a hook had **no steps** but `stash` was enabled, hk could **stash unstaged/untracked work**, hit an early **"no steps to run"** return **after** the stash and **before** `pop_stash`, leaving a **dangling stash** and a **stripped worktree**.
> 
> **`Hook::run`** now returns immediately when `total_steps == 0`, **before** git status, stashing, or other side effects. The duplicate empty-groups check after the stash block was removed.
> 
> **Stash restore failures** now include the path to the latest **`~/.local/state/hk/patches/*.patch`** backup (`Git::last_patch_path`, set when `save_stash_patch` writes a file).
> 
> Regression coverage in **`test/stash_no_steps_to_run.bats`** (empty `pre-commit` with dirty tree; commit aborted by failing `commit-msg`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 649d2d31891e21de4f432c4dbda467ea82b4825c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Running a hook with no steps no longer creates a temporary Git stash or alters tracked and untracked files.
  * Working-tree changes are preserved even when setup-related hook processing fails.
  * Stash restoration failures now provide clearer diagnostics, including the location of an available patch backup.
* **Tests**
  * Added regression coverage for empty hook runs, failed setup commits, stash handling, and preservation of local changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->