### PR TITLE
fix(builtins): oxlint does not error for unmatched patterns

### DIFF
--- a/pkl/builtins/oxfmt.pkl
+++ b/pkl/builtins/oxfmt.pkl
@@ -58,9 +58,9 @@ oxfmt = new Config.Step {
       "**/*.handlebars",
       "**/*.hbs",
     )
-  check = "oxfmt --check {{ files }}"
-  check_list_files = "oxfmt --list-different {{ files }}"
-  fix = "oxfmt --write {{ files }}"
+  check = "oxfmt --check --no-error-on-unmatched-pattern {{ files }}"
+  check_list_files = "oxfmt --list-different --no-error-on-unmatched-pattern {{ files }}"
+  fix = "oxfmt --write --no-error-on-unmatched-pattern {{ files }}"
   tests {
     local const testMaker = new helpers.TestMaker { filename = "foo.ts" }
     // Source: https://github.com/oxc-project/oxc/blob/apps_v1.63.0/apps/oxfmt/test/api/basic.test.ts


### PR DESCRIPTION
https://oxc.rs/docs/guide/usage/formatter/cli.html#runtime-options
Similar to https://github.com/jdx/hk/blob/5239d3d43a3e474940a65eceab213b1e028bf45a/pkl/builtins/biome.pkl#L16