### PR TITLE
chore: release v1.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,47 @@
 # Changelog
 
-## [1.54.1](https://github.com/jdx/hk/compare/v1.54.0..v1.54.1) - 2026-08-04
+## [1.55.0](https://github.com/jdx/hk/compare/v1.54.1..v1.55.0) - 2026-08-11
+
+### 🚀 Features
+
+- **(agent)** generate coding-agent integrations by [@jdx](https://github.com/jdx) in [#1171](https://github.com/jdx/hk/pull/1171)
+- **(builtins)** add kingfisher secret scanner by [@thoroc](https://github.com/thoroc) in [#1160](https://github.com/jdx/hk/pull/1160)
+- **(builtins)** classify command effects by [@jdx](https://github.com/jdx) in [#1167](https://github.com/jdx/hk/pull/1167)
+- **(check)** add normalized diagnostics and SARIF by [@jdx](https://github.com/jdx) in [#1168](https://github.com/jdx/hk/pull/1168)
+- **(mcp)** expose hk to coding agents by [@jdx](https://github.com/jdx) in [#1169](https://github.com/jdx/hk/pull/1169)
+- **(mcp)** add interactive hk dashboard by [@jdx](https://github.com/jdx) in [#1170](https://github.com/jdx/hk/pull/1170)
+- **(run)** add agent-friendly execution scoping by [@jdx](https://github.com/jdx) in [#1162](https://github.com/jdx/hk/pull/1162)
+- **(run)** add structured execution results by [@jdx](https://github.com/jdx) in [#1163](https://github.com/jdx/hk/pull/1163)
+- **(step)** add command effect safety by [@jdx](https://github.com/jdx) in [#1166](https://github.com/jdx/hk/pull/1166)
+
+### 🐛 Bug Fixes
+
+- **(check)** exclude deleted paths from ref checks by [@jdx](https://github.com/jdx) in [#1177](https://github.com/jdx/hk/pull/1177)
+- **(docs)** keep search modal above site navigation by [@jdx](https://github.com/jdx) in [#1188](https://github.com/jdx/hk/pull/1188)
+- **(step)** support argv prefixes for structured commands by [@jdx](https://github.com/jdx) in [#1175](https://github.com/jdx/hk/pull/1175)
+
+### 🧪 Testing
+
+- **(init)** decouple agent docs assertion from releases by [@jdx](https://github.com/jdx) in [#1187](https://github.com/jdx/hk/pull/1187)
+
+### 📦️ Dependency Updates
+
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1151](https://github.com/jdx/hk/pull/1151)
+- simplify cargo version requirements by [@jdx](https://github.com/jdx) in [#1161](https://github.com/jdx/hk/pull/1161)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1173](https://github.com/jdx/hk/pull/1173)
+- update zizmorcore/zizmor-action action to v0.6.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1180](https://github.com/jdx/hk/pull/1180)
+- update jdx/mise-action action to v4.2.4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1179](https://github.com/jdx/hk/pull/1179)
+- update anthropics/claude-code-action action to v1.0.184 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1178](https://github.com/jdx/hk/pull/1178)
+- update dependency @testing-library/jest-dom to v7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1182](https://github.com/jdx/hk/pull/1182)
+- update dependency jsdom to v30 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1183](https://github.com/jdx/hk/pull/1183)
+- update dependency typescript to v7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1184](https://github.com/jdx/hk/pull/1184)
+- update jdx/mise-action action to v4.2.4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1181](https://github.com/jdx/hk/pull/1181)
+
+### New Contributors
+
+- @thoroc made their first contribution in [#1160](https://github.com/jdx/hk/pull/1160)
+
+## [1.54.1](https://github.com/jdx/hk/compare/v1.54.0..v1.54.1) - 2026-08-07
 
 ### 🐛 Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.54.1"
+version = "1.55.0"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "hk"
 repository = "https://github.com/jdx/hk"
 resolver = "3"
 rust-version = "1.88.0"
-version = "1.54.1"
+version = "1.55.0"
 
 [[bin]]
 name = "generate-docs"

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 140+ pre-configured linters and formatters through the `Builtins` mo
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6064,7 +6064,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.54.1",
+  "version": "1.55.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.54.1
+**Version**: 1.55.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined
@@ -299,8 +299,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -333,7 +333,7 @@ Add steps to your hkrc. hk merges them into every project's hooks — steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -426,7 +426,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,8 +105,8 @@ Separately from global *hooks*, you can also create a global *config* file that 
 `hk init` generates an `hk.pkl` file in the root of the repository. Here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -43,7 +43,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,8 +3,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,8 +3,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,8 +3,8 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,8 +4,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -6,8 +6,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -6,8 +6,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -13,8 +13,8 @@ Groups can set common step attributes such as `dir`, `workspace_indicator`, `pre
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {
@@ -114,7 +114,7 @@ its own `hk.pkl` next to its code. The root config lists the subproject director
 
 ```pkl
 // hk.pkl (repo root)
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
 
 subprojects = List("frontend", "backend", "packages/*")
 
@@ -126,8 +126,8 @@ hooks {
 
 ```pkl
 // frontend/hk.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 hooks {
   ["check"] {

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -7,8 +7,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.54.1/hk@1.54.1#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
 amends "pkl/Config.pkl"
 import "pkl/Builtins.pkl"
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name hk
 bin hk
-version "1.54.1"
+version "1.55.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --cd help="Run as if hk was started in this directory" global=#true {


### PR DESCRIPTION
### 🚀 Features

- **(agent)** generate coding-agent integrations by [@jdx](https://github.com/jdx) in [#1171](https://github.com/jdx/hk/pull/1171)
- **(builtins)** add kingfisher secret scanner by [@thoroc](https://github.com/thoroc) in [#1160](https://github.com/jdx/hk/pull/1160)
- **(builtins)** classify command effects by [@jdx](https://github.com/jdx) in [#1167](https://github.com/jdx/hk/pull/1167)
- **(check)** add normalized diagnostics and SARIF by [@jdx](https://github.com/jdx) in [#1168](https://github.com/jdx/hk/pull/1168)
- **(mcp)** expose hk to coding agents by [@jdx](https://github.com/jdx) in [#1169](https://github.com/jdx/hk/pull/1169)
- **(mcp)** add interactive hk dashboard by [@jdx](https://github.com/jdx) in [#1170](https://github.com/jdx/hk/pull/1170)
- **(run)** add agent-friendly execution scoping by [@jdx](https://github.com/jdx) in [#1162](https://github.com/jdx/hk/pull/1162)
- **(run)** add structured execution results by [@jdx](https://github.com/jdx) in [#1163](https://github.com/jdx/hk/pull/1163)
- **(step)** add command effect safety by [@jdx](https://github.com/jdx) in [#1166](https://github.com/jdx/hk/pull/1166)

### 🐛 Bug Fixes

- **(check)** exclude deleted paths from ref checks by [@jdx](https://github.com/jdx) in [#1177](https://github.com/jdx/hk/pull/1177)
- **(docs)** keep search modal above site navigation by [@jdx](https://github.com/jdx) in [#1188](https://github.com/jdx/hk/pull/1188)
- **(step)** support argv prefixes for structured commands by [@jdx](https://github.com/jdx) in [#1175](https://github.com/jdx/hk/pull/1175)

### 🧪 Testing

- **(init)** decouple agent docs assertion from releases by [@jdx](https://github.com/jdx) in [#1187](https://github.com/jdx/hk/pull/1187)

### 📦️ Dependency Updates

- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1151](https://github.com/jdx/hk/pull/1151)
- simplify cargo version requirements by [@jdx](https://github.com/jdx) in [#1161](https://github.com/jdx/hk/pull/1161)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1173](https://github.com/jdx/hk/pull/1173)
- update zizmorcore/zizmor-action action to v0.6.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1180](https://github.com/jdx/hk/pull/1180)
- update jdx/mise-action action to v4.2.4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1179](https://github.com/jdx/hk/pull/1179)
- update anthropics/claude-code-action action to v1.0.184 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1178](https://github.com/jdx/hk/pull/1178)
- update dependency @testing-library/jest-dom to v7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1182](https://github.com/jdx/hk/pull/1182)
- update dependency jsdom to v30 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1183](https://github.com/jdx/hk/pull/1183)
- update dependency typescript to v7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1184](https://github.com/jdx/hk/pull/1184)
- update jdx/mise-action action to v4.2.4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1181](https://github.com/jdx/hk/pull/1181)

### New Contributors

- @thoroc made their first contribution in [#1160](https://github.com/jdx/hk/pull/1160)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and documentation sync for a scheduled release; no runtime code changes in the diff itself.
> 
> **Overview**
> **Release v1.55.0** — bumps the crate and CLI metadata from `1.54.1` to `1.55.0` and adds the corresponding **CHANGELOG** entry for work already merged on `main`.
> 
> The diff is mostly **version alignment**: `Cargo.toml` / `Cargo.lock`, generated usage (`hk.usage.kdl`, `docs/cli/commands.json`, `docs/cli/index.md`), and every doc/example `hk.pkl` snippet that `amends` / `imports` the published Pkl package now points at **`v1.55.0`** instead of `v1.54.1`.
> 
> There is **no new application logic** in this PR; it packages the **1.55.0** feature set described in the changelog (agent/MCP exposure, structured run results, command-effect safety, kingfisher builtin, normalized diagnostics/SARIF, and related fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc789210885e109ddb58e7025c2aa8313d51d58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->