### PR TITLE
test(builtins): exclude hono from textlint trust policy

### DIFF
--- a/test/builtin_tool_stubs/textlint
+++ b/test/builtin_tool_stubs/textlint
@@ -2,3 +2,4 @@
 
 version = "15.7.1"
 tool = "npm:textlint"
+trust_policy_excludes = ["@hono/node-server"]


### PR DESCRIPTION
## Summary

- exclude all versions of `@hono/node-server` from aube's no-downgrade trust policy for the textlint test stub
- keep the exception scoped to the `npm:textlint` builtin test tool

## Root cause

The macOS `ci-nogit` job could not install `textlint@15.7.1` because aube flagged `@hono/node-server@1.19.15` as a trust downgrade. This caused the textlint check/fix builtin tests to fail on every retry, while the PR's oxfmt tests passed.

## Impact

Builtin tests can install the pinned textlint version again without disabling aube's trust policy globally.

## Validation

- clean textlint stub install with mise 2026.7.13
- `PATH="$PWD/test/builtin_tool_stubs:$PATH" target/debug/hk test --step textlint`
- `mise run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mise tool-stub config change; no production auth, security, or runtime behavior.
> 
> **Overview**
> Fixes **macOS `ci-nogit`** failures when installing the pinned `textlint@15.7.1` stub: aube’s no-downgrade trust policy was blocking `@hono/node-server` as a transitive dependency.
> 
> The `npm:textlint` builtin test stub now sets `trust_policy_excludes = ["@hono/node-server"]` so that package is exempt from the downgrade check for this tool only, without weakening trust policy elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2634135e20d28d2543732729be7b29d3beea9276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the textlint tool configuration to exclude a specific server package from trust-policy checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->