### PR TITLE
chore(deps): use rust-aware cargo resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ build = "build/mod.rs"
 description = "A tool for managing git hooks"
 documentation = "https://hk.jdx.dev"
 edition = "2024"
-resolver = "3"
 homepage = "https://hk.jdx.dev"
 include = [
   "/src/**/*",
@@ -19,6 +18,7 @@ include = [
 license = "MIT"
 name = "hk"
 repository = "https://github.com/jdx/hk"
+resolver = "3"
 rust-version = "1.88.0"
 version = "1.53.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ build = "build/mod.rs"
 description = "A tool for managing git hooks"
 documentation = "https://hk.jdx.dev"
 edition = "2024"
+resolver = "3"
 homepage = "https://hk.jdx.dev"
 include = [
   "/src/**/*",


### PR DESCRIPTION
## Summary
- explicitly select Cargo resolver version 3
- make Rust-version-aware dependency selection intentional and visible

## Why
Resolver 3 prefers dependency releases compatible with hk's declared Rust 1.88 MSRV, reducing accidental MSRV breakage during lockfile maintenance. Edition 2024 already implies resolver 3; declaring it explicitly keeps the policy visible in the manifest.

## Validation
- `cargo metadata --locked --no-deps --format-version 1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a4daf6c87f3cf93cb57d6a9c1eb295e809d82eae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s package configuration to use Cargo’s latest dependency resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->