### PR TITLE
fix(step): hide informational stderr from passing check_diff/check_list_files

### DIFF
--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -312,12 +312,23 @@ impl Step {
                         result.stderr.len()
                     );
                 }
+                // `check_list_files` and `check_diff` report their results through
+                // stdout, so on success their stderr carries nothing actionable —
+                // usually a tally like "1 file did not need formatting". Drop it from
+                // the end-of-run summary rather than reporting it under an otherwise
+                // clean step. Steps that do want it can set
+                // `output_summary = "combined"`.
+                let summary_stderr = if ran_check_list_files || ran_check_diff {
+                    ""
+                } else {
+                    result.stderr.as_str()
+                };
                 // Save output for end-of-run summary based on configured mode
                 self.save_output_summary(
                     ctx,
                     job,
                     &result.stdout,
-                    &result.stderr,
+                    summary_stderr,
                     &result.combined_output,
                     false, // not a failure
                 );

--- a/test/output_summary_check_success.bats
+++ b/test/output_summary_check_success.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+# NB: these assert on the end-of-run summary block ("<step> stderr:") rather than
+# the message text, which also appears in the transient progress lines.
+
+@test "check_diff informational stderr is hidden when the check passes" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["format"] {
+        check_diff = "echo '1 file did not need formatting' 1>&2"
+        fix = "echo 'Fixed' 1>&2"
+        glob = List("*.txt")
+      }
+    }
+  }
+}
+EOF
+    echo "content" > file.txt
+    git add file.txt
+
+    HK_SUMMARY_TEXT=1 run hk check
+    assert_success
+    refute_output --partial "format stderr:"
+}
+
+@test "check_list_files informational stderr is hidden when the check passes" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["format"] {
+        check_list_files = "echo 'all files are formatted' 1>&2"
+        fix = "echo 'Fixed' 1>&2"
+        glob = List("*.txt")
+      }
+    }
+  }
+}
+EOF
+    echo "content" > file.txt
+    git add file.txt
+
+    HK_SUMMARY_TEXT=1 run hk check
+    assert_success
+    refute_output --partial "format stderr:"
+}
+
+@test "check_diff informational stderr is hidden when check_first passes during fix" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["fix"] {
+    steps {
+      ["format"] {
+        check_first = true
+        check_diff = "echo '1 file did not need formatting' 1>&2"
+        fix = "echo 'Fixed' 1>&2"
+        glob = List("*.txt")
+      }
+    }
+  }
+}
+EOF
+    echo "content" > file.txt
+    git add file.txt
+
+    HK_SUMMARY_TEXT=1 run hk fix
+    assert_success
+    refute_output --partial "format stderr:"
+    # The fixer never runs because check_diff reported nothing to fix
+    refute_output --partial "Fixed"
+}
+
+@test "check_diff stderr is still shown when the check fails" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["format"] {
+        check_diff = "echo 'file.txt is not formatted' 1>&2 && exit 1"
+        fix = "echo 'Fixed' 1>&2"
+        glob = List("*.txt")
+      }
+    }
+  }
+}
+EOF
+    echo "content" > file.txt
+    git add file.txt
+
+    HK_SUMMARY_TEXT=1 run hk check
+    assert_failure
+    assert_output --partial "format stderr:"
+    summary=$(echo "$output" | sed -n '/format stderr:/,$p')
+    echo "$summary" | grep -q "file.txt is not formatted" \
+        || fail "Summary should contain the check_diff failure output"
+}
+
+@test "check_diff stderr can be opted back in with output_summary combined" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["format"] {
+        output_summary = "combined"
+        check_diff = "echo '1 file did not need formatting' 1>&2"
+        fix = "echo 'Fixed' 1>&2"
+        glob = List("*.txt")
+      }
+    }
+  }
+}
+EOF
+    echo "content" > file.txt
+    git add file.txt
+
+    HK_SUMMARY_TEXT=1 run hk check
+    assert_success
+    assert_output --partial "format output:"
+    summary=$(echo "$output" | sed -n '/format output:/,$p')
+    echo "$summary" | grep -q "1 file did not need formatting" \
+        || fail "Summary should contain the check_diff informational output"
+}
+
+@test "plain check stderr is still shown when the check passes" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["lint"] {
+        check = "echo 'Check output' 1>&2"
+        glob = List("*.txt")
+      }
+    }
+  }
+}
+EOF
+    echo "content" > file.txt
+    git add file.txt
+
+    HK_SUMMARY_TEXT=1 run hk check
+    assert_success
+    assert_output --partial "lint stderr:"
+    summary=$(echo "$output" | sed -n '/lint stderr:/,$p')
+    echo "$summary" | grep -q "Check output" \
+        || fail "Summary should contain the check output"
+}


