### PR TITLE
feat(check): add focused diagnostics for failed files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,6 +140,26 @@ Structured commands preserve argument boundaries, so filenames containing spaces
 
 Structured commands cannot be combined with the step's `shell` or `prefix` options. Other step behavior, including `dir`, `env`, and automatic batching for large file lists, continues to apply.
 
+### Focus checks on failing files
+
+For tools whose detailed `check` output cannot identify failing files in a machine-readable form, set `check_failed_files = true` and provide either `check_list_files` or `check_diff`:
+
+```pkl
+local linters = new Mapping<String, Step> {
+    ["my-linter"] {
+        glob = List("**/*.py")
+        check_list_files = "my-linter --list-failing-files {{files}}"
+        check = "my-linter check {{files}}"
+        fix = "my-linter fix {{files}}"
+        check_failed_files = true
+    }
+}
+```
+
+In check mode, hk first runs `check_diff` or `check_list_files` over the complete job. If that command reports a failure, hk extracts and deduplicates the affected paths, then runs `check` only on those files so its full diagnostics remain available without rendering every input path again. If both file-reporting commands are configured, `check_diff` takes precedence.
+
+This behavior is opt-in because it adds another process invocation and requires `check` to accept file arguments. Enabling it requires `check` and at least one of `check_diff` or `check_list_files`. Paths not present in the original job are ignored, focused commands retain automatic argument-limit batching, and a failure from the file-reporting command remains authoritative if the focused check unexpectedly succeeds.
+
 ### `<GROUP>`
 
 A group is a collection of steps that are executed in parallel, waiting for previous steps/groups to finish and blocking other steps/groups from starting until it finishes. This is a naive way to ensure the order of execution. It's better to make use of read/write locks and depends.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -21,7 +21,7 @@ hk hooks perform the following assuming `fix = true`:
   * if any of the files have been modified and match the `stage` globs, they will be added to the git index (defaults to the step's `glob` for steps with a `fix` command)
 * untracked/unstaged changes are unstashed
 
-If `fix = false`, hk will just run the `check` steps and won't need to deal with read/write locks as nothing should be making modifications.
+If `fix = false`, hk will just run the `check` steps and won't need to deal with read/write locks as nothing should be making modifications. Steps with [`check_failed_files = true`](/configuration#focus-checks-on-failing-files) first use `check_diff` or `check_list_files` to identify affected paths, then run the detailed `check` command only on that focused set.
 
 ## `pre-commit`
 

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -485,6 +485,16 @@ class Step {
   /// Falls back to running the fix command if patch application fails.
   check_diff: (String | Script | Command)?
 
+  /// Default: `false`
+  ///
+  /// If true, check mode first runs `check_diff` or `check_list_files` to
+  /// identify failing files, then runs `check` only on those files. This keeps
+  /// detailed diagnostics while avoiding commands and suggestions containing
+  /// every file in a large repository.
+  ///
+  /// Requires `check` and at least one of `check_diff` or `check_list_files`.
+  check_failed_files: Boolean = false
+
   /// A command to run that modifies files.
   /// This typically is a "fix" command like `eslint --fix` or `prettier --write`.
   /// Templates variables are the same as for `check`.

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -230,13 +230,18 @@ impl Step {
                 } else {
                     vec![job]
                 };
-                let additional_jobs = jobs.len().saturating_sub(1);
-                ctx.increment_job_count(additional_jobs);
-                ctx.hook_ctx.inc_total_jobs(additional_jobs);
 
                 let mut files_to_return = IndexSet::new();
                 let mut last_job = None;
-                for mut job in jobs {
+                for (index, mut job) in jobs.into_iter().enumerate() {
+                    // Focused batches run sequentially. Register each
+                    // additional batch only when it is about to run so a
+                    // failure cannot leave later, unrun batches in progress
+                    // totals.
+                    if index > 0 {
+                        ctx.increment_job_count(1);
+                        ctx.hook_ctx.inc_total_jobs(1);
+                    }
                     let result = step.run(&ctx, &mut job).await;
                     if let Err(err) = &result {
                         if focused_check_failed

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -222,31 +222,54 @@ impl Step {
                             );
                         }
                 }
-                let mut result = step.run(&ctx, &mut job).await;
-                // The file-listing check is authoritative. If it found
-                // failures but the focused diagnostic check unexpectedly
-                // succeeds, keep the overall step failed and preserve the
-                // original output instead of silently hiding the mismatch.
-                if result.is_ok() && focused_check_failed {
-                    if let Some((stdout, stderr, combined)) = &focused_check_output {
-                        step.save_output_summary(&ctx, &job, stdout, stderr, combined, true);
-                    }
-                    result = Err(eyre::eyre!(
-                        "{step}: file-listing check failed but focused check succeeded"
-                    ));
-                }
-                if let Err(err) = &result {
-                    job.status_errored(&ctx, format!("{err}")).await?;
-                }
-                ctx.hook_ctx.inc_completed_jobs(1);
-                // Return the actual files that were processed after filtering
-                // If job was skipped (status still Pending or marked skipped), return empty
-                let files_to_return = if matches!(job.status, StepJobStatus::Pending) {
-                    vec![]
+                // The initial auto-batching pass sizes the file-listing
+                // command. Reapply it after narrowing so a larger focused
+                // check command receives the same ARG_MAX protection.
+                let jobs = if focused_check_failed {
+                    step.auto_batch_jobs(vec![job], &ctx.hook_ctx.tctx)?
                 } else {
-                    job.files
+                    vec![job]
                 };
-                result.map(|_| files_to_return)
+                let additional_jobs = jobs.len().saturating_sub(1);
+                ctx.increment_job_count(additional_jobs);
+                ctx.hook_ctx.inc_total_jobs(additional_jobs);
+
+                let mut files_to_return = IndexSet::new();
+                let mut last_job = None;
+                for mut job in jobs {
+                    let result = step.run(&ctx, &mut job).await;
+                    if let Err(err) = &result {
+                        job.status_errored(&ctx, format!("{err}")).await?;
+                    }
+                    ctx.hook_ctx.inc_completed_jobs(1);
+                    if !matches!(job.status, StepJobStatus::Pending) {
+                        files_to_return.extend(job.files.clone());
+                    }
+                    result?;
+                    last_job = Some(job);
+                }
+
+                // The file-listing check is authoritative. If every focused
+                // diagnostic command completed successfully, keep the overall
+                // step failed and preserve the original output. Cancellation
+                // returns Ok without executing a command and must not be
+                // reported as a contradictory success.
+                if focused_check_failed && !ctx.hook_ctx.failed.is_cancelled() {
+                    if let Some((stdout, stderr, combined)) = &focused_check_output
+                        && let Some(job) = &last_job
+                    {
+                        step.save_output_summary(&ctx, job, stdout, stderr, combined, true);
+                    }
+                    let err = eyre::eyre!(
+                        "{step}: file-listing check failed but focused check succeeded"
+                    );
+                    if let Some(job) = &mut last_job {
+                        job.status_errored(&ctx, format!("{err}")).await?;
+                    }
+                    return Err(err);
+                }
+
+                Ok(files_to_return.into_iter().collect())
             });
         }
         let mut actual_job_files: IndexSet<PathBuf> = IndexSet::new();

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -226,7 +226,23 @@ impl Step {
                 // command. Reapply it after narrowing so a larger focused
                 // check command receives the same ARG_MAX protection.
                 let jobs = if focused_check_failed {
-                    step.auto_batch_jobs(vec![job], &ctx.hook_ctx.tctx)?
+                    let batch_error_job = job.clone();
+                    match step.auto_batch_jobs(vec![job], &ctx.hook_ctx.tctx) {
+                        Ok(jobs) => jobs,
+                        Err(err) => {
+                            if let Some((stdout, stderr, combined)) = &focused_check_output {
+                                step.save_output_summary(
+                                    &ctx,
+                                    &batch_error_job,
+                                    stdout,
+                                    stderr,
+                                    combined,
+                                    true,
+                                );
+                            }
+                            return Err(err);
+                        }
+                    }
                 } else {
                     vec![job]
                 };

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -105,6 +105,8 @@ impl Step {
             let step = self.clone();
             let mut job = job;
             set.spawn(async move {
+                let mut focused_check_failed = false;
+                let mut focused_check_output: Option<(String, String, String)> = None;
                 if let Some(reason) = &job.skip_reason {
                     step.mark_skipped(&ctx, reason)?;
                     // Skipped jobs reduce the total rather than incrementing completed
@@ -134,6 +136,13 @@ impl Step {
                                     debug!("{step}: check stderr output:\n{}", stderr);
                                 }
                                 check_first_output = Some((stdout.clone(), stderr.clone(), combined.clone()));
+                                if step.check_failed_files
+                                    && matches!(prev_run_type, RunType::Check)
+                                {
+                                    focused_check_failed = true;
+                                    focused_check_output =
+                                        Some((stdout.clone(), stderr.clone(), combined.clone()));
+                                }
                                 // Parse according to the check-first command that actually ran.
                                 // Platform-specific Script values can be empty, in which case
                                 // check_first_cmd falls back to the next available command.
@@ -213,7 +222,19 @@ impl Step {
                             );
                         }
                 }
-                let result = step.run(&ctx, &mut job).await;
+                let mut result = step.run(&ctx, &mut job).await;
+                // The file-listing check is authoritative. If it found
+                // failures but the focused diagnostic check unexpectedly
+                // succeeds, keep the overall step failed and preserve the
+                // original output instead of silently hiding the mismatch.
+                if result.is_ok() && focused_check_failed {
+                    if let Some((stdout, stderr, combined)) = &focused_check_output {
+                        step.save_output_summary(&ctx, &job, stdout, stderr, combined, true);
+                    }
+                    result = Err(eyre::eyre!(
+                        "{step}: file-listing check failed but focused check succeeded"
+                    ));
+                }
                 if let Err(err) = &result {
                     job.status_errored(&ctx, format!("{err}")).await?;
                 }

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -239,6 +239,13 @@ impl Step {
                 for mut job in jobs {
                     let result = step.run(&ctx, &mut job).await;
                     if let Err(err) = &result {
+                        if focused_check_failed
+                            && let Some((stdout, stderr, combined)) = &focused_check_output
+                        {
+                            step.save_output_summary(
+                                &ctx, &job, stdout, stderr, combined, true,
+                            );
+                        }
                         job.status_errored(&ctx, format!("{err}")).await?;
                     }
                     ctx.hook_ctx.inc_completed_jobs(1);

--- a/src/step/job_builder.rs
+++ b/src/step/job_builder.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use super::types::{RunType, Step};
+use super::types::{CheckFirstCmd, RunType, Step};
 
 impl Step {
     /// Create step jobs from a list of files.
@@ -173,10 +173,20 @@ impl Step {
         // In Check mode, this is avoided as check_diff may hide non-auto-fixable errors.
         let can_apply_diff = self.check_diff.is_some() && matches!(run_type, RunType::Fix);
 
+        // Optionally use the list/diff command to focus the regular check on
+        // only the files that failed. This is opt-in because it adds a second
+        // tool invocation and not every check command accepts file arguments.
+        let needs_focused_check = self.check_failed_files
+            && matches!(run_type, RunType::Check)
+            && matches!(
+                self.check_first_cmd(),
+                Some(CheckFirstCmd::Diff(_) | CheckFirstCmd::ListFiles(_))
+            );
+
         for job in jobs.iter_mut() {
-            if needs_filtering_for_stage || can_apply_diff {
+            if needs_filtering_for_stage || can_apply_diff || needs_focused_check {
                 // Always run check_first when we need to filter files for stage=<JOB_FILES>
-                // or when we can apply the diff directly
+                // or when we can apply the diff directly or focus a check
                 job.check_first = true;
             } else if job.check_first {
                 // Only adjust check_first for jobs where it was already enabled from config

--- a/src/step/output.rs
+++ b/src/step/output.rs
@@ -11,6 +11,8 @@ use std::sync::Arc;
 
 use super::types::{OutputSummary, RunType, Step};
 
+const MAX_INLINE_FIX_COMMAND_CHARS: usize = 2048;
+
 impl Step {
     /// Save command output for the end-of-run summary.
     ///
@@ -134,9 +136,10 @@ impl Step {
             && let Ok(rendered) = fix_cmd.render(&suggest_ctx, self.prefix.as_deref())
         {
             let rendered = rendered.display(self.shell_type());
-            let is_multi_line = rendered.contains('\n');
-            if is_multi_line {
-                // Too long to inline; suggest hk fix with step filter
+            let should_use_hk_fix =
+                rendered.contains('\n') || rendered.chars().count() > MAX_INLINE_FIX_COMMAND_CHARS;
+            if should_use_hk_fix {
+                // Multi-line or overly long commands are clearer through hk.
                 let step_flag = format!("-S {}", &self.name);
                 let cmd = format!(
                     "To fix, run: {}",

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -384,6 +384,15 @@ impl Step {
                 name
             );
         }
+        if self.check_failed_files
+            && (self.check.is_none()
+                || (self.check_diff.is_none() && self.check_list_files.is_none()))
+        {
+            eyre::bail!(
+                "Step '{name}' with `check_failed_files = true` requires `check` and at least one \
+                 of `check_diff` or `check_list_files`."
+            );
+        }
         let commands = [
             self.check.as_ref(),
             self.check_list_files.as_ref(),

--- a/src/step/types.rs
+++ b/src/step/types.rs
@@ -201,6 +201,10 @@ pub struct Step {
     #[serde_as(as = "Option<PickFirst<(_, DisplayFromStr)>>")]
     pub check_diff: Option<Command>,
 
+    /// Run a file-listing check first, then check only the failing files
+    #[serde(default)]
+    pub check_failed_files: bool,
+
     /// Command to fix issues
     #[serde_as(as = "Option<PickFirst<(_, DisplayFromStr)>>")]
     pub fix: Option<Command>,

--- a/src/step_context.rs
+++ b/src/step_context.rs
@@ -44,6 +44,23 @@ impl StepContext {
         }
     }
 
+    pub fn increment_job_count(&self, count: usize) {
+        if count == 0 {
+            return;
+        }
+        *self.jobs_remaining.lock().unwrap() += count;
+        let jobs_total = {
+            let mut jobs_total = self.jobs_total.lock().unwrap();
+            *jobs_total += count;
+            *jobs_total
+        };
+        if jobs_total > 1 {
+            self.progress.progress_total(jobs_total);
+            self.progress.prop("show_step_progress", &true);
+        }
+        self.update_progress();
+    }
+
     pub fn add_files(&self, added_paths: &[PathBuf], created_paths: &[PathBuf]) {
         let mut files_added = self.files_added.lock().unwrap();
         files_added.extend(added_paths.iter().cloned());

--- a/src/step_job.rs
+++ b/src/step_job.rs
@@ -147,7 +147,10 @@ impl StepJob {
 
     pub async fn status_errored(&mut self, ctx: &StepContext, err: String) -> Result<()> {
         match &mut self.status {
-            StepJobStatus::Pending | StepJobStatus::Started(_) => {}
+            // A command may finish successfully before an orchestration-level
+            // postcondition detects a failure (for example, disagreement
+            // between a file-listing check and a focused diagnostic check).
+            StepJobStatus::Pending | StepJobStatus::Started(_) | StepJobStatus::Finished => {}
             _ => unreachable!("invalid status: {:?}", self.status),
         }
         self.status = StepJobStatus::Errored(err.to_string());

--- a/test/auto_batch_large_files.bats
+++ b/test/auto_batch_large_files.bats
@@ -127,3 +127,35 @@ EOF
     assert_success
     assert_output --partial "Fixing"
 }
+
+@test "focused check is rebatched after file-list filtering" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["focused"] {
+                check_list_files = "find very -type f; exit 1"
+                check = "echo batch >> batches.log; echo '{{files}}' > /dev/null"
+                check_failed_files = true
+            }
+        }
+    }
+}
+EOF
+
+    # The listing command is short, while the focused command exceeds Linux's
+    # per-argument limit and must be sized again after the files are filtered.
+    for i in {1..1200}; do
+        dir="very/long/directory/path/number/$i/with/many/levels/to/increase/path/length"
+        mkdir -p "$dir"
+        echo "test" > "$dir/file_with_very_long_name_to_increase_arg_size_$i.txt"
+    done
+
+    run hk check --all
+    assert_failure
+    assert_output --partial "file-listing check failed but focused check succeeded"
+    if [[ "$OSTYPE" == "linux"* ]]; then
+        [ "$(wc -l < batches.log)" -gt 1 ]
+    fi
+}

--- a/test/auto_batch_large_files.bats
+++ b/test/auto_batch_large_files.bats
@@ -159,3 +159,32 @@ EOF
         [ "$(wc -l < batches.log)" -gt 1 ]
     fi
 }
+
+@test "focused re-batch errors preserve listing diagnostics" {
+    if [[ "$OSTYPE" != "linux"* ]]; then
+        skip "Linux MAX_ARG_STRLEN behavior"
+    fi
+
+    max_arg_strlen=$(( $(getconf PAGESIZE) * 32 ))
+    oversized=$(printf '%*s' "$max_arg_strlen" '' | tr ' ' x)
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["focused"] {
+                check_list_files = "sh -c 'echo bad.txt; echo listing-diagnostic >&2; exit 1'"
+                check = "echo $oversized {{files}}"
+                check_failed_files = true
+            }
+        }
+    }
+}
+EOF
+    echo "bad" > bad.txt
+
+    run hk check --all
+    assert_failure
+    assert_output --partial "listing-diagnostic"
+    assert_output --partial "command-line limit"
+}

--- a/test/check_fix_suggestion.bats
+++ b/test/check_fix_suggestion.bats
@@ -161,6 +161,30 @@ EOF
     assert_output --partial "file-listing check failed but focused check succeeded"
 }
 
+@test "check_failed_files preserves listing diagnostics when focused check fails" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["lint"] {
+        check_list_files = "sh -c 'echo a.js; echo listing-diagnostic >&2; exit 1'"
+        check = "sh -c 'echo focused-diagnostic >&2; exit 1'"
+        check_failed_files = true
+      }
+    }
+  }
+}
+EOF
+
+    echo "bad" > a.js
+
+    run hk check a.js
+    assert_failure
+    assert_output --partial "listing-diagnostic"
+    assert_output --partial "focused-diagnostic"
+}
+
 @test "long fix suggestion falls back to focused hk command" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"

--- a/test/check_fix_suggestion.bats
+++ b/test/check_fix_suggestion.bats
@@ -110,3 +110,102 @@ EOF
     # Should not print the multi-line fix body
     refute_output --partial "echo line1"
 }
+
+@test "check_failed_files runs detailed check only on listed files" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["lint"] {
+        check_list_files = "sh -c 'echo a.js; exit 1'"
+        check = "sh -c 'echo detailed:{{files}} >&2; exit 1'"
+        fix = "echo fix {{files}}"
+        check_failed_files = true
+      }
+    }
+  }
+}
+EOF
+
+    echo "bad" > a.js
+    echo "good" > b.js
+
+    run hk check a.js b.js
+    assert_failure
+    assert_output --partial "detailed:a.js"
+    refute_output --partial "detailed:a.js b.js"
+    assert_output --partial "To fix, run: echo fix a.js"
+}
+
+@test "check_failed_files keeps listing failure authoritative" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["lint"] {
+        check_list_files = "sh -c 'echo a.js; exit 1'"
+        check = "echo focused {{files}}"
+        check_failed_files = true
+      }
+    }
+  }
+}
+EOF
+
+    echo "bad" > a.js
+
+    run hk check a.js
+    assert_failure
+    assert_output --partial "file-listing check failed but focused check succeeded"
+}
+
+@test "long fix suggestion falls back to focused hk command" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["fmt"] {
+        check = "exit 1"
+        fix = "echo fix {{files}}"
+      }
+    }
+  }
+}
+EOF
+
+    files=()
+    for i in $(seq 1 400); do
+        file="long-filename-for-output-$i.js"
+        echo "bad" > "$file"
+        files+=("$file")
+    done
+
+    run hk check "${files[@]}"
+    assert_failure
+    assert_output --partial "To fix, run: hk fix -S fmt"
+    refute_output --partial "To fix, run: echo fix"
+}
+
+@test "check_failed_files validates required commands" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["lint"] {
+        check = "exit 1"
+        check_failed_files = true
+      }
+    }
+  }
+}
+EOF
+
+    run hk validate
+    assert_failure
+    assert_output --partial \
+        "check_failed_files = true\` requires \`check\` and at least one of \`check_diff\` or \`check_list_files"
+}


