### PR TITLE
chore: release v1.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## [1.54.0](https://github.com/jdx/hk/compare/v1.53.0..v1.54.0) - 2026-07-30
+
+### 🚀 Features
+
+- **(check)** add focused diagnostics for failed files by [@jdx](https://github.com/jdx) in [#1123](https://github.com/jdx/hk/pull/1123)
+- **(usage)** declare what each command does to the world by [@jdx](https://github.com/jdx) in [#1121](https://github.com/jdx/hk/pull/1121)
+
+### 🐛 Bug Fixes
+
+- **(builtins)** pass --quiet to tombi-format by [@jdx](https://github.com/jdx) in [#1117](https://github.com/jdx/hk/pull/1117)
+- **(builtins)** oxlint does not error for unmatched patterns by [@CallumKerson](https://github.com/CallumKerson) in [#1119](https://github.com/jdx/hk/pull/1119)
+
+### 📚 Documentation
+
+- **(contributing)** standardize AI disclosures by [@jdx](https://github.com/jdx) in [#1128](https://github.com/jdx/hk/pull/1128)
+
+### ⚡ Performance
+
+- **(release)** add PGO and BOLT optimization pipeline by [@jdx](https://github.com/jdx) in [#1136](https://github.com/jdx/hk/pull/1136)
+- **(util)** optimize `mixed-line-ending` and `check-merge-conflict` using `memchr` crate by [@astei](https://github.com/astei) in [#1115](https://github.com/jdx/hk/pull/1115)
+- track instruction counts, and gate pull requests on them by [@jdx](https://github.com/jdx) in [#1125](https://github.com/jdx/hk/pull/1125)
+
+### 🧪 Testing
+
+- **(builtins)** exclude hono from textlint trust policy by [@jdx](https://github.com/jdx) in [#1120](https://github.com/jdx/hk/pull/1120)
+
+### 📦️ Dependency Updates
+
+- update zizmorcore/zizmor-action action to v0.6.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1112](https://github.com/jdx/hk/pull/1112)
+- update anthropics/claude-code-action action to v1.0.176 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1108](https://github.com/jdx/hk/pull/1108)
+- update jdx/renovate-config digest to 5fee46e by [@renovate[bot]](https://github.com/renovate[bot]) in [#1107](https://github.com/jdx/hk/pull/1107)
+- update rust crate clx to v2.1.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1111](https://github.com/jdx/hk/pull/1111)
+- update namespacelabs/nscloud-cache-action action to v1.6.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1110](https://github.com/jdx/hk/pull/1110)
+- update rust crate infer to 0.22 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1113](https://github.com/jdx/hk/pull/1113)
+- update jdx/mise-action action to v4.2.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1109](https://github.com/jdx/hk/pull/1109)
+- update demand by [@jdx](https://github.com/jdx) in [#1124](https://github.com/jdx/hk/pull/1124)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1126](https://github.com/jdx/hk/pull/1126)
+- use rust-aware cargo resolver by [@jdx](https://github.com/jdx) in [#1127](https://github.com/jdx/hk/pull/1127)
+- update anthropics/claude-code-action action to v1.0.179 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1131](https://github.com/jdx/hk/pull/1131)
+- update jdx/pr-closer action to v1.2.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1132](https://github.com/jdx/hk/pull/1132)
+- update actions/checkout action to v7.0.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1130](https://github.com/jdx/hk/pull/1130)
+- update jdx/renovate-config digest to aa7a43b by [@renovate[bot]](https://github.com/renovate[bot]) in [#1129](https://github.com/jdx/hk/pull/1129)
+- update rust crate clx to v3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1133](https://github.com/jdx/hk/pull/1133)
+- update jdx/renovate-config digest to d4f71e1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1134](https://github.com/jdx/hk/pull/1134)
+- update anthropics/claude-code-action action to v1.0.180 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1135](https://github.com/jdx/hk/pull/1135)
+
+### New Contributors
+
+- @astei made their first contribution in [#1115](https://github.com/jdx/hk/pull/1115)
+
 ## [1.53.0](https://github.com/jdx/hk/compare/v1.52.0..v1.53.0) - 2026-07-23
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.53.0"
+version = "1.54.0"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "hk"
 repository = "https://github.com/jdx/hk"
 resolver = "3"
 rust-version = "1.88.0"
-version = "1.53.0"
+version = "1.54.0"
 
 [[bin]]
 name = "generate-docs"

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 140+ pre-configured linters and formatters through the `Builtins` mo
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -5098,7 +5098,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.53.0",
+  "version": "1.54.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.53.0
+**Version**: 1.54.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined
@@ -281,8 +281,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -315,7 +315,7 @@ Add steps to your hkrc. hk merges them into every project's hooks — steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -408,7 +408,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,8 +105,8 @@ Separately from global *hooks*, you can also create a global *config* file that 
 `hk init` generates an `hk.pkl` file in the root of the repository. Here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -43,7 +43,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,8 +3,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,8 +3,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,8 +3,8 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,8 +4,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -6,8 +6,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -6,8 +6,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -13,8 +13,8 @@ Groups can set common step attributes such as `dir`, `workspace_indicator`, `pre
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {
@@ -114,7 +114,7 @@ its own `hk.pkl` next to its code. The root config lists the subproject director
 
 ```pkl
 // hk.pkl (repo root)
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
 
 subprojects = List("frontend", "backend", "packages/*")
 
@@ -126,8 +126,8 @@ hooks {
 
 ```pkl
 // frontend/hk.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 hooks {
   ["check"] {

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -7,8 +7,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.53.0/hk@1.53.0#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
 amends "pkl/Config.pkl"
 import "pkl/Builtins.pkl"
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name hk
 bin hk
-version "1.53.0"
+version "1.54.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --hkrc help="Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)" hide=#true global=#true {


### PR DESCRIPTION
### 🚀 Features

- **(check)** add focused diagnostics for failed files by [@jdx](https://github.com/jdx) in [#1123](https://github.com/jdx/hk/pull/1123)
- **(usage)** declare what each command does to the world by [@jdx](https://github.com/jdx) in [#1121](https://github.com/jdx/hk/pull/1121)

### 🐛 Bug Fixes

- **(builtins)** pass --quiet to tombi-format by [@jdx](https://github.com/jdx) in [#1117](https://github.com/jdx/hk/pull/1117)
- **(builtins)** oxlint does not error for unmatched patterns by [@CallumKerson](https://github.com/CallumKerson) in [#1119](https://github.com/jdx/hk/pull/1119)

### 📚 Documentation

- **(contributing)** standardize AI disclosures by [@jdx](https://github.com/jdx) in [#1128](https://github.com/jdx/hk/pull/1128)

### ⚡ Performance

- **(release)** add PGO and BOLT optimization pipeline by [@jdx](https://github.com/jdx) in [#1136](https://github.com/jdx/hk/pull/1136)
- **(util)** optimize `mixed-line-ending` and `check-merge-conflict` using `memchr` crate by [@astei](https://github.com/astei) in [#1115](https://github.com/jdx/hk/pull/1115)
- track instruction counts, and gate pull requests on them by [@jdx](https://github.com/jdx) in [#1125](https://github.com/jdx/hk/pull/1125)

### 🧪 Testing

- **(builtins)** exclude hono from textlint trust policy by [@jdx](https://github.com/jdx) in [#1120](https://github.com/jdx/hk/pull/1120)

### 📦️ Dependency Updates

- update zizmorcore/zizmor-action action to v0.6.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1112](https://github.com/jdx/hk/pull/1112)
- update anthropics/claude-code-action action to v1.0.176 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1108](https://github.com/jdx/hk/pull/1108)
- update jdx/renovate-config digest to 5fee46e by [@renovate[bot]](https://github.com/renovate[bot]) in [#1107](https://github.com/jdx/hk/pull/1107)
- update rust crate clx to v2.1.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1111](https://github.com/jdx/hk/pull/1111)
- update namespacelabs/nscloud-cache-action action to v1.6.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1110](https://github.com/jdx/hk/pull/1110)
- update rust crate infer to 0.22 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1113](https://github.com/jdx/hk/pull/1113)
- update jdx/mise-action action to v4.2.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1109](https://github.com/jdx/hk/pull/1109)
- update demand by [@jdx](https://github.com/jdx) in [#1124](https://github.com/jdx/hk/pull/1124)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1126](https://github.com/jdx/hk/pull/1126)
- use rust-aware cargo resolver by [@jdx](https://github.com/jdx) in [#1127](https://github.com/jdx/hk/pull/1127)
- update anthropics/claude-code-action action to v1.0.179 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1131](https://github.com/jdx/hk/pull/1131)
- update jdx/pr-closer action to v1.2.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1132](https://github.com/jdx/hk/pull/1132)
- update actions/checkout action to v7.0.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1130](https://github.com/jdx/hk/pull/1130)
- update jdx/renovate-config digest to aa7a43b by [@renovate[bot]](https://github.com/renovate[bot]) in [#1129](https://github.com/jdx/hk/pull/1129)
- update rust crate clx to v3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1133](https://github.com/jdx/hk/pull/1133)
- update jdx/renovate-config digest to d4f71e1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1134](https://github.com/jdx/hk/pull/1134)
- update anthropics/claude-code-action action to v1.0.180 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1135](https://github.com/jdx/hk/pull/1135)

### New Contributors

- @astei made their first contribution in [#1115](https://github.com/jdx/hk/pull/1115)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release packaging only (version strings and docs); no application logic changes in the diff.
> 
> **Overview**
> **Release v1.54.0** bumps the crate and generated metadata from `1.53.0` to `1.54.0` and adds the **1.54.0** section to `CHANGELOG.md`.
> 
> The mechanical updates align version strings in `Cargo.toml` / `Cargo.lock`, `hk.usage.kdl`, CLI docs (`docs/cli/*`), and every doc/example `hk.pkl` `amends` / `import` URI that points at the published Pkl package (`v1.54.0`).
> 
> Shipped behavior (documented in the changelog, not in this diff) includes **focused check diagnostics for failed files**, richer **command usage** metadata, builtin fixes (**tombi-format** `--quiet`, **oxlint** unmatched patterns), **memchr**-backed util performance, a **PGO/BOLT** release pipeline, and **PR instruction-count** gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d66ca6bbe9ac81ede5aa11ad8b77dd7afadcfc16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->