### PR DESCRIPTION
Follow-up to #1117, which worked around this at the builtin level by passing `--quiet` to `tombi format`. This fixes the underlying behavior for every `check_diff` / `check_list_files` step.

## The bug

Both commands report their results through **stdout**, so on success their stderr carries nothing actionable — usually a tally line. hk already says as much in `runner.rs`:

```rust
// For both check_list_files and check_diff: stderr is informational only
// Files are read from stdout; stderr may contain warnings, debug info, etc.
```

```rust
} else if ran_check_diff {
    // For check_diff, stderr with exit 0 is just informational (e.g., "N files already formatted")
    debug!(...);
}
```

…but it only `debug!`s, then falls through to `save_output_summary`, which on success appends stderr under the default `output_summary = "stderr"` (`src/step/output.rs:60`, default at `src/step/types.rs:314` / `pkl/Config.pkl:831`). So a fully clean run still ends with:

```
tombi-format stderr:
1 file did not need formatting
```

which is what https://github.com/jdx/hk/discussions/1116 reported.

## The fix

On success, drop **only the stderr channel** for these two commands. That means:

- `output_summary = "stderr"` (default) → informational tally hidden ✅
- `output_summary = "combined"` → still shown, so there's an opt-in escape hatch for a step whose tool emits a genuine warning on exit 0
- `output_summary = "stdout"` → unchanged
- failures → completely untouched (they go through the `is_failure` path, which uses combined output)

Suppressing only stderr rather than early-returning is what preserves the `combined` escape hatch.

## Testing

New `test/output_summary_check_success.bats` covers six cases. Verified the three new-behavior tests fail on `main` and pass with the fix, while the three guard tests pass both ways:

| test | on `main` | with fix |
|---|---|---|
| `check_diff` informational stderr hidden when check passes | ✗ | ✓ |
| `check_list_files` informational stderr hidden when check passes | ✗ | ✓ |
| `check_diff` informational stderr hidden when `check_first` passes during fix | ✗ | ✓ |
| `check_diff` stderr still shown when the check **fails** | ✓ | ✓ |
| `check_diff` stderr opt-in via `output_summary = "combined"` | ✓ | ✓ |
| plain `check` stderr still shown when the check passes | ✓ | ✓ |

The assertions target the `<step> stderr:` summary header rather than the message text, since the message also appears in the transient progress lines.

Also ran the full suite: `cargo test` 200/200, and `bats test/*.bats` produces an **identical** set of 40 pre-existing failures with and without this change (environmental — prettier/git-lfs/node/pkl CLI unavailable in my sandbox). `cargo clippy` findings are likewise identical to baseline (21 both ways, all pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, success-path-only change to summary output in the step runner; failure handling and other step types are untouched.
> 
> **Overview**
> Fixes noisy end-of-run summaries on **clean** runs where `check_diff` or `check_list_files` exit 0 but still print tally lines to stderr (e.g. “1 file did not need formatting”).
> 
> On **success only**, the step runner now passes an **empty stderr** into `save_output_summary` when those commands ran, so the default `output_summary = "stderr"` no longer prints a misleading `<step> stderr:` block. **Failures** are unchanged (still use combined output). **`output_summary = "combined"`** still includes informational stderr via `combined_output`. Ordinary **`check`** steps are unaffected.
> 
> Adds **`test/output_summary_check_success.bats`** with six cases covering pass/fix+`check_first`, failures, the `combined` opt-in, and plain `check` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cafd5aad8a8c2460e4b7c7ad00e2d23060442a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced redundant informational output in end-of-run summaries for successful file-list and diff checks.
  * Informational details remain available when checks fail or when combined output is selected.
  * Standard checks continue to display their summary output as expected.
* **Tests**
  * Added coverage for summary output across successful, failed, and fix-related check scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->