### PR TITLE
fix(builtins): pass --quiet to tombi-format

### DIFF
--- a/pkl/builtins/tombi_format.pkl
+++ b/pkl/builtins/tombi_format.pkl
@@ -8,8 +8,8 @@ import "./test/helpers.pkl"
 }
 tombi_format = new Config.Step {
   glob = "**/*.toml"
-  check_diff = "tombi format --check --diff {{ files }}"
-  fix = "tombi format {{ files }}"
+  check_diff = "tombi format --quiet --check --diff {{ files }}"
+  fix = "tombi format --quiet {{ files }}"
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.toml"


### PR DESCRIPTION
Fixes https://github.com/jdx/hk/discussions/1116

`tombi format` prints a summary line to stderr even when everything is already formatted:

```
tombi-format stderr:
1 file did not need formatting
```

hk surfaces that stderr after the run, so an otherwise clean `pre-commit` still ends with noise. `tombi format --quiet` suppresses only the summary messages — the diff and the `"x.toml" is not formatted` error are still printed on failure — so this adds `--quiet` to both `check_diff` and `fix`.

Verified against tombi 1.2.4 and the pinned test-stub version 0.7.27 (both support `--quiet` on `format`):

- clean files, `hk check --all` / `hk fix --all` → no output
- unformatted file, `hk check --all` → still fails with the diff and error
- unformatted file, `hk fix --all` → still reports `1 file modified` and rewrites the file

`hk test --step tombi-format` passes (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line command flag change in a formatter builtin with no auth, data, or behavioral change on failure paths.
> 
> **Overview**
> The **tombi-format** builtin now runs `tombi format` with **`--quiet`** on both **`check_diff`** and **`fix`**, so hk no longer surfaces tombi’s “file did not need formatting” stderr on clean pre-commit runs.
> 
> Check failures and diffs are unchanged; only the success-path summary messages are suppressed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 343abfe1d290b7fb048820933583877eacc204b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->