### PR TITLE
fix(builtins): detect extensionless python scripts with ruff

### DIFF
--- a/pkl/builtins/ruff.pkl
+++ b/pkl/builtins/ruff.pkl
@@ -11,7 +11,7 @@ import "./test/helpers.pkl"
   }
 }
 ruff = new Config.Step {
-  glob = List("**/*.py", "**/*.pyi")
+  types = List("python")
   check = new Config.Command { argv = List("ruff", "check", "--force-exclude", "{{files}}") }
   // `ruff check --diff` can exit 0 even if non-fixable issues exist, making it an
   // unreliable signal for whether to run `fix`. We use `check` instead.

--- a/pkl/builtins/ruff_format.pkl
+++ b/pkl/builtins/ruff_format.pkl
@@ -11,7 +11,7 @@ import "./test/helpers.pkl"
   }
 }
 ruff_format = new Config.Step {
-  glob = List("**/*.py", "**/*.pyi")
+  types = List("python")
   check_diff = "ruff format --quiet --force-exclude --diff {{ files }}"
   fix = "ruff format --quiet --force-exclude {{ files }}"
   tests {

--- a/test/builtins_tests.bats
+++ b/test/builtins_tests.bats
@@ -63,3 +63,38 @@ SCRIPT
     assert_output --partial "shfmt script"
     refute_output --partial "fish-script"
 }
+
+@test "ruff builtins select extensionless python scripts" {
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl" as Builtins
+hooks {
+  ["check"] {
+    steps {
+      ["ruff"] = (Builtins.ruff) {
+        check = "for f in {{ files }}; do echo ruff:\$f; done"
+      }
+      ["ruff_format"] = (Builtins.ruff_format) {
+        check = "for f in {{ files }}; do echo ruff_format:\$f; done"
+      }
+    }
+  }
+}
+PKL
+
+    echo "print('python')" > test.py
+    cat <<'SCRIPT' > script
+#!/usr/bin/env python
+print('python')
+SCRIPT
+    chmod +x script
+    echo "console.log('javascript')" > test.js
+
+    run hk check --all
+    assert_success
+    assert_output --partial "ruff:script"
+    assert_output --partial "ruff:test.py"
+    assert_output --partial "ruff_format:script"
+    assert_output --partial "ruff_format:test.py"
+    refute_output --partial "test.js"
+}


### PR DESCRIPTION
## Summary

- select files for the `ruff` and `ruff_format` builtins using hk's Python type detection
- include extensionless scripts with Python shebangs while retaining `.py` and `.pyi` support
- add an end-to-end regression test for both builtins and a non-Python control file

## Root cause

The Ruff builtins filtered files exclusively with `**/*.py` and `**/*.pyi` globs. hk already identifies extensionless Python scripts from their shebang, but those type tags were not consulted by either builtin.

This fixes [discussion #1146](https://github.com/jdx/hk/discussions/1146).

## Validation

- `HK_LIBGIT2='' bats --filter 'ruff builtins select extensionless python scripts' test/builtins_tests.bats`
- `git diff --check`
- The new regression also passed within `mise run test:bats test/builtins_tests.bats`; the aggregate builtin-tool case could not complete in this environment because unrelated Ruby and Node tool shims were unavailable.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Builtin file-selection only; behavior widens coverage to match existing hk Python typing, with regression tests and no auth or data-path changes.
> 
> **Overview**
> **Ruff** and **ruff_format** now pick files via hk’s `python` type instead of `**/*.py` / `**/*.pyi` globs, so extensionless executables with a Python shebang are included alongside normal `.py` / `.pyi` files.
> 
> A bats regression mirrors the existing shell-builtin test: shebang `script` and `test.py` are selected; `test.js` is not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 780802f535bc0b2a1d05b6a3a44f9d1950a6fa77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that built-in checks select extensionless Python scripts and `.py` files while excluding JavaScript files.
  * Confirmed expected formatter and linter invocations when running checks across all files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->