### PR TITLE
fix(config): report min_hk_version errors without panicking

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use crate::{Result, env, logger, settings::Settings};
 use clap::Parser;
 use clx::progress::ProgressOutput;
+use eyre::WrapErr;
 
 mod builtins;
 mod cache;
@@ -166,7 +167,7 @@ pub async fn run() -> Result<()> {
     ) {
         Arc::new(crate::settings::generated::settings::Settings::default())
     } else {
-        Settings::try_get()?
+        Settings::try_get().wrap_err("Failed to load configuration")?
     };
     if !settings.terminal_progress {
         clx::osc::configure(settings.terminal_progress);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -166,7 +166,7 @@ pub async fn run() -> Result<()> {
     ) {
         Arc::new(crate::settings::generated::settings::Settings::default())
     } else {
-        Settings::get()
+        Settings::try_get()?
     };
     if !settings.terminal_progress {
         clx::osc::configure(settings.terminal_progress);

--- a/test/version.bats
+++ b/test/version.bats
@@ -24,7 +24,7 @@ hooks {
 EOF
 
     run hk check
-    assert_failure
+    assert_failure 1
     assert_output --partial "less than the minimum required version 999.0.0"
     refute_output --partial "panicked"
 }

--- a/test/version.bats
+++ b/test/version.bats
@@ -13,3 +13,18 @@ teardown() {
     run hk --version
     assert_output --regexp "^hk\ [0-9]+\.[0-9]+\.[0-9]+$"
 }
+
+@test "hk check fails cleanly when min_hk_version is not satisfied" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+min_hk_version = "999.0.0"
+hooks {
+    ["check"] { steps { ["a"] { check = "echo checking {{files}}" } } }
+}
+EOF
+
+    run hk check
+    assert_failure
+    assert_output --partial "less than the minimum required version 999.0.0"
+    refute_output --partial "panicked"
+}


### PR DESCRIPTION
## Summary

Follow-up to #1069 / #1070. When `min_hk_version` in `hk.pkl` is newer than the running hk, the error surfaced through the `Failed to load configuration` panic path (`.expect()` in `Settings::get()`), printing a Rust panic message — and aborting with SIGABRT when triggered from a git hook. This was noted as out of scope in both #1069 and #1070.

## Before

```
thread 'main' panicked at src/settings.rs:101:30:
Failed to load configuration: Failed to read config file: .../hk.pkl

Caused by:
    hk version 1.54.0 is less than the minimum required version 999.0.0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## After

```
Error: Failed to load configuration

Caused by:
   0: Failed to read config file: .../hk.pkl
   1: hk version 1.54.0 is less than the minimum required version 999.0.0
```

Exit code 1, no panic. Any other config-load error (e.g. pkl syntax errors) now also surfaces through the same clean path.

## Fix

Replace `Settings::get()` with the existing `Settings::try_get()` at the CLI entry point (`cli::run()`), so config-load errors propagate as a `Result` instead of panicking. The error is wrapped with the same `Failed to load configuration` context the panic message used to carry, so the user-visible wording (and the existing tests asserting it) are unchanged. One line is sufficient:

- All other `Settings::get()` call sites (hook.rs / git.rs / step/*) run only after this initial load succeeds, so they return the cached snapshot and can no longer hit the panic path.
- Commands that don't require `hk.pkl` (`init`, `migrate`, `completion`, etc.) already use `Settings::default()` in the branch just above and are unaffected.

## Tests

Added a bats test that runs `hk check` with `min_hk_version = "999.0.0"` and asserts a non-zero exit, the expected error message, and that the output does not contain `panicked`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: 2.1.220.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configuration-loading errors so failures are reported cleanly with useful context.
  * Fixed version checks to clearly report when the required minimum version is newer than the installed version without crashing.

* **Tests**
  * Added coverage for minimum-version validation and graceful failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
