### PR TITLE
fix(conventional-commit): allow fixup!, squash!, and amend! commit prefixes

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -4497,6 +4497,7 @@
             "effect": "read",
             "hide": false,
             "help": "Check for conventional commit message",
+            "help_long": "Check for conventional commit message\n\nTitles starting with `fixup! `, `squash! `, or `amend! ` (temporary commits created for `git rebase --autosquash`) skip validation.",
             "name": "check-conventional-commit",
             "aliases": [],
             "hidden_aliases": [],

--- a/docs/cli/util/check-conventional-commit.md
+++ b/docs/cli/util/check-conventional-commit.md
@@ -7,6 +7,8 @@
 
 Check for conventional commit message
 
+Titles starting with `fixup! `, `squash! `, or `amend! ` (temporary commits created for `git rebase --autosquash`) skip validation.
+
 ## Arguments
 
 ### `<COMMIT_MSG_FILE>`

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -713,6 +713,11 @@ cmd util subcommand_required=#true help="Utility commands for file operations" e
         arg <FILES>… help="Files to check for case conflicts" var=#true
     }
     cmd check-conventional-commit help="Check for conventional commit message" effect=read {
+        long_help #"""
+Check for conventional commit message
+
+Titles starting with `fixup! `, `squash! `, or `amend! ` (temporary commits created for `git rebase --autosquash`) skip validation.
+"""#
         flag --allowed-types var=#true default=build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test {
             arg <ALLOWED_TYPES>
         }

--- a/src/cli/util/check_conventional_commit.rs
+++ b/src/cli/util/check_conventional_commit.rs
@@ -39,6 +39,17 @@ fn check_conventional_commit(path: &PathBuf, allowed_types: &[String]) -> Result
 }
 
 fn parse_commit_title(title: &str, allowed_types: &[String]) -> Result<bool> {
+    // `git commit --fixup`/`--squash` and `rebase --autosquash` produce commits titled
+    // `fixup! <msg>` / `squash! <msg>` / `amend! <msg>`. These are meant to be squashed
+    // away by `git rebase --autosquash` and never carry a conventional format themselves,
+    // so skip validation for them.
+    if ["fixup! ", "squash! ", "amend! "]
+        .iter()
+        .any(|prefix| title.starts_with(prefix))
+    {
+        return Ok(true);
+    }
+
     // Per conventional commit spec:
     //
     // 1. Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc.,
@@ -219,5 +230,61 @@ mod tests {
 
         let result = check_conventional_commit(&path, &["test".to_string()]);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_fixup_commit_skipped() {
+        let commit_msg_file = NamedTempFile::new().unwrap();
+        let path = commit_msg_file.path().to_path_buf();
+        fs::write(&path, b"fixup! chore: some description").unwrap();
+
+        let result = check_conventional_commit(&path, &["test".to_string()]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_squash_commit_skipped() {
+        let commit_msg_file = NamedTempFile::new().unwrap();
+        let path = commit_msg_file.path().to_path_buf();
+        fs::write(&path, b"squash! feat: something").unwrap();
+
+        let result = check_conventional_commit(&path, &["test".to_string()]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_amend_commit_skipped() {
+        let commit_msg_file = NamedTempFile::new().unwrap();
+        let path = commit_msg_file.path().to_path_buf();
+        fs::write(&path, b"amend! fix: something").unwrap();
+
+        let result = check_conventional_commit(&path, &["test".to_string()]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_nested_fixup_skipped() {
+        let commit_msg_file = NamedTempFile::new().unwrap();
+        let path = commit_msg_file.path().to_path_buf();
+        fs::write(&path, b"fixup! fixup! chore: deps").unwrap();
+
+        let result = check_conventional_commit(&path, &["test".to_string()]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_fixup_without_space_not_skipped() {
+        let commit_msg_file = NamedTempFile::new().unwrap();
+        let path = commit_msg_file.path().to_path_buf();
+        fs::write(&path, b"fixup!chore: description").unwrap();
+
+        let result = check_conventional_commit(&path, &["test".to_string()]);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .starts_with("Invalid commit type")
+        );
     }
 }

--- a/src/cli/util/mod.rs
+++ b/src/cli/util/mod.rs
@@ -48,6 +48,9 @@ enum UtilCommands {
     /// Check for case-insensitive filename conflicts
     CheckCaseConflict(CheckCaseConflict),
     /// Check for conventional commit message
+    ///
+    /// Titles starting with `fixup! `, `squash! `, or `amend! ` (temporary commits
+    /// created for `git rebase --autosquash`) skip validation.
     CheckConventionalCommit(CheckConventionalCommit),
     /// Check that executable files have shebangs
     CheckExecutablesHaveShebangs(CheckExecutablesHaveShebangs),


### PR DESCRIPTION
## Problem

`hk util check-conventional-commit` rejects the temporary commits created by
`git commit --fixup` / `--squash` (and `--fixup=amend`) with
`Invalid commit type: 'fixup! <type>'`, which makes the
`git rebase --autosquash` workflow unusable with the `check_conventional_commit`
builtin enabled as a `commit-msg` hook.

This was requested in discussion #902.

## Solution

Skip validation for commit titles starting with `fixup! `, `squash! `, or
`amend! ` — the exact prefixes git generates for autosquash commits. These
commits are squashed away by `git rebase --autosquash` and never carry a
conventional format themselves. This matches commitlint's `defaultIgnores`
behavior.

Notes:

- Nested prefixes (`fixup! fixup! chore: deps`) are covered since the check
  only looks at the start of the title.
- A bang without a trailing space (`fixup!chore: ...`) is not git-generated
  and is still validated (and rejected) as before.

## Tests

Added 5 unit tests: skip for each of the three prefixes, nested `fixup!`, and
a regression test that `fixup!` without a space is still rejected.

## Docs

The command's long help now describes the autosquash prefix exemptions, and
the generated CLI docs (`hk.usage.kdl`, `docs/cli/`) were regenerated with
`mise run render:usage`.

---

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conventional-commit validation now allows properly formatted `fixup!`, `squash!`, and `amend!` commit titles.
  * Invalid variants without the required spacing continue to be rejected.

* **Documentation**
  * Command help now explains how autosquash-related commit prefixes are handled during validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

