### PR TITLE
fix(hook): suggest serialization for git index lock failures

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,7 +164,7 @@ This behavior is opt-in because it adds another process invocation and requires 
 
 A group is a collection of steps that are executed in parallel, waiting for previous steps/groups to finish and blocking other steps/groups from starting until it finishes. This is a naive way to ensure the order of execution. It's better to make use of read/write locks and depends.
 
-Commands that write the Git index, including scripts that invoke `git add` or `git update-index`, must not run concurrently. hk cannot infer those hidden writes from a command, so serialize them with `exclusive = true`, a `depends` chain, or separate groups.
+Steps should not normally run `git add` or `git update-index` themselves. Declare generated or modified files with the step's `stage` setting and let hk stage them; hk serializes its own index writes. If a legacy or third-party command stages files internally and cannot be changed, hk cannot infer that hidden write, so serialize it with `exclusive = true`, a `depends` chain, or a separate group.
 
 ```pkl
 hooks {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,6 +164,8 @@ This behavior is opt-in because it adds another process invocation and requires 
 
 A group is a collection of steps that are executed in parallel, waiting for previous steps/groups to finish and blocking other steps/groups from starting until it finishes. This is a naive way to ensure the order of execution. It's better to make use of read/write locks and depends.
 
+Commands that write the Git index, including scripts that invoke `git add` or `git update-index`, must not run concurrently. hk cannot infer those hidden writes from a command, so serialize them with `exclusive = true`, a `depends` chain, or separate groups.
+
 ```pkl
 hooks {
     ["pre-commit"] {

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -686,8 +686,9 @@ class Step {
   /// If true, this step will wait for any previous steps to finish before running.
   /// No other steps will start until this one finishes.
   /// Under the hood this groups the previous steps into a group.
-  /// Use this for commands that access shared resources hk cannot infer, such as
-  /// commands or scripts that write the Git index with `git add` or `git update-index`.
+  /// Prefer declaring generated files with `stage` and letting hk own Git staging.
+  /// Use this for legacy or third-party commands that access shared resources hk
+  /// cannot infer, such as scripts that cannot avoid writing the Git index themselves.
   ///
   /// ```pkl
   /// hooks {

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -686,6 +686,8 @@ class Step {
   /// If true, this step will wait for any previous steps to finish before running.
   /// No other steps will start until this one finishes.
   /// Under the hood this groups the previous steps into a group.
+  /// Use this for commands that access shared resources hk cannot infer, such as
+  /// commands or scripts that write the Git index with `git add` or `git update-index`.
   ///
   /// ```pkl
   /// hooks {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -8,7 +8,10 @@ use std::{
     ffi::OsString,
     fmt,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex as StdMutex},
+    sync::{
+        Arc, Mutex as StdMutex,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 use tokio::{
     signal,
@@ -321,6 +324,9 @@ pub struct HookContext {
     pub failed_steps: std::sync::Mutex<HashSet<String>>,
     /// Collected fix suggestions to display at end of run
     pub fix_suggestions: std::sync::Mutex<Vec<String>>,
+    /// Whether a failed step reported Git's index lock. This is tracked at the
+    /// hook level so concurrent failures still produce only one actionable hint.
+    git_index_lock_contention: AtomicBool,
     pub should_stage: bool,
     /// Untracked files at the start of the hook run, used to avoid staging
     /// pre-existing untracked files that were not created by a fixer.
@@ -371,6 +377,7 @@ impl HookContext {
             output_by_step: StdMutex::new(IndexMap::new()),
             failed_steps: StdMutex::new(HashSet::new()),
             fix_suggestions: StdMutex::new(Vec::new()),
+            git_index_lock_contention: AtomicBool::new(false),
             should_stage,
             initial_untracked,
         }
@@ -472,6 +479,15 @@ impl HookContext {
 
     pub fn take_fix_suggestions(&self) -> Vec<String> {
         self.fix_suggestions.lock().unwrap().clone()
+    }
+
+    pub fn mark_git_index_lock_contention(&self) {
+        self.git_index_lock_contention
+            .store(true, Ordering::Relaxed);
+    }
+
+    pub fn saw_git_index_lock_contention(&self) -> bool {
+        self.git_index_lock_contention.load(Ordering::Relaxed)
     }
 }
 
@@ -1239,6 +1255,19 @@ impl Hook {
                 eprintln!("\n{}", style::ebold(format!("{} {}:", step_name, label)));
                 eprintln!("{}", trimmed);
             }
+        }
+
+        if !settings.silent && hook_ctx.saw_git_index_lock_contention() {
+            eprintln!(
+                "\n{}",
+                style::eyellow(
+                    "hint: this may be contention between concurrent steps that write the Git index."
+                )
+            );
+            eprintln!(
+                "      serialize index-writing steps with `exclusive = true`, `depends`, or separate groups."
+            );
+            eprintln!("      https://hk.jdx.dev/hooks#hook-behavior");
         }
 
         // Display summary of profile-skipped steps

--- a/src/step/output.rs
+++ b/src/step/output.rs
@@ -13,7 +13,20 @@ use super::types::{OutputSummary, RunType, Step};
 
 const MAX_INLINE_FIX_COMMAND_CHARS: usize = 2048;
 
+/// Git localizes and occasionally changes the surrounding error text, but the
+/// lock filename itself is stable. Keep this deliberately narrow so ordinary
+/// command failures do not receive Git-specific advice.
+pub(crate) fn indicates_git_index_lock_contention(output: &str) -> bool {
+    output.to_ascii_lowercase().contains("index.lock")
+}
+
 impl Step {
+    pub(crate) fn collect_failure_hint(&self, ctx: &StepContext, combined: &str) {
+        if indicates_git_index_lock_contention(combined) {
+            ctx.hook_ctx.mark_git_index_lock_contention();
+        }
+    }
+
     /// Save command output for the end-of-run summary.
     ///
     /// Based on the step's `output_summary` setting, captures the appropriate
@@ -151,5 +164,28 @@ impl Step {
                 ctx.hook_ctx.add_fix_suggestion(cmd);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::indicates_git_index_lock_contention;
+
+    #[test]
+    fn detects_git_index_lock_output_without_relying_on_surrounding_wording() {
+        assert!(indicates_git_index_lock_contention(
+            "fatal: Unable to create '/repo/.git/index.lock': File exists."
+        ));
+        assert!(indicates_git_index_lock_contention(
+            "fatal: could not create C:\\repo\\.git\\INDEX.LOCK"
+        ));
+    }
+
+    #[test]
+    fn ignores_generic_index_write_failures() {
+        assert!(!indicates_git_index_lock_contention(
+            "fatal: could not write index"
+        ));
+        assert!(!indicates_git_index_lock_contention("lint failed"));
     }
 }

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -324,6 +324,7 @@ impl Step {
             }
             Err(err) => {
                 if let ensembler::Error::ScriptFailed(e) = &err {
+                    self.collect_failure_hint(ctx, &e.3.combined_output);
                     if job.check_first
                         && matches!(
                             check_first_cmd,

--- a/test/index_lock_hint.bats
+++ b/test/index_lock_hint.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "index lock failure suggests serializing concurrent steps once" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+fail_fast = false
+hooks {
+  ["check"] {
+    steps {
+      ["writer-a"] {
+        check = "echo \"fatal: Unable to create '/repo/.git/index.lock': File exists.\" >&2; exit 128"
+        glob = "*.txt"
+      }
+      ["writer-b"] {
+        check = "echo \"fatal: Unable to create '/repo/.git/index.lock': File exists.\" >&2; exit 128"
+        glob = "*.txt"
+      }
+    }
+  }
+}
+EOF
+    echo "content" > file.txt
+    git add file.txt
+
+    run hk check
+    assert_failure
+    assert_output --partial "hint: this may be contention between concurrent steps that write the Git index."
+    assert_output --partial 'serialize index-writing steps with `exclusive = true`, `depends`, or separate groups.'
+    count=$(echo "$output" | grep -c "hint: this may be contention" || true)
+    [ "$count" -eq 1 ] || fail "hint appeared $count times, expected 1"
+}
+
+@test "ordinary command failure does not show index lock hint" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["lint"] {
+        check = "echo 'lint failed' >&2; exit 1"
+        glob = "*.txt"
+      }
+    }
+  }
+}
+EOF
+    echo "content" > file.txt
+    git add file.txt
+
+    run hk check
+    assert_failure
+    refute_output --partial "hint: this may be contention"
+}
+
+@test "silent mode suppresses index lock hint" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["writer"] {
+        check = "echo \"fatal: Unable to create '/repo/.git/index.lock': File exists.\" >&2; exit 128"
+        glob = "*.txt"
+      }
+    }
+  }
+}
+EOF
+    echo "content" > file.txt
+    git add file.txt
+
+    run hk check --silent
+    assert_failure
+    refute_output --partial "hint: this may be contention"
+}