### PR DESCRIPTION
## Summary

- add an opt-in `check_failed_files` step setting
- run `check_diff` or `check_list_files` first, then run `check` only on the reported files
- keep the file-listing failure authoritative when the focused check unexpectedly succeeds
- bound inline fix suggestions and fall back to `hk fix -S <step>` for oversized commands

## Why

Large repositories can produce enormous fix suggestions when a detailed checker reports an error but cannot identify the failing files separately. This lets configurations combine a compact file-listing command with the checker's full diagnostics without passing every repository file to the second invocation.

This addresses the workflow proposed in [discussion #1122](https://github.com/jdx/hk/discussions/1122).

## Validation

- `mise run test:cargo` — 204 tests passed
- `bats test/check_fix_suggestion.bats` — 8 tests passed
- targeted `hk check` for all changed files passed
- the repository-wide `hk check --all` was also attempted; unrelated workflow linting could not run because the environment's ShellCheck mise shim has no configured version

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core check-first execution path and job/progress accounting, but the behavior is opt-in and covered by new bats tests; misconfiguration is caught at validate time.
> 
> **Overview**
> Adds an opt-in **`check_failed_files`** step setting so check mode can run **`check_diff` or `check_list_files`** over the full job, then run the detailed **`check`** only on paths reported as failing—keeping full diagnostics without passing every matched file to the second command.
> 
> **Execution changes:** job building forces check-first when this flag is set in check mode; after the listing/diff fails, the runner re-applies **ARG_MAX auto-batching** on the narrowed file set, runs focused batches **sequentially** with adjusted progress totals, and treats the **listing failure as authoritative** if focused `check` succeeds anyway (preserving original output). Listing diagnostics are kept when focused checks or re-batch sizing fail. **`hk validate`** rejects misconfigured steps missing `check` or a file-reporting command.
> 
> **UX:** inline “To fix, run” suggestions now fall back to **`hk fix -S <step>`** when the rendered fix command exceeds **2048 characters** (not only multi-line). Docs cover the new option and hook behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ed4413fd16b402b06a5b776267484a8b212e702. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->