### PR TITLE
feat(run): add agent-friendly execution scoping

### DIFF
--- a/docs/cli/check.md
+++ b/docs/cli/check.md
@@ -55,6 +55,10 @@ Show detailed reasons for inclusion/exclusion. Pass a step name to focus on one 
 
 Abort on first failure
 
+### `--files0-from <PATH>`
+
+Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -201,6 +201,23 @@
             "global": false
           },
           {
+            "name": "files0-from",
+            "usage": "--files0-from <PATH>",
+            "help": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+            "help_first_line": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+            "short": [],
+            "long": ["files0-from"],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "PATH",
+              "usage": "<PATH>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
             "name": "from-hook",
             "usage": "--from-hook",
             "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -657,6 +674,23 @@
             "long": ["fail-fast"],
             "hide": false,
             "global": false
+          },
+          {
+            "name": "files0-from",
+            "usage": "--files0-from <PATH>",
+            "help": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+            "help_first_line": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+            "short": [],
+            "long": ["files0-from"],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "PATH",
+              "usage": "<PATH>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
           },
           {
             "name": "from-hook",
@@ -1182,6 +1216,23 @@
                 "global": false
               },
               {
+                "name": "files0-from",
+                "usage": "--files0-from <PATH>",
+                "help": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "help_first_line": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "short": [],
+                "long": ["files0-from"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "from-hook",
                 "usage": "--from-hook",
                 "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -1517,6 +1568,23 @@
                 "global": false
               },
               {
+                "name": "files0-from",
+                "usage": "--files0-from <PATH>",
+                "help": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "help_first_line": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "short": [],
+                "long": ["files0-from"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "from-hook",
                 "usage": "--from-hook",
                 "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -1823,6 +1891,23 @@
                 "long": ["fail-fast"],
                 "hide": false,
                 "global": false
+              },
+              {
+                "name": "files0-from",
+                "usage": "--files0-from <PATH>",
+                "help": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "help_first_line": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "short": [],
+                "long": ["files0-from"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
               },
               {
                 "name": "from-hook",
@@ -2142,6 +2227,23 @@
                 "global": false
               },
               {
+                "name": "files0-from",
+                "usage": "--files0-from <PATH>",
+                "help": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "help_first_line": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "short": [],
+                "long": ["files0-from"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "from-hook",
                 "usage": "--from-hook",
                 "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -2459,6 +2561,23 @@
                 "global": false
               },
               {
+                "name": "files0-from",
+                "usage": "--files0-from <PATH>",
+                "help": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "help_first_line": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "short": [],
+                "long": ["files0-from"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "from-hook",
                 "usage": "--from-hook",
                 "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -2765,6 +2884,23 @@
                 "long": ["fail-fast"],
                 "hide": false,
                 "global": false
+              },
+              {
+                "name": "files0-from",
+                "usage": "--files0-from <PATH>",
+                "help": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "help_first_line": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "short": [],
+                "long": ["files0-from"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
               },
               {
                 "name": "from-hook",
@@ -3094,6 +3230,23 @@
                 "global": false
               },
               {
+                "name": "files0-from",
+                "usage": "--files0-from <PATH>",
+                "help": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "help_first_line": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "short": [],
+                "long": ["files0-from"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "from-hook",
                 "usage": "--from-hook",
                 "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -3418,6 +3571,23 @@
                 "long": ["fail-fast"],
                 "hide": false,
                 "global": false
+              },
+              {
+                "name": "files0-from",
+                "usage": "--files0-from <PATH>",
+                "help": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "help_first_line": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "short": [],
+                "long": ["files0-from"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
               },
               {
                 "name": "from-hook",
@@ -3755,6 +3925,23 @@
                 "global": false
               },
               {
+                "name": "files0-from",
+                "usage": "--files0-from <PATH>",
+                "help": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "help_first_line": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+                "short": [],
+                "long": ["files0-from"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "from-hook",
                 "usage": "--from-hook",
                 "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -4065,6 +4252,23 @@
             "long": ["fail-fast"],
             "hide": false,
             "global": false
+          },
+          {
+            "name": "files0-from",
+            "usage": "--files0-from <PATH>",
+            "help": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+            "help_first_line": "Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)",
+            "short": [],
+            "long": ["files0-from"],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "PATH",
+              "usage": "<PATH>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
           },
           {
             "name": "from-hook",
@@ -4964,6 +5168,23 @@
     },
     "args": [],
     "flags": [
+      {
+        "name": "cd",
+        "usage": "--cd <DIRECTORY>",
+        "help": "Run as if hk was started in this directory",
+        "help_first_line": "Run as if hk was started in this directory",
+        "short": [],
+        "long": ["cd"],
+        "hide": false,
+        "global": true,
+        "arg": {
+          "name": "DIRECTORY",
+          "usage": "<DIRECTORY>",
+          "required": true,
+          "double_dash": "Optional",
+          "hide": false
+        }
+      },
       {
         "name": "hkrc",
         "usage": "--hkrc <PATH>",

--- a/docs/cli/fix.md
+++ b/docs/cli/fix.md
@@ -55,6 +55,10 @@ Show detailed reasons for inclusion/exclusion. Pass a step name to focus on one 
 
 Abort on first failure
 
+### `--files0-from <PATH>`
+
+Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -10,6 +10,10 @@
 
 ## Global Flags
 
+### `--cd <DIRECTORY>`
+
+Run as if hk was started in this directory
+
 ### `-j --jobs <JOBS>`
 
 Number of jobs to run in parallel

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -55,6 +55,10 @@ Show detailed reasons for inclusion/exclusion. Pass a step name to focus on one 
 
 Abort on first failure
 
+### `--files0-from <PATH>`
+
+Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/commit-msg.md
+++ b/docs/cli/run/commit-msg.md
@@ -57,6 +57,10 @@ Show detailed reasons for inclusion/exclusion. Pass a step name to focus on one 
 
 Abort on first failure
 
+### `--files0-from <PATH>`
+
+Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/post-checkout.md
+++ b/docs/cli/run/post-checkout.md
@@ -64,6 +64,10 @@ Show detailed reasons for inclusion/exclusion. Pass a step name to focus on one 
 
 Abort on first failure
 
+### `--files0-from <PATH>`
+
+Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/post-commit.md
+++ b/docs/cli/run/post-commit.md
@@ -52,6 +52,10 @@ Show detailed reasons for inclusion/exclusion. Pass a step name to focus on one 
 
 Abort on first failure
 
+### `--files0-from <PATH>`
+
+Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/post-merge.md
+++ b/docs/cli/run/post-merge.md
@@ -56,6 +56,10 @@ Show detailed reasons for inclusion/exclusion. Pass a step name to focus on one 
 
 Abort on first failure
 
+### `--files0-from <PATH>`
+
+Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/post-rewrite.md
+++ b/docs/cli/run/post-rewrite.md
@@ -56,6 +56,10 @@ Show detailed reasons for inclusion/exclusion. Pass a step name to focus on one 
 
 Abort on first failure
 
+### `--files0-from <PATH>`
+
+Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/pre-commit.md
+++ b/docs/cli/run/pre-commit.md
@@ -55,6 +55,10 @@ Show detailed reasons for inclusion/exclusion. Pass a step name to focus on one 
 
 Abort on first failure
 
+### `--files0-from <PATH>`
+
+Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/pre-push.md
+++ b/docs/cli/run/pre-push.md
@@ -61,6 +61,10 @@ Show detailed reasons for inclusion/exclusion. Pass a step name to focus on one 
 
 Abort on first failure
 
+### `--files0-from <PATH>`
+
+Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/pre-rebase.md
+++ b/docs/cli/run/pre-rebase.md
@@ -60,6 +60,10 @@ Show detailed reasons for inclusion/exclusion. Pass a step name to focus on one 
 
 Abort on first failure
 
+### `--files0-from <PATH>`
+
+Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/prepare-commit-msg.md
+++ b/docs/cli/run/prepare-commit-msg.md
@@ -65,6 +65,10 @@ Show detailed reasons for inclusion/exclusion. Pass a step name to focus on one 
 
 Abort on first failure
 
+### `--files0-from <PATH>`
+
+Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -5,6 +5,9 @@ bin hk
 version "1.54.1"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
+flag --cd help="Run as if hk was started in this directory" global=#true {
+    arg <DIRECTORY>
+}
 flag --hkrc help="Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)" hide=#true global=#true {
     arg <PATH>
 }
@@ -45,6 +48,9 @@ cmd check help="Checks code" {
         arg <STEP>
     }
     flag --fail-fast help="Abort on first failure"
+    flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
+        arg <PATH>
+    }
     flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
     flag --from-ref help="Start reference for checking files (requires --to-ref)" {
         arg <FROM_REF>
@@ -139,6 +145,9 @@ cmd fix help="Fixes code" {
         arg <STEP>
     }
     flag --fail-fast help="Abort on first failure"
+    flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
+        arg <PATH>
+    }
     flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
     flag --from-ref help="Start reference for checking files (requires --to-ref)" {
         arg <FROM_REF>
@@ -249,6 +258,9 @@ cmd run help="Run a hook" {
         arg <STEP>
     }
     flag --fail-fast help="Abort on first failure"
+    flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
+        arg <PATH>
+    }
     flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
     flag --from-ref help="Start reference for checking files (requires --to-ref)" {
         arg <FROM_REF>
@@ -293,6 +305,9 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --fail-fast help="Abort on first failure"
+        flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
+            arg <PATH>
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>
@@ -337,6 +352,9 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --fail-fast help="Abort on first failure"
+        flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
+            arg <PATH>
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>
@@ -383,6 +401,9 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --fail-fast help="Abort on first failure"
+        flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
+            arg <PATH>
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>
@@ -426,6 +447,9 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --fail-fast help="Abort on first failure"
+        flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
+            arg <PATH>
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>
@@ -470,6 +494,9 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --fail-fast help="Abort on first failure"
+        flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
+            arg <PATH>
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>
@@ -515,6 +542,9 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --fail-fast help="Abort on first failure"
+        flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
+            arg <PATH>
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>
@@ -559,6 +589,9 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --fail-fast help="Abort on first failure"
+        flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
+            arg <PATH>
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>
@@ -604,6 +637,9 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --fail-fast help="Abort on first failure"
+        flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
+            arg <PATH>
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>
@@ -650,6 +686,9 @@ cmd run help="Run a hook" {
             arg <STEP>
         }
         flag --fail-fast help="Abort on first failure"
+        flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
+            arg <PATH>
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,6 @@
 use crate::version as version_lib;
 use std::num::NonZero;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::{Result, env, logger, settings::Settings};
@@ -30,6 +30,9 @@ mod version;
 #[derive(clap::Parser)]
 #[clap(name = "hk", version = env!("CARGO_PKG_VERSION"), about = env!("CARGO_PKG_DESCRIPTION"), version = version_lib::version())]
 struct Cli {
+    /// Run as if hk was started in this directory
+    #[clap(long, global = true, value_name = "DIRECTORY", value_hint = clap::ValueHint::DirPath)]
+    cd: Option<PathBuf>,
     /// Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)
     #[clap(long, global = true, value_name = "PATH", hide = true)]
     hkrc: Option<PathBuf>,
@@ -66,6 +69,49 @@ struct Cli {
     command: Commands,
 }
 
+/// Re-execute hk in the directory selected by `--cd`.
+///
+/// `std::process::Command::current_dir` applies the directory at process creation
+/// time, avoiding a process-global `set_current_dir` while preserving all of the
+/// existing cwd-based config and repository discovery.
+fn reexec_for_cd(cd: &Path) -> Result<std::process::ExitStatus> {
+    // The child is already rooted correctly, so remove --cd while copying its
+    // arguments. This avoids a process-global cwd change and avoids a marker
+    // environment variable that would incorrectly affect nested hk commands.
+    let mut args = std::env::args_os().skip(1);
+    let mut child_args = Vec::new();
+    while let Some(arg) = args.next() {
+        if arg == "--" {
+            child_args.push(arg);
+            child_args.extend(args);
+            break;
+        }
+        if arg == "--cd" {
+            let _ = args.next();
+            continue;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+            if arg.as_bytes().starts_with(b"--cd=") {
+                continue;
+            }
+        }
+        #[cfg(not(unix))]
+        if arg.to_str().is_some_and(|arg| arg.starts_with("--cd=")) {
+            continue;
+        }
+        child_args.push(arg);
+    }
+
+    let status = std::process::Command::new(std::env::current_exe()?)
+        .args(child_args)
+        .current_dir(cd)
+        .status()
+        .wrap_err_with(|| format!("failed to run hk in {}", cd.display()))?;
+    Ok(status)
+}
+
 #[derive(clap::Subcommand)]
 enum Commands {
     Builtins(Box<builtins::Builtins>),
@@ -87,8 +133,11 @@ enum Commands {
     Version(Box<version::Version>),
 }
 
-pub async fn run() -> Result<()> {
+pub async fn run() -> Result<Option<std::process::ExitStatus>> {
     let args = Cli::parse();
+    if let Some(cd) = &args.cd {
+        return reexec_for_cd(cd).map(Some);
+    }
 
     // Determine effective log level from CLI flags (env default applied by logger if None)
     let mut level: Option<log::LevelFilter> = None;
@@ -192,7 +241,8 @@ pub async fn run() -> Result<()> {
         Commands::Validate(cmd) => cmd.run().await,
         Commands::Version(cmd) => cmd.run().await,
         Commands::Test(cmd) => cmd.run().await,
-    }
+    }?;
+    Ok(None)
 }
 
 #[cfg(test)]

--- a/src/cli/run/post_rewrite.rs
+++ b/src/cli/run/post_rewrite.rs
@@ -14,6 +14,11 @@ pub struct PostRewrite {
 
 impl PostRewrite {
     pub async fn run(mut self) -> Result<()> {
+        if self.hook.reads_file_list_from_stdin() {
+            return Err(eyre::eyre!(
+                "--files0-from - cannot be used with post-rewrite because the hook reads rewrite data from stdin"
+            ));
+        }
         self.hook.tctx.insert("hook_args", &self.command);
         let hook_stdin = if std::io::stdin().is_terminal() {
             String::new()

--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -36,6 +36,11 @@ impl From<&str> for PrePushRefs {
 
 impl PrePush {
     pub async fn run(mut self) -> Result<()> {
+        if self.hook.reads_file_list_from_stdin() {
+            return Err(eyre::eyre!(
+                "--files0-from - cannot be used with pre-push because the hook reads refs from stdin"
+            ));
+        }
         self.hook.tctx.insert(
             "hook_args",
             &format!(

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1385,7 +1385,7 @@ impl Hook {
             files
                 .iter()
                 .map(|f| {
-                    let p = PathBuf::from(f);
+                    let p = f.clone();
                     if p.is_dir() {
                         all_files_in_dir(&p)
                     } else {

--- a/src/hook_options.rs
+++ b/src/hook_options.rs
@@ -1,10 +1,11 @@
 use crate::{Result, config::Config, git::Git, settings::Settings, tera::Context};
+use std::path::PathBuf;
 
 #[derive(clap::Args)]
 pub(crate) struct HookOptions {
     /// Run on specific files
     #[clap(conflicts_with_all = &["all", "fix", "check"], value_hint = clap::ValueHint::FilePath)]
-    pub files: Option<Vec<String>>,
+    pub files: Option<Vec<PathBuf>>,
     /// Run on all files instead of just staged files
     #[clap(short, long, conflicts_with_all = &["staged", "unstaged"])]
     pub all: bool,
@@ -36,6 +37,14 @@ pub(crate) struct HookOptions {
     /// Abort on first failure
     #[clap(long, overrides_with = "no_fail_fast")]
     pub fail_fast: bool,
+    /// Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
+    #[clap(
+        long,
+        value_name = "PATH",
+        value_hint = clap::ValueHint::FilePath,
+        conflicts_with_all = &["files", "all", "from_ref", "glob", "pr", "staged", "to_ref", "unstaged"]
+    )]
+    pub files0_from: Option<PathBuf>,
     /// Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is
     /// present or the event isn't defined. Set automatically by `hk install`.
     #[clap(long, hide = true)]
@@ -100,6 +109,46 @@ impl HookOptions {
         Ok(())
     }
 
+    pub(crate) fn reads_file_list_from_stdin(&self) -> bool {
+        self.files0_from.as_deref() == Some(std::path::Path::new("-"))
+    }
+
+    fn load_files0(&mut self) -> Result<()> {
+        use std::io::Read;
+
+        let Some(source) = self.files0_from.take() else {
+            return Ok(());
+        };
+        let mut bytes = Vec::new();
+        if source == std::path::Path::new("-") {
+            std::io::stdin().read_to_end(&mut bytes)?;
+        } else {
+            std::fs::File::open(&source)?.read_to_end(&mut bytes)?;
+        }
+
+        let mut files = Vec::new();
+        for raw in bytes.split(|byte| *byte == 0) {
+            if raw.is_empty() {
+                continue;
+            }
+            #[cfg(unix)]
+            let path = {
+                use std::os::unix::ffi::OsStringExt;
+                std::str::from_utf8(raw).map_err(|_| {
+                    eyre::eyre!("--files0-from contains a path that is not valid UTF-8")
+                })?;
+                PathBuf::from(std::ffi::OsString::from_vec(raw.to_vec()))
+            };
+            #[cfg(not(unix))]
+            let path = PathBuf::from(String::from_utf8(raw.to_vec()).map_err(|_| {
+                eyre::eyre!("--files0-from contains a path that is not valid UTF-8")
+            })?);
+            files.push(path);
+        }
+        self.files = Some(files);
+        Ok(())
+    }
+
     pub fn should_stage(&self) -> Option<bool> {
         if self.stage {
             Some(true)
@@ -112,6 +161,7 @@ impl HookOptions {
 
     pub(crate) async fn run(mut self, name: &str) -> Result<()> {
         self.validate()?;
+        self.load_files0()?;
         // Under `--from-hook`, short-circuit *before* loading the config. A
         // broken user-global hkrc (or missing `pkl`) shouldn't fail every
         // `git commit` in a repo that doesn't even use hk — which is the

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,8 +67,10 @@ async fn async_main() -> Result<()> {
     let result = cli::run().await;
     clx::progress::flush();
     match result {
+        Ok(Some(status)) => std::process::exit(status.code().unwrap_or(1)),
+        Ok(None) => Ok(()),
         Err(e) if !log::log_enabled!(log::Level::Debug) => friendly_error(e),
-        r => r,
+        Err(e) => Err(e),
     }
 }
 

--- a/test/agent_scope.bats
+++ b/test/agent_scope.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+write_capture_config() {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["capture"] {
+                check = "printf '%s\\n' {{files}} | sort > seen.txt"
+            }
+        }
+    }
+}
+EOF
+}
+
+@test "--cd runs hk from the selected project" {
+    mkdir nested
+    cd nested
+    git init .
+    write_capture_config
+    touch selected.txt ignored.txt
+    git add .
+    git commit -m init
+    cd ..
+
+    run hk --cd nested check selected.txt
+    assert_success
+
+    run cat nested/seen.txt
+    assert_output "selected.txt"
+}
+
+@test "--cd reports an invalid directory" {
+    run hk --cd missing check --all
+    assert_failure
+    assert_output --partial "missing"
+}
+
+@test "--cd propagates the child exit status" {
+    mkdir nested
+    cat <<EOF > nested/hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["fail"] { check = "exit 7" }
+        }
+    }
+}
+EOF
+    touch nested/input.txt
+    git add .
+    git commit -m init
+
+    run hk --cd nested check --all
+
+    assert_failure 7
+}
+
+@test "--cd accepts the equals form" {
+    mkdir nested
+    cd nested
+    git init .
+    write_capture_config
+    touch selected.txt
+    git add .
+    git commit -m init
+    cd ..
+
+    run hk --cd=nested check selected.txt
+    assert_success
+    assert_file_exists nested/seen.txt
+}
+
+@test "--cd remains available to hk invoked by a step" {
+    mkdir first second
+    cat <<EOF > first/hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["nested"] {
+                check = "hk --cd second check --all"
+            }
+        }
+    }
+}
+EOF
+    cat <<EOF > second/hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["capture"] {
+                check = "touch nested-ran"
+            }
+        }
+    }
+}
+EOF
+    touch first/input.txt second/input.txt
+    git add .
+    git commit -m init
+
+    run hk --cd first check --all
+    assert_success
+    # Step commands run at the repository root unless `dir` overrides it.
+    assert_file_exists nested-ran
+}
+
+@test "--files0-from reads exact paths including spaces" {
+    write_capture_config
+    touch "with space.txt" other.txt
+    git add .
+    git commit -m init
+    printf 'with space.txt\0' > files.list
+
+    run hk check --files0-from files.list
+    assert_success
+
+    run cat seen.txt
+    assert_output "with space.txt"
+}
+
+@test "--files0-from accepts stdin" {
+    write_capture_config
+    touch first.txt second.txt
+    git add .
+    git commit -m init
+
+    run bash -c "printf 'second.txt\\0' | hk check --files0-from -"
+    assert_success
+
+    run cat seen.txt
+    assert_output "second.txt"
+}
+
+@test "--files0-from conflicts with other selection modes" {
+    write_capture_config
+    git add hk.pkl
+    git commit -m init
+    : > files.list
+
+    run hk check --files0-from files.list --all
+    assert_failure
+    assert_output --partial "cannot be used with"
+}
+
+@test "--files0-from stdin is rejected for hooks that own stdin" {
+    run bash -c "printf 'file.txt\\0' | hk run post-rewrite amend --files0-from -"
+    assert_failure
+    assert_output --partial "post-rewrite"
+    assert_output --partial "reads rewrite data from stdin"
+
+    run bash -c "printf 'refs/heads/main abc refs/heads/main def\\n' | hk run pre-push origin example --files0-from -"
+    assert_failure
+    assert_output --partial "pre-push"
+    assert_output --partial "reads refs from stdin"
+}
+
+@test "--files0-from rejects non-UTF-8 paths without panicking" {
+    printf '\377\0' >files.list
+
+    run hk check --files0-from files.list
+
+    assert_failure
+    assert_output --partial "not valid UTF-8"
+    refute_output --partial "panicked"
+}


### PR DESCRIPTION
## Summary

- add a global `--cd` option that re-executes hk in the selected project without mutating process-global cwd
- add `--files0-from <path|->` for exact NUL-delimited file selection
- reject stdin file lists for pre-push, where stdin belongs to the Git hook protocol

## Validation

- `cargo fmt --check`
- `mise run build`
- `mise run test:bats test/agent_scope.bats`

## Stack

This is PR 1 of the agent-native hk stack and targets `main` directly.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI entry (`reexec`), file selection, and hook stdin handling; behavior is additive but mistakes could affect which files run or nested hk cwd.
> 
> **Overview**
> Adds **agent-friendly scoping** so hk can be driven from outside the repo cwd and with machine-generated file lists.
> 
> **`--cd <DIRECTORY>`** is a new global flag that **re-executes** hk with `current_dir` set to the chosen path and **strips `--cd`** from the child argv (including `--cd=`). Exit status comes from the child; nested `hk` invocations from steps can still pass `--cd` because no env marker is used.
> 
> **`--files0-from <PATH>`** on check/fix/run (and hook subcommands) loads an **exact** NUL-delimited path list from a file or from **stdin** when `PATH` is `-`. It **conflicts** with positional files, `--all`, `--glob`, `--pr`, ref ranges, `--staged`, and `--unstaged`. **`post-rewrite`** and **`pre-push`** error if `--files0-from -` is used, since those hooks already read hook protocol data from stdin.
> 
> Positional **`FILES`** are now **`PathBuf`** end-to-end (including hook file resolution). CLI usage docs and generated `commands.json` / `hk.usage.kdl` are updated; **`test/agent_scope.bats`** covers `--cd`, `--files0-from`, conflicts, and invalid UTF-8 paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b41ccef2656a2f5be847db57379e32efb4a9ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a global `--cd <DIRECTORY>` option to run commands from a selected directory.
  - Added `--files0-from <PATH>` support for exact NUL-delimited file lists, including paths with spaces and non-UTF-8 Unix paths.
  - File lists can be read from standard input by specifying `-`.

- **Bug Fixes**
  - Improved handling of explicitly provided file paths.
  - Added clear errors for invalid directories and incompatible standard-input configurations.
  - Prevented conflicting file-selection modes from being used together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->