### PR DESCRIPTION
## Summary

- detect failed step output that references Git's `index.lock`
- emit one hook-level hint recommending `exclusive = true`, `depends`, or separate groups
- document serialization for commands and scripts that write the Git index
- cover deduplication, ordinary failures, and silent mode

## Root cause

hk coordinates steps through their declared files, but opaque commands can invoke `git add` or `git update-index` and contend on Git's index lock without hk knowing that they share a resource. Git's raw error suggests an external process or stale lock without pointing users to hk's existing serialization controls.

This addresses https://github.com/jdx/hk/discussions/1139.

## Validation

- `mise run test:bats test/index_lock_hint.bats`
- `mise run test:cargo`
- `cargo fmt --all -- --check`
- `pkl format --diff-name-only pkl/Config.pkl`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing diagnostics and documentation only; no changes to hook scheduling or Git staging behavior.
> 
> **Overview**
> When a failed step’s output mentions Git’s **`index.lock`**, hk records that at hook scope and prints **one** end-of-run hint (unless **`--silent`**) pointing users to **`exclusive`**, **`depends`**, or separate groups—so parallel steps that touch the index get actionable guidance instead of only Git’s generic lock error.
> 
> Docs now steer authors toward **`stage`** for hk-owned staging and call out **`exclusive`** for legacy/third-party commands that still write the index. Unit tests cover narrow detection; Bats covers deduplication, unrelated failures, and silent mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 680042eeb3631ac3bf8d4779625191c7a13d9cdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer guidance when concurrent operations encounter Git index-lock conflicts.
  * Failure messages now identify likely Git index contention without reporting unrelated command failures.
  * Repeated lock-conflict hints are shown only once and can be suppressed with silent output.

* **Documentation**
  * Documented ways to serialize Git index-writing commands and avoid lock conflicts.

* **Tests**
  * Added coverage for lock detection, duplicate hints, unrelated failures, varied lock-message wording, and silent output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->