### PR TITLE
fix(stash): preserve unstaged fixer output

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1062,45 +1062,41 @@ impl Git {
                     })
                     .collect();
 
-                // When staging is disabled, fixer output remains in the isolated worktree
-                // rather than being written to the index. Snapshot it before restoring the
-                // user's unstaged changes so it can be used as the fixer side of the merge.
-                // Map presence identifies hook files; None distinguishes a fixer deletion
-                // from a path that was not processed. Keep bytes so non-UTF-8 output survives.
-                let mut fixer_worktree_map: std::collections::HashMap<PathBuf, Option<Vec<u8>>> =
-                    std::collections::HashMap::new();
-                if !should_stage {
-                    for (_, oid, p) in self
+                // When staging is disabled, fixer output remains in the isolated worktree.
+                // Ask Git which hook files differ from the unchanged index so unchanged files
+                // (especially large or binary ones) are not read eagerly.
+                let fixer_worktree_paths: std::collections::HashSet<PathBuf> = if should_stage {
+                    std::collections::HashSet::new()
+                } else {
+                    let candidate_paths: Vec<&PathBuf> = self
                         .saved_index
                         .as_deref()
                         .unwrap_or_default()
                         .iter()
-                        .filter(|(_, _, p)| stash_paths.contains(p))
-                    {
-                        let contents = match std::fs::read(p) {
-                            Ok(contents) => Some(contents),
-                            Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
-                            Err(err) => {
-                                return Err(err).wrap_err_with(|| {
-                                    format!(
-                                        "failed to snapshot fixer output for {}",
-                                        display_path(p)
-                                    )
-                                });
-                            }
-                        };
-                        let index_contents = git_read_bytes(["cat-file", "-p", oid])
-                            .wrap_err_with(|| {
-                                format!(
-                                    "failed to read saved index content for {}",
-                                    display_path(p)
-                                )
-                            })?;
-                        if contents.as_deref() != Some(index_contents.as_slice()) {
-                            fixer_worktree_map.insert(p.clone(), contents);
-                        }
+                        .map(|(_, _, p)| p)
+                        .filter(|p| stash_paths.contains(p))
+                        .collect();
+                    if candidate_paths.is_empty() {
+                        std::collections::HashSet::new()
+                    } else {
+                        let mut args: Vec<OsString> = vec![
+                            "diff".into(),
+                            "--name-only".into(),
+                            "-z".into(),
+                            "--".into(),
+                        ];
+                        args.extend(
+                            candidate_paths
+                                .iter()
+                                .map(|p| OsString::from(p.as_os_str())),
+                        );
+                        git_read(args)?
+                            .split('\0')
+                            .filter(|s| !s.is_empty())
+                            .map(PathBuf::from)
+                            .collect()
                     }
-                }
+                };
 
                 // Build a map of CURRENT index (post-step) entries to re-stage Fixer blobs.
                 // Only include files that are actually staged-changed to avoid treating unrelated
@@ -1213,48 +1209,82 @@ impl Git {
                         continue;
                     }
 
-                    // A stage-disabled fixer can delete a file or replace it with binary
-                    // content. Neither result can participate in the text merge below, so
-                    // restore it directly while leaving the original index untouched.
-                    match fixer_worktree_map.get(&path) {
-                        Some(None) => {
-                            debug!(
-                                "manual-unstash: preserving fixer deletion path={}",
-                                display_path(&path)
-                            );
-                            if let Err(err) = std::fs::remove_file(&path)
-                                && err.kind() != std::io::ErrorKind::NotFound
-                            {
+                    let has_fixer = if should_stage {
+                        fixer_map.contains_key(&path)
+                    } else {
+                        fixer_worktree_paths.contains(&path)
+                    };
+                    let work_ref = format!("{}:{}", &stash_ref, path_str);
+                    let work_size = git_cmd_silent(["cat-file", "-s", &work_ref])
+                        .read()
+                        .ok()
+                        .and_then(|size| size.trim().parse::<usize>().ok());
+                    if work_size.unwrap_or(0) >= LARGE_STASH_FILE_BYTES && !has_fixer {
+                        debug!(
+                            "manual-unstash: large file without fixer; restoring worktree snapshot directly path={} size={}",
+                            display_path(&path),
+                            work_size.unwrap_or(0)
+                        );
+                        if let Ok(bytes) = git_read_bytes(["cat-file", "-p", &work_ref]) {
+                            if let Err(err) = xx::file::write(&path, &bytes) {
                                 warn!(
-                                    "failed to preserve fixer deletion for {}: {err:?}",
+                                    "failed to write large worktree snapshot for {}: {err:?}",
                                     display_path(&path)
                                 );
                                 restoration_failed = true;
                             }
-                            continue;
-                        }
-                        Some(Some(contents)) if std::str::from_utf8(contents).is_err() => {
-                            debug!(
-                                "manual-unstash: preserving binary fixer output path={}",
+                        } else {
+                            warn!(
+                                "failed to read large worktree snapshot for {}",
                                 display_path(&path)
                             );
-                            if let Err(err) = xx::file::write(&path, contents) {
-                                warn!(
-                                    "failed to preserve binary fixer output for {}: {err:?}",
-                                    display_path(&path)
-                                );
-                                restoration_failed = true;
-                            }
-                            continue;
+                            restoration_failed = true;
                         }
-                        _ => {}
+                        continue;
                     }
+
+                    let fixer_worktree = if !should_stage && has_fixer {
+                        match std::fs::read(&path) {
+                            Ok(contents) => match String::from_utf8(contents) {
+                                Ok(contents) => Some(contents),
+                                Err(err) => {
+                                    debug!(
+                                        "manual-unstash: preserving binary fixer output path={}",
+                                        display_path(&path)
+                                    );
+                                    if let Err(write_err) = xx::file::write(&path, err.as_bytes()) {
+                                        warn!(
+                                            "failed to preserve binary fixer output for {}: {write_err:?}",
+                                            display_path(&path)
+                                        );
+                                        restoration_failed = true;
+                                    }
+                                    continue;
+                                }
+                            },
+                            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                                debug!(
+                                    "manual-unstash: preserving fixer deletion path={}",
+                                    display_path(&path)
+                                );
+                                continue;
+                            }
+                            Err(err) => {
+                                warn!(
+                                    "failed to read fixer output for {}: {err:?}",
+                                    display_path(&path)
+                                );
+                                restoration_failed = true;
+                                continue;
+                            }
+                        }
+                    } else {
+                        None
+                    };
 
                     // Detect binary files: try reading the worktree blob as UTF-8.
                     // If it fails, restore using raw bytes and skip text merging entirely.
-                    let work_bytes =
-                        git_read_bytes(["cat-file", "-p", &format!("{}:{}", &stash_ref, path_str)])
-                            .ok();
+                    let work_bytes = git_read_bytes(["cat-file", "-p", &work_ref]).ok();
                     let is_binary = work_bytes
                         .as_ref()
                         .is_some_and(|b| std::str::from_utf8(b).is_err());
@@ -1276,36 +1306,6 @@ impl Git {
                         continue;
                     }
 
-                    let work_size: Option<usize> = work_bytes.as_ref().map(|b| b.len());
-                    let has_fixer = if should_stage {
-                        fixer_map.contains_key(&path)
-                    } else {
-                        fixer_worktree_map.contains_key(&path)
-                    };
-                    if work_size.unwrap_or(0) >= LARGE_STASH_FILE_BYTES && !has_fixer {
-                        debug!(
-                            "manual-unstash: large file without fixer; restoring worktree snapshot directly path={} size={}",
-                            display_path(&path),
-                            work_size.unwrap_or(0)
-                        );
-                        if let Some(bytes) = &work_bytes {
-                            if let Err(err) = xx::file::write(&path, bytes) {
-                                warn!(
-                                    "failed to write large worktree snapshot for {}: {err:?}",
-                                    display_path(&path)
-                                );
-                                restoration_failed = true;
-                            }
-                        } else {
-                            warn!(
-                                "failed to read large worktree snapshot for {}",
-                                display_path(&path)
-                            );
-                            restoration_failed = true;
-                        }
-                        // Skip normal merge path for large files
-                        continue;
-                    }
                     // Worktree content and Base (HEAD at stash time) from stash
                     // Prefer saved worktree snapshot captured before stashing; fallback to stash blob
                     // Prefer saved worktree snapshot; fall back to already-fetched work_bytes
@@ -1332,11 +1332,7 @@ impl Git {
                             .get(&path)
                             .and_then(|(_, oid)| git_read_raw(["cat-file", "-p", oid]).ok())
                     } else {
-                        fixer_worktree_map
-                            .get(&path)
-                            .and_then(|contents| contents.as_deref())
-                            .and_then(|contents| std::str::from_utf8(contents).ok())
-                            .map(str::to_owned)
+                        fixer_worktree
                     };
 
                     // Trace summaries of inputs for diagnostics (trace-level only)

--- a/src/git.rs
+++ b/src/git.rs
@@ -1065,22 +1065,42 @@ impl Git {
                 // When staging is disabled, fixer output remains in the isolated worktree
                 // rather than being written to the index. Snapshot it before restoring the
                 // user's unstaged changes so it can be used as the fixer side of the merge.
-                let fixer_worktree_map: std::collections::HashMap<PathBuf, String> = if should_stage
-                {
-                    std::collections::HashMap::new()
-                } else {
-                    self.saved_index
+                // Map presence identifies hook files; None distinguishes a fixer deletion
+                // from a path that was not processed. Keep bytes so non-UTF-8 output survives.
+                let mut fixer_worktree_map: std::collections::HashMap<PathBuf, Option<Vec<u8>>> =
+                    std::collections::HashMap::new();
+                if !should_stage {
+                    for (_, oid, p) in self
+                        .saved_index
                         .as_deref()
                         .unwrap_or_default()
                         .iter()
                         .filter(|(_, _, p)| stash_paths.contains(p))
-                        .filter_map(|(_, _, p)| {
-                            xx::file::read_to_string(p)
-                                .ok()
-                                .map(|contents| (p.clone(), contents))
-                        })
-                        .collect()
-                };
+                    {
+                        let contents = match std::fs::read(p) {
+                            Ok(contents) => Some(contents),
+                            Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+                            Err(err) => {
+                                return Err(err).wrap_err_with(|| {
+                                    format!(
+                                        "failed to snapshot fixer output for {}",
+                                        display_path(p)
+                                    )
+                                });
+                            }
+                        };
+                        let index_contents = git_read_bytes(["cat-file", "-p", oid])
+                            .wrap_err_with(|| {
+                                format!(
+                                    "failed to read saved index content for {}",
+                                    display_path(p)
+                                )
+                            })?;
+                        if contents.as_deref() != Some(index_contents.as_slice()) {
+                            fixer_worktree_map.insert(p.clone(), contents);
+                        }
+                    }
+                }
 
                 // Build a map of CURRENT index (post-step) entries to re-stage Fixer blobs.
                 // Only include files that are actually staged-changed to avoid treating unrelated
@@ -1193,6 +1213,43 @@ impl Git {
                         continue;
                     }
 
+                    // A stage-disabled fixer can delete a file or replace it with binary
+                    // content. Neither result can participate in the text merge below, so
+                    // restore it directly while leaving the original index untouched.
+                    match fixer_worktree_map.get(&path) {
+                        Some(None) => {
+                            debug!(
+                                "manual-unstash: preserving fixer deletion path={}",
+                                display_path(&path)
+                            );
+                            if let Err(err) = std::fs::remove_file(&path)
+                                && err.kind() != std::io::ErrorKind::NotFound
+                            {
+                                warn!(
+                                    "failed to preserve fixer deletion for {}: {err:?}",
+                                    display_path(&path)
+                                );
+                                restoration_failed = true;
+                            }
+                            continue;
+                        }
+                        Some(Some(contents)) if std::str::from_utf8(contents).is_err() => {
+                            debug!(
+                                "manual-unstash: preserving binary fixer output path={}",
+                                display_path(&path)
+                            );
+                            if let Err(err) = xx::file::write(&path, contents) {
+                                warn!(
+                                    "failed to preserve binary fixer output for {}: {err:?}",
+                                    display_path(&path)
+                                );
+                                restoration_failed = true;
+                            }
+                            continue;
+                        }
+                        _ => {}
+                    }
+
                     // Detect binary files: try reading the worktree blob as UTF-8.
                     // If it fails, restore using raw bytes and skip text merging entirely.
                     let work_bytes =
@@ -1275,7 +1332,11 @@ impl Git {
                             .get(&path)
                             .and_then(|(_, oid)| git_read_raw(["cat-file", "-p", oid]).ok())
                     } else {
-                        fixer_worktree_map.get(&path).cloned()
+                        fixer_worktree_map
+                            .get(&path)
+                            .and_then(|contents| contents.as_deref())
+                            .and_then(|contents| std::str::from_utf8(contents).ok())
+                            .map(str::to_owned)
                     };
 
                     // Trace summaries of inputs for diagnostics (trace-level only)

--- a/src/git.rs
+++ b/src/git.rs
@@ -1306,6 +1306,14 @@ impl Git {
                         .is_some_and(|b| std::str::from_utf8(b).is_err());
 
                     if is_binary {
+                        if !should_stage && fixer_worktree.is_some() {
+                            warn!(
+                                "text fixer output for {} cannot be merged with binary stashed edits; preserving the fixer output{}",
+                                display_path(&path),
+                                patch_hint
+                            );
+                            continue;
+                        }
                         debug!(
                             "manual-unstash: binary file detected; restoring worktree snapshot directly path={}",
                             display_path(&path),

--- a/src/git.rs
+++ b/src/git.rs
@@ -1146,6 +1146,10 @@ impl Git {
 
                 // Track whether any file restoration failed so we can preserve the stash
                 let mut restoration_failed = false;
+                let patch_hint = self
+                    .last_patch_path()
+                    .map(|p| format!("; stashed edits are backed up at {}", p.display()))
+                    .unwrap_or_default();
 
                 for p in stash_paths.iter() {
                     let path = PathBuf::from(p);
@@ -1244,13 +1248,24 @@ impl Git {
                     }
 
                     let fixer_worktree = if !should_stage && has_fixer {
+                        if std::fs::symlink_metadata(&path)
+                            .is_ok_and(|metadata| metadata.file_type().is_symlink())
+                        {
+                            warn!(
+                                "fixer replaced {} with a symlink; preserving the symlink instead of conflicting stashed edits{}",
+                                display_path(&path),
+                                patch_hint
+                            );
+                            continue;
+                        }
                         match std::fs::read(&path) {
                             Ok(contents) => match String::from_utf8(contents) {
                                 Ok(contents) => Some(contents),
                                 Err(err) => {
-                                    debug!(
-                                        "manual-unstash: preserving binary fixer output path={}",
-                                        display_path(&path)
+                                    warn!(
+                                        "fixer wrote binary content to {}; preserving it instead of conflicting stashed edits{}",
+                                        display_path(&path),
+                                        patch_hint
                                     );
                                     if let Err(write_err) = xx::file::write(&path, err.as_bytes()) {
                                         warn!(
@@ -1263,9 +1278,10 @@ impl Git {
                                 }
                             },
                             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                                debug!(
-                                    "manual-unstash: preserving fixer deletion path={}",
-                                    display_path(&path)
+                                warn!(
+                                    "fixer deleted {}; preserving the deletion instead of conflicting stashed edits{}",
+                                    display_path(&path),
+                                    patch_hint
                                 );
                                 continue;
                             }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1000,7 +1000,7 @@ impl Git {
         self.last_patch_path.as_ref()
     }
 
-    pub fn pop_stash(&mut self) -> Result<()> {
+    pub fn pop_stash(&mut self, should_stage: bool) -> Result<()> {
         let Some(diff) = self.stash.take() else {
             return Ok(());
         };
@@ -1061,6 +1061,26 @@ impl Git {
                             .is_none_or(|stashed_paths| stashed_paths.contains(p))
                     })
                     .collect();
+
+                // When staging is disabled, fixer output remains in the isolated worktree
+                // rather than being written to the index. Snapshot it before restoring the
+                // user's unstaged changes so it can be used as the fixer side of the merge.
+                let fixer_worktree_map: std::collections::HashMap<PathBuf, String> = if should_stage
+                {
+                    std::collections::HashMap::new()
+                } else {
+                    self.saved_index
+                        .as_deref()
+                        .unwrap_or_default()
+                        .iter()
+                        .filter(|(_, _, p)| stash_paths.contains(p))
+                        .filter_map(|(_, _, p)| {
+                            xx::file::read_to_string(p)
+                                .ok()
+                                .map(|contents| (p.clone(), contents))
+                        })
+                        .collect()
+                };
 
                 // Build a map of CURRENT index (post-step) entries to re-stage Fixer blobs.
                 // Only include files that are actually staged-changed to avoid treating unrelated
@@ -1200,7 +1220,11 @@ impl Git {
                     }
 
                     let work_size: Option<usize> = work_bytes.as_ref().map(|b| b.len());
-                    let has_fixer = fixer_map.contains_key(&path);
+                    let has_fixer = if should_stage {
+                        fixer_map.contains_key(&path)
+                    } else {
+                        fixer_worktree_map.contains_key(&path)
+                    };
                     if work_size.unwrap_or(0) >= LARGE_STASH_FILE_BYTES && !has_fixer {
                         debug!(
                             "manual-unstash: large file without fixer; restoring worktree snapshot directly path={} size={}",
@@ -1244,10 +1268,15 @@ impl Git {
                     let index_pre =
                         git_read_raw(["cat-file", "-p", &format!("{}^2:{}", &stash_ref, path_str)])
                             .ok();
-                    // Fixer content from saved index blob
-                    let fixer = fixer_map
-                        .get(&path)
-                        .and_then(|(_, oid)| git_read_raw(["cat-file", "-p", oid]).ok());
+                    // Fixer content comes from the index when fixes were staged, or from the
+                    // isolated post-step worktree when staging was disabled.
+                    let fixer = if should_stage {
+                        fixer_map
+                            .get(&path)
+                            .and_then(|(_, oid)| git_read_raw(["cat-file", "-p", oid]).ok())
+                    } else {
+                        fixer_worktree_map.get(&path).cloned()
+                    };
 
                     // Trace summaries of inputs for diagnostics (trace-level only)
                     {
@@ -1433,7 +1462,7 @@ impl Git {
                             "manual-unstash: newline-only change; leaving index untouched path={}",
                             display_path(&path)
                         );
-                    } else if let Some((mode, oid)) = fixer_map.get(&path) {
+                    } else if should_stage && let Some((mode, oid)) = fixer_map.get(&path) {
                         let mode_str = format!("{:o}", mode);
                         if let Err(err) = git_cmd(["update-index", "--cacheinfo"]) // set index blob
                             .arg(mode_str)

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1167,7 +1167,7 @@ impl Hook {
 
         {
             let mut repo = repo.lock().await;
-            if let Err(err) = repo.pop_stash() {
+            if let Err(err) = repo.pop_stash(hook_ctx.should_stage) {
                 // The stashed content is also backed up as a patch; surface it so the
                 // user can recover manually if the automatic restore failed.
                 let patch_hint = repo

--- a/test/fail_on_fix.bats
+++ b/test/fail_on_fix.bats
@@ -195,9 +195,11 @@ EOF
     git add hk.pkl partial.js
     git commit -m "initial commit"
 
-    sed -i 's/x = 1/x=2/' partial.js
+    sed 's/x = 1/x=2/' partial.js > partial.js.tmp
+    mv partial.js.tmp partial.js
     git add partial.js
-    sed -i 's/z = 1/z=2/' partial.js
+    sed 's/z = 1/z=2/' partial.js > partial.js.tmp
+    mv partial.js.tmp partial.js
 
     run hk run pre-commit
     assert_failure
@@ -239,9 +241,11 @@ EOF
     git add hk.pkl deleted.txt
     git commit -m "initial commit"
 
-    sed -i 's/x = 1/x=2/' deleted.txt
+    sed 's/x = 1/x=2/' deleted.txt > deleted.txt.tmp
+    mv deleted.txt.tmp deleted.txt
     git add deleted.txt
-    sed -i 's/z = 1/z=2/' deleted.txt
+    sed 's/z = 1/z=2/' deleted.txt > deleted.txt.tmp
+    mv deleted.txt.tmp deleted.txt
 
     run hk run pre-commit
     assert_failure
@@ -280,9 +284,11 @@ EOF
     git add hk.pkl binary.dat
     git commit -m "initial commit"
 
-    sed -i 's/x = 1/x=2/' binary.dat
+    sed 's/x = 1/x=2/' binary.dat > binary.dat.tmp
+    mv binary.dat.tmp binary.dat
     git add binary.dat
-    sed -i 's/z = 1/z=2/' binary.dat
+    sed 's/z = 1/z=2/' binary.dat > binary.dat.tmp
+    mv binary.dat.tmp binary.dat
 
     run hk run pre-commit
     assert_failure

--- a/test/fail_on_fix.bats
+++ b/test/fail_on_fix.bats
@@ -168,3 +168,47 @@ EOF
     run cat b.md
     assert_output "modified"
 }
+
+@test "fail_on_fix=true preserves fixer output in a partially staged file (#1144)" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        stage = false
+        fail_on_fix = true
+        steps {
+            ["format"] {
+                glob = "*.js"
+                fix = #"for f in {{ files }}; do sed 's/x=2/x = 2/' "\$f" > "\$f.tmp" && mv "\$f.tmp" "\$f"; done"#
+            }
+        }
+    }
+}
+EOF
+    cat <<'EOF' > partial.js
+const x = 1;
+const y = 1;
+const z = 1;
+EOF
+    git add hk.pkl partial.js
+    git commit -m "initial commit"
+
+    sed -i 's/x = 1/x=2/' partial.js
+    git add partial.js
+    sed -i 's/z = 1/z=2/' partial.js
+
+    run hk run pre-commit
+    assert_failure
+
+    # The index retains only the user's staged change, without the fixer's formatting.
+    run git show :partial.js
+    assert_line "const x=2;"
+    assert_line "const z = 1;"
+
+    # The worktree combines the formatter output with the user's unstaged change.
+    run cat partial.js
+    assert_line "const x = 2;"
+    assert_line "const z=2;"
+}

--- a/test/fail_on_fix.bats
+++ b/test/fail_on_fix.bats
@@ -212,3 +212,85 @@ EOF
     assert_line "const x = 2;"
     assert_line "const z=2;"
 }
+
+@test "fail_on_fix=true preserves fixer deletion of a partially staged file" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        stage = false
+        fail_on_fix = true
+        steps {
+            ["delete"] {
+                glob = "deleted.txt"
+                fix = "rm -- {{ files }}"
+            }
+        }
+    }
+}
+EOF
+    cat <<'EOF' > deleted.txt
+x = 1
+y = 1
+z = 1
+EOF
+    git add hk.pkl deleted.txt
+    git commit -m "initial commit"
+
+    sed -i 's/x = 1/x=2/' deleted.txt
+    git add deleted.txt
+    sed -i 's/z = 1/z=2/' deleted.txt
+
+    run hk run pre-commit
+    assert_failure
+
+    # The deletion remains in the worktree while the original staged blob stays in the index.
+    run test -e deleted.txt
+    assert_failure
+    run git show :deleted.txt
+    assert_line "x=2"
+    assert_line "z = 1"
+}
+
+@test "fail_on_fix=true preserves binary fixer output for a partially staged file" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        stage = false
+        fail_on_fix = true
+        steps {
+            ["binary"] {
+                glob = "binary.dat"
+                fix = #"for f in {{ files }}; do printf '\377' > "\$f"; done"#
+            }
+        }
+    }
+}
+EOF
+    cat <<'EOF' > binary.dat
+x = 1
+y = 1
+z = 1
+EOF
+    git add hk.pkl binary.dat
+    git commit -m "initial commit"
+
+    sed -i 's/x = 1/x=2/' binary.dat
+    git add binary.dat
+    sed -i 's/z = 1/z=2/' binary.dat
+
+    run hk run pre-commit
+    assert_failure
+
+    # The binary fixer result remains in the worktree while the index stays unchanged.
+    run od -An -tx1 binary.dat
+    assert_output --partial "ff"
+    run git show :binary.dat
+    assert_line "x=2"
+    assert_line "z = 1"
+}

--- a/test/stash_binary_files.bats
+++ b/test/stash_binary_files.bats
@@ -148,6 +148,44 @@ EOF
     [ "$actual_md5" = "$expected_md5" ]
 }
 
+@test "stage=false preserves text fixer output over conflicting binary changes" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+    stage = false
+    fail_on_fix = true
+    steps {
+      ["replace"] {
+        glob = "*.png"
+        fix = #"for f in {{ files }}; do printf 'fixed\n' > "\$f"; done"#
+      }
+    }
+  }
+}
+EOF
+    echo "base" > snapshot.png
+    git add hk.pkl snapshot.png
+    git commit -m "base"
+
+    echo "staged" > snapshot.png
+    git add snapshot.png
+    local expected_index_md5
+    expected_index_md5=$(git show :snapshot.png | md5sum | cut -d' ' -f1)
+    create_binary_file snapshot.png
+
+    run hk run pre-commit
+    assert_failure
+
+    run cat snapshot.png
+    assert_output "fixed"
+    local actual_index_md5
+    actual_index_md5=$(git show :snapshot.png | md5sum | cut -d' ' -f1)
+    [ "$actual_index_md5" = "$expected_index_md5" ]
+}
+
 @test "stash=git preserves untracked binary files" {
     create_config_with_stash "git"
 

--- a/test/stash_binary_files.bats
+++ b/test/stash_binary_files.bats
@@ -113,6 +113,41 @@ create_binary_file() {
     [ "$actual_md5" = "$expected_md5" ]
 }
 
+@test "stage=false preserves unstaged binary changes when fixer is a no-op" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+    stage = false
+    steps {
+      ["no-op"] {
+        glob = "*.png"
+        fix = "true"
+      }
+    }
+  }
+}
+EOF
+    create_binary_file snapshot.png
+    git add hk.pkl snapshot.png
+    git commit -m "base"
+
+    printf '\xde\xad\xbe\xef' >> snapshot.png
+    git add snapshot.png
+    printf '\xca\xfe\xba\xbe' >> snapshot.png
+
+    local expected_md5
+    expected_md5=$(md5sum snapshot.png | cut -d' ' -f1)
+
+    hk run pre-commit
+
+    local actual_md5
+    actual_md5=$(md5sum snapshot.png | cut -d' ' -f1)
+    [ "$actual_md5" = "$expected_md5" ]
+}
+
 @test "stash=git preserves untracked binary files" {
     create_config_with_stash "git"
 


### PR DESCRIPTION
## Summary

- preserve fixer output when smart stashing is combined with disabled auto-staging
- merge the isolated post-fixer worktree with the user's saved unstaged edits
- leave the user's original index content unchanged
- add regression coverage for a partially staged file with `fail_on_fix=true`

## Root cause

Stash restoration always used the post-hook index as the fixer side of its three-way merge. With `stage=false`—including the implicit staging disable from `fail_on_fix=true`—the fixer only modified the isolated worktree, so the index still contained the pre-fix staged blob. Restoration consequently saw no fixer change and discarded the formatter output.

## Validation

- `mise run test:bats test/fail_on_fix.bats` (libgit2 and shell Git)
- `mise run test:bats test/pre_commit_restores_unstaged_over_fixer_regression.bats`
- `mise run test:bats test/fix_preserves_unstaged_newline.bats`
- `mise run test:cargo` (204 tests)
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes discussion #1144.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core pre-commit stash merge behavior for stage=false/fail_on_fix paths; extensive new tests reduce regression risk but edge cases (binary/text conflicts, large files) remain sensitive.
> 
> **Overview**
> Fixes stash restore when **`stage=false`** or **`fail_on_fix=true`** (which disables auto-staging): formatter output lived only in the worktree, but **`pop_stash`** treated the post-hook **index** as the fixer side, so fixes were dropped after unstaged edits were merged back.
> 
> **`pop_stash(should_stage)`** now takes the hook’s staging flag. With staging off, it discovers fixer-touched paths via **`git diff`** against the saved index (avoiding eager reads of large unchanged files), uses **worktree** content as the fixer input for three-way merge, and **does not** write fixer blobs back into the index. Conflicts favor keeping fixer results (deletions, binary output, symlinks) and warn with stash **patch backup** hints.
> 
> **`hook.rs`** passes **`hook_ctx.should_stage`** into **`pop_stash`**. New **bats** cases cover partially staged files with **`fail_on_fix`**, binary/unstaged preservation, and text fixer vs binary stash conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4cd09da4ea5e8b537fdb995562cd34c640d922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved staged and unstaged changes correctly when automatic fixes run on partially staged files.
  * Ensured stash restoration respects the selected staging behavior, including file deletions, symlinks, and binary changes.
  * Prevented fixer formatting from being added to the index when staging is disabled.

* **Tests**
  * Added regression coverage for failed fixes involving partially staged files.
  * Added coverage for preserving unstaged binary changes when staging is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->