### PR TITLE
feat(run): add structured execution results

### DIFF
--- a/docs/cli/check.md
+++ b/docs/cli/check.md
@@ -59,6 +59,16 @@ Abort on first failure
 
 Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
 
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -218,6 +218,26 @@
             }
           },
           {
+            "name": "format",
+            "usage": "--format <FORMAT>",
+            "help": "Select human or machine-readable execution output",
+            "help_first_line": "Select human or machine-readable execution output",
+            "short": [],
+            "long": ["format"],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "FORMAT",
+              "usage": "<FORMAT>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false,
+              "choices": {
+                "choices": ["human", "json", "jsonl"]
+              }
+            }
+          },
+          {
             "name": "from-hook",
             "usage": "--from-hook",
             "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -690,6 +710,26 @@
               "required": true,
               "double_dash": "Optional",
               "hide": false
+            }
+          },
+          {
+            "name": "format",
+            "usage": "--format <FORMAT>",
+            "help": "Select human or machine-readable execution output",
+            "help_first_line": "Select human or machine-readable execution output",
+            "short": [],
+            "long": ["format"],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "FORMAT",
+              "usage": "<FORMAT>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false,
+              "choices": {
+                "choices": ["human", "json", "jsonl"]
+              }
             }
           },
           {
@@ -1233,6 +1273,26 @@
                 }
               },
               {
+                "name": "format",
+                "usage": "--format <FORMAT>",
+                "help": "Select human or machine-readable execution output",
+                "help_first_line": "Select human or machine-readable execution output",
+                "short": [],
+                "long": ["format"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "FORMAT",
+                  "usage": "<FORMAT>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false,
+                  "choices": {
+                    "choices": ["human", "json", "jsonl"]
+                  }
+                }
+              },
+              {
                 "name": "from-hook",
                 "usage": "--from-hook",
                 "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -1585,6 +1645,26 @@
                 }
               },
               {
+                "name": "format",
+                "usage": "--format <FORMAT>",
+                "help": "Select human or machine-readable execution output",
+                "help_first_line": "Select human or machine-readable execution output",
+                "short": [],
+                "long": ["format"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "FORMAT",
+                  "usage": "<FORMAT>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false,
+                  "choices": {
+                    "choices": ["human", "json", "jsonl"]
+                  }
+                }
+              },
+              {
                 "name": "from-hook",
                 "usage": "--from-hook",
                 "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -1907,6 +1987,26 @@
                   "required": true,
                   "double_dash": "Optional",
                   "hide": false
+                }
+              },
+              {
+                "name": "format",
+                "usage": "--format <FORMAT>",
+                "help": "Select human or machine-readable execution output",
+                "help_first_line": "Select human or machine-readable execution output",
+                "short": [],
+                "long": ["format"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "FORMAT",
+                  "usage": "<FORMAT>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false,
+                  "choices": {
+                    "choices": ["human", "json", "jsonl"]
+                  }
                 }
               },
               {
@@ -2244,6 +2344,26 @@
                 }
               },
               {
+                "name": "format",
+                "usage": "--format <FORMAT>",
+                "help": "Select human or machine-readable execution output",
+                "help_first_line": "Select human or machine-readable execution output",
+                "short": [],
+                "long": ["format"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "FORMAT",
+                  "usage": "<FORMAT>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false,
+                  "choices": {
+                    "choices": ["human", "json", "jsonl"]
+                  }
+                }
+              },
+              {
                 "name": "from-hook",
                 "usage": "--from-hook",
                 "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -2578,6 +2698,26 @@
                 }
               },
               {
+                "name": "format",
+                "usage": "--format <FORMAT>",
+                "help": "Select human or machine-readable execution output",
+                "help_first_line": "Select human or machine-readable execution output",
+                "short": [],
+                "long": ["format"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "FORMAT",
+                  "usage": "<FORMAT>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false,
+                  "choices": {
+                    "choices": ["human", "json", "jsonl"]
+                  }
+                }
+              },
+              {
                 "name": "from-hook",
                 "usage": "--from-hook",
                 "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -2900,6 +3040,26 @@
                   "required": true,
                   "double_dash": "Optional",
                   "hide": false
+                }
+              },
+              {
+                "name": "format",
+                "usage": "--format <FORMAT>",
+                "help": "Select human or machine-readable execution output",
+                "help_first_line": "Select human or machine-readable execution output",
+                "short": [],
+                "long": ["format"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "FORMAT",
+                  "usage": "<FORMAT>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false,
+                  "choices": {
+                    "choices": ["human", "json", "jsonl"]
+                  }
                 }
               },
               {
@@ -3247,6 +3407,26 @@
                 }
               },
               {
+                "name": "format",
+                "usage": "--format <FORMAT>",
+                "help": "Select human or machine-readable execution output",
+                "help_first_line": "Select human or machine-readable execution output",
+                "short": [],
+                "long": ["format"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "FORMAT",
+                  "usage": "<FORMAT>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false,
+                  "choices": {
+                    "choices": ["human", "json", "jsonl"]
+                  }
+                }
+              },
+              {
                 "name": "from-hook",
                 "usage": "--from-hook",
                 "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -3587,6 +3767,26 @@
                   "required": true,
                   "double_dash": "Optional",
                   "hide": false
+                }
+              },
+              {
+                "name": "format",
+                "usage": "--format <FORMAT>",
+                "help": "Select human or machine-readable execution output",
+                "help_first_line": "Select human or machine-readable execution output",
+                "short": [],
+                "long": ["format"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "FORMAT",
+                  "usage": "<FORMAT>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false,
+                  "choices": {
+                    "choices": ["human", "json", "jsonl"]
+                  }
                 }
               },
               {
@@ -3942,6 +4142,26 @@
                 }
               },
               {
+                "name": "format",
+                "usage": "--format <FORMAT>",
+                "help": "Select human or machine-readable execution output",
+                "help_first_line": "Select human or machine-readable execution output",
+                "short": [],
+                "long": ["format"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "FORMAT",
+                  "usage": "<FORMAT>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false,
+                  "choices": {
+                    "choices": ["human", "json", "jsonl"]
+                  }
+                }
+              },
+              {
                 "name": "from-hook",
                 "usage": "--from-hook",
                 "help": "Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`",
@@ -4268,6 +4488,26 @@
               "required": true,
               "double_dash": "Optional",
               "hide": false
+            }
+          },
+          {
+            "name": "format",
+            "usage": "--format <FORMAT>",
+            "help": "Select human or machine-readable execution output",
+            "help_first_line": "Select human or machine-readable execution output",
+            "short": [],
+            "long": ["format"],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "FORMAT",
+              "usage": "<FORMAT>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false,
+              "choices": {
+                "choices": ["human", "json", "jsonl"]
+              }
             }
           },
           {
@@ -5184,6 +5424,27 @@
           "double_dash": "Optional",
           "hide": false
         }
+      },
+      {
+        "name": "format",
+        "usage": "--format <FORMAT>",
+        "help": "Select human or machine-readable execution output",
+        "help_first_line": "Select human or machine-readable execution output",
+        "short": [],
+        "long": ["format"],
+        "hide": false,
+        "global": false,
+        "arg": {
+          "name": "FORMAT",
+          "usage": "<FORMAT>",
+          "required": true,
+          "double_dash": "Optional",
+          "hide": false,
+          "choices": {
+            "choices": ["human", "json", "jsonl"]
+          }
+        },
+        "default": ["human"]
       },
       {
         "name": "hkrc",

--- a/docs/cli/fix.md
+++ b/docs/cli/fix.md
@@ -59,6 +59,16 @@ Abort on first failure
 
 Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
 
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -50,6 +50,20 @@ Enable tracing spans and performance diagnostics
 
 Output in JSON format
 
+## Flags
+
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
+**Default:** `human`
+
 ## Subcommands
 
 - [`hk builtins`](/cli/builtins.md)

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -59,6 +59,16 @@ Abort on first failure
 
 Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
 
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/commit-msg.md
+++ b/docs/cli/run/commit-msg.md
@@ -61,6 +61,16 @@ Abort on first failure
 
 Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
 
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/post-checkout.md
+++ b/docs/cli/run/post-checkout.md
@@ -68,6 +68,16 @@ Abort on first failure
 
 Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
 
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/post-commit.md
+++ b/docs/cli/run/post-commit.md
@@ -56,6 +56,16 @@ Abort on first failure
 
 Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
 
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/post-merge.md
+++ b/docs/cli/run/post-merge.md
@@ -60,6 +60,16 @@ Abort on first failure
 
 Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
 
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/post-rewrite.md
+++ b/docs/cli/run/post-rewrite.md
@@ -60,6 +60,16 @@ Abort on first failure
 
 Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
 
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/pre-commit.md
+++ b/docs/cli/run/pre-commit.md
@@ -59,6 +59,16 @@ Abort on first failure
 
 Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
 
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/pre-push.md
+++ b/docs/cli/run/pre-push.md
@@ -65,6 +65,16 @@ Abort on first failure
 
 Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
 
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/pre-rebase.md
+++ b/docs/cli/run/pre-rebase.md
@@ -64,6 +64,16 @@ Abort on first failure
 
 Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
 
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/docs/cli/run/prepare-commit-msg.md
+++ b/docs/cli/run/prepare-commit-msg.md
@@ -69,6 +69,16 @@ Abort on first failure
 
 Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)
 
+### `--format <FORMAT>`
+
+Select human or machine-readable execution output
+
+**Choices:**
+
+- `human`
+- `json`
+- `jsonl`
+
 ### `--from-ref <FROM_REF>`
 
 Start reference for checking files (requires --to-ref)

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -8,6 +8,11 @@ usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --cd help="Run as if hk was started in this directory" global=#true {
     arg <DIRECTORY>
 }
+flag --format help="Select human or machine-readable execution output" default=human {
+    arg <FORMAT> {
+        choices human json jsonl
+    }
+}
 flag --hkrc help="Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)" hide=#true global=#true {
     arg <PATH>
 }
@@ -50,6 +55,11 @@ cmd check help="Checks code" {
     flag --fail-fast help="Abort on first failure"
     flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
         arg <PATH>
+    }
+    flag --format help="Select human or machine-readable execution output" {
+        arg <FORMAT> {
+            choices human json jsonl
+        }
     }
     flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
     flag --from-ref help="Start reference for checking files (requires --to-ref)" {
@@ -147,6 +157,11 @@ cmd fix help="Fixes code" {
     flag --fail-fast help="Abort on first failure"
     flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
         arg <PATH>
+    }
+    flag --format help="Select human or machine-readable execution output" {
+        arg <FORMAT> {
+            choices human json jsonl
+        }
     }
     flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
     flag --from-ref help="Start reference for checking files (requires --to-ref)" {
@@ -261,6 +276,11 @@ cmd run help="Run a hook" {
     flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
         arg <PATH>
     }
+    flag --format help="Select human or machine-readable execution output" {
+        arg <FORMAT> {
+            choices human json jsonl
+        }
+    }
     flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
     flag --from-ref help="Start reference for checking files (requires --to-ref)" {
         arg <FROM_REF>
@@ -308,6 +328,11 @@ cmd run help="Run a hook" {
         flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
             arg <PATH>
         }
+        flag --format help="Select human or machine-readable execution output" {
+            arg <FORMAT> {
+                choices human json jsonl
+            }
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>
@@ -354,6 +379,11 @@ cmd run help="Run a hook" {
         flag --fail-fast help="Abort on first failure"
         flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
             arg <PATH>
+        }
+        flag --format help="Select human or machine-readable execution output" {
+            arg <FORMAT> {
+                choices human json jsonl
+            }
         }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
@@ -404,6 +434,11 @@ cmd run help="Run a hook" {
         flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
             arg <PATH>
         }
+        flag --format help="Select human or machine-readable execution output" {
+            arg <FORMAT> {
+                choices human json jsonl
+            }
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>
@@ -449,6 +484,11 @@ cmd run help="Run a hook" {
         flag --fail-fast help="Abort on first failure"
         flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
             arg <PATH>
+        }
+        flag --format help="Select human or machine-readable execution output" {
+            arg <FORMAT> {
+                choices human json jsonl
+            }
         }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
@@ -496,6 +536,11 @@ cmd run help="Run a hook" {
         flag --fail-fast help="Abort on first failure"
         flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
             arg <PATH>
+        }
+        flag --format help="Select human or machine-readable execution output" {
+            arg <FORMAT> {
+                choices human json jsonl
+            }
         }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
@@ -545,6 +590,11 @@ cmd run help="Run a hook" {
         flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
             arg <PATH>
         }
+        flag --format help="Select human or machine-readable execution output" {
+            arg <FORMAT> {
+                choices human json jsonl
+            }
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>
@@ -591,6 +641,11 @@ cmd run help="Run a hook" {
         flag --fail-fast help="Abort on first failure"
         flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
             arg <PATH>
+        }
+        flag --format help="Select human or machine-readable execution output" {
+            arg <FORMAT> {
+                choices human json jsonl
+            }
         }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
@@ -640,6 +695,11 @@ cmd run help="Run a hook" {
         flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
             arg <PATH>
         }
+        flag --format help="Select human or machine-readable execution output" {
+            arg <FORMAT> {
+                choices human json jsonl
+            }
+        }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {
             arg <FROM_REF>
@@ -688,6 +748,11 @@ cmd run help="Run a hook" {
         flag --fail-fast help="Abort on first failure"
         flag --files0-from help="Read the exact file list from a NUL-delimited file, or from stdin with `-` (except hooks that reserve stdin)" {
             arg <PATH>
+        }
+        flag --format help="Select human or machine-readable execution output" {
+            arg <FORMAT> {
+                choices human json jsonl
+            }
         }
         flag --from-hook help="Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is present or the event isn't defined. Set automatically by `hk install`" hide=#true
         flag --from-ref help="Start reference for checking files (requires --to-ref)" {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -33,6 +33,9 @@ struct Cli {
     /// Run as if hk was started in this directory
     #[clap(long, global = true, value_name = "DIRECTORY", value_hint = clap::ValueHint::DirPath)]
     cd: Option<PathBuf>,
+    /// Select human or machine-readable execution output
+    #[clap(long, value_enum, default_value_t)]
+    format: crate::structured_output::OutputFormat,
     /// Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)
     #[clap(long, global = true, value_name = "PATH", hide = true)]
     hkrc: Option<PathBuf>,
@@ -133,11 +136,24 @@ enum Commands {
     Version(Box<version::Version>),
 }
 
+impl Commands {
+    fn output_format(&self) -> Option<crate::structured_output::OutputFormat> {
+        match self {
+            Self::Check(command) => command.hook.format,
+            Self::Fix(command) => command.hook.format,
+            Self::Run(command) => command.output_format(),
+            _ => None,
+        }
+    }
+}
+
 pub async fn run() -> Result<Option<std::process::ExitStatus>> {
     let args = Cli::parse();
     if let Some(cd) = &args.cd {
         return reexec_for_cd(cd).map(Some);
     }
+
+    let output_format = args.command.output_format().unwrap_or(args.format);
 
     // Determine effective log level from CLI flags (env default applied by logger if None)
     let mut level: Option<log::LevelFilter> = None;
@@ -150,6 +166,7 @@ pub async fn run() -> Result<Option<std::process::ExitStatus>> {
         quiet: args.quiet,
         silent: args.silent,
         trace: args.trace,
+        output_format,
     });
 
     if is_ci::cached() || !console::user_attended_stderr() || args.no_progress {
@@ -174,7 +191,9 @@ pub async fn run() -> Result<Option<std::process::ExitStatus>> {
 
     // Decide tracing enablement and output format
     // Support: --trace, HK_TRACE mode (Text/Json), or effective log level TRACE
-    let json_output = args.json || *env::HK_JSON || matches!(*env::HK_TRACE, env::TraceMode::Json);
+    // Structured execution output owns stdout. Keep trace records on stderr so
+    // JSON remains a single document and JSONL contains only lifecycle events.
+    let json_trace = args.json || *env::HK_JSON || matches!(*env::HK_TRACE, env::TraceMode::Json);
 
     let mut trace_enabled =
         args.trace || matches!(*env::HK_TRACE, env::TraceMode::Text | env::TraceMode::Json);
@@ -193,7 +212,10 @@ pub async fn run() -> Result<Option<std::process::ExitStatus>> {
     logger::init(level);
     if trace_enabled {
         clx::progress::set_output(ProgressOutput::Text);
-        crate::trace::init_tracing(json_output)?;
+        crate::trace::init_tracing(
+            json_trace,
+            output_format != crate::structured_output::OutputFormat::Human,
+        )?;
     }
 
     // Skip config loading for commands that don't need it

--- a/src/cli/run/commit_msg.rs
+++ b/src/cli/run/commit_msg.rs
@@ -10,7 +10,7 @@ pub struct CommitMsg {
     /// The path to the file that contains the commit message
     commit_msg_file: PathBuf,
     #[clap(flatten)]
-    hook: HookOptions,
+    pub(super) hook: HookOptions,
 }
 
 impl CommitMsg {

--- a/src/cli/run/mod.rs
+++ b/src/cli/run/mod.rs
@@ -41,6 +41,21 @@ enum Commands {
 }
 
 impl Run {
+    pub(crate) fn output_format(&self) -> Option<crate::structured_output::OutputFormat> {
+        let command_format = self.command.as_ref().and_then(|command| match command {
+            Commands::CommitMsg(command) => command.hook.format,
+            Commands::PostCheckout(command) => command.hook.format,
+            Commands::PostCommit(command) => command.hook.format,
+            Commands::PostMerge(command) => command.hook.format,
+            Commands::PostRewrite(command) => command.hook.format,
+            Commands::PreCommit(command) => command.hook.format,
+            Commands::PrePush(command) => command.hook.format,
+            Commands::PreRebase(command) => command.hook.format,
+            Commands::PrepareCommitMsg(command) => command.hook.format,
+        });
+        command_format.or(self.hook.format)
+    }
+
     pub async fn run(mut self) -> Result<()> {
         if let Some(hook) = &self.other {
             // Hooks without a dedicated handler get an empty hook_args;

--- a/src/cli/run/post_checkout.rs
+++ b/src/cli/run/post_checkout.rs
@@ -10,7 +10,7 @@ pub struct PostCheckout {
     /// Flag indicating whether the checkout was a branch checkout (1) or file checkout (0)
     is_branch_checkout: String,
     #[clap(flatten)]
-    hook: HookOptions,
+    pub(super) hook: HookOptions,
 }
 
 impl PostCheckout {

--- a/src/cli/run/post_commit.rs
+++ b/src/cli/run/post_commit.rs
@@ -4,7 +4,7 @@ use crate::hook_options::HookOptions;
 #[derive(clap::Args)]
 pub struct PostCommit {
     #[clap(flatten)]
-    hook: HookOptions,
+    pub(super) hook: HookOptions,
 }
 
 impl PostCommit {

--- a/src/cli/run/post_merge.rs
+++ b/src/cli/run/post_merge.rs
@@ -6,7 +6,7 @@ pub struct PostMerge {
     /// Flag indicating whether the merge was a squash merge (1) or not (0)
     is_squash: String,
     #[clap(flatten)]
-    hook: HookOptions,
+    pub(super) hook: HookOptions,
 }
 
 impl PostMerge {

--- a/src/cli/run/post_rewrite.rs
+++ b/src/cli/run/post_rewrite.rs
@@ -9,7 +9,7 @@ pub struct PostRewrite {
     /// The command that triggered the rewrite ("amend" or "rebase")
     command: String,
     #[clap(flatten)]
-    hook: HookOptions,
+    pub(super) hook: HookOptions,
 }
 
 impl PostRewrite {

--- a/src/cli/run/pre_commit.rs
+++ b/src/cli/run/pre_commit.rs
@@ -5,7 +5,7 @@ use crate::{Result, hook_options::HookOptions};
 #[clap(visible_alias = "pc")]
 pub struct PreCommit {
     #[clap(flatten)]
-    hook: HookOptions,
+    pub(super) hook: HookOptions,
 }
 
 impl PreCommit {

--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -15,7 +15,7 @@ pub struct PrePush {
     /// Remote URL
     url: Option<String>,
     #[clap(flatten)]
-    hook: HookOptions,
+    pub(super) hook: HookOptions,
 }
 
 #[derive(Debug)]

--- a/src/cli/run/pre_rebase.rs
+++ b/src/cli/run/pre_rebase.rs
@@ -8,7 +8,7 @@ pub struct PreRebase {
     /// The branch being rebased (unset when rebasing the current branch)
     branch: Option<String>,
     #[clap(flatten)]
-    hook: HookOptions,
+    pub(super) hook: HookOptions,
 }
 
 impl PreRebase {

--- a/src/cli/run/prepare_commit_msg.rs
+++ b/src/cli/run/prepare_commit_msg.rs
@@ -14,7 +14,7 @@ pub struct PrepareCommitMsg {
     /// The SHA of the commit being amended (if applicable)
     sha: Option<String>,
     #[clap(flatten)]
-    hook: HookOptions,
+    pub(super) hook: HookOptions,
 }
 
 impl PrepareCommitMsg {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -12,6 +12,7 @@ use std::{
         Arc, Mutex as StdMutex,
         atomic::{AtomicBool, Ordering},
     },
+    time::Instant,
 };
 use tokio::{
     signal,
@@ -322,6 +323,11 @@ pub struct HookContext {
     /// `step_contexts` are shift_remove'd as soon as each step finishes, so
     /// status info is not available to the end-of-run summary.
     pub failed_steps: std::sync::Mutex<HashSet<String>>,
+    /// Steps that reached a terminal successful state. Timing alone is not a
+    /// completion signal because an in-flight command can be aborted.
+    pub finished_steps: std::sync::Mutex<HashSet<String>>,
+    /// Steps explicitly aborted by cancellation or fail-fast.
+    pub cancelled_steps: std::sync::Mutex<HashSet<String>>,
     /// Collected fix suggestions to display at end of run
     pub fix_suggestions: std::sync::Mutex<Vec<String>>,
     /// Whether a failed step reported Git's index lock. This is tracked at the
@@ -376,6 +382,8 @@ impl HookContext {
             skipped_steps: StdMutex::new(IndexMap::new()),
             output_by_step: StdMutex::new(IndexMap::new()),
             failed_steps: StdMutex::new(HashSet::new()),
+            finished_steps: StdMutex::new(HashSet::new()),
+            cancelled_steps: StdMutex::new(HashSet::new()),
             fix_suggestions: StdMutex::new(Vec::new()),
             git_index_lock_contention: AtomicBool::new(false),
             should_stage,
@@ -468,6 +476,20 @@ impl HookContext {
 
     pub fn mark_step_failed(&self, step_name: &str) {
         self.failed_steps
+            .lock()
+            .unwrap()
+            .insert(step_name.to_string());
+    }
+
+    pub fn mark_step_finished(&self, step_name: &str) {
+        self.finished_steps
+            .lock()
+            .unwrap()
+            .insert(step_name.to_string());
+    }
+
+    pub fn mark_step_cancelled(&self, step_name: &str) {
+        self.cancelled_steps
             .lock()
             .unwrap()
             .insert(step_name.to_string());
@@ -1005,6 +1027,10 @@ impl Hook {
     pub async fn run(&self, opts: HookOptions) -> Result<()> {
         tracing::info!("running hook");
         let settings = Settings::get();
+        let output_format = Settings::cli_output_format();
+        let machine_output = output_format != crate::structured_output::OutputFormat::Human;
+        let run_started = Instant::now();
+        let started_at = chrono::Utc::now().to_rfc3339();
         let fail_fast = if opts.fail_fast {
             true
         } else if opts.no_fail_fast {
@@ -1020,12 +1046,34 @@ impl Hook {
 
         if settings.skip_hooks.contains(&self.name) {
             warn!("{}: skipping hook due to HK_SKIP_HOOK", &self.name);
+            crate::structured_output::emit_noop_run(
+                output_format,
+                &self.name,
+                started_at,
+                run_started.elapsed().as_millis(),
+                vec![],
+                "hook disabled by HK_SKIP_HOOK",
+            )?;
             return Ok(());
         }
         let run_type = self.run_type(&opts);
         // fail_on_fix exists to surface fixes for review; staging would defeat that.
         let should_stage = should_stage && !(self.fail_on_fix && matches!(run_type, RunType::Fix));
-        let repo = Arc::new(Mutex::new(Git::new()?));
+        let repo = match Git::new() {
+            Ok(repo) => Arc::new(Mutex::new(repo)),
+            Err(err) => {
+                if let Err(emit_err) = crate::structured_output::emit_error_run(
+                    output_format,
+                    &self.name,
+                    started_at,
+                    run_started.elapsed().as_millis(),
+                    err.to_string(),
+                ) {
+                    warn!("failed to emit structured setup failure: {emit_err}");
+                }
+                return Err(err);
+            }
+        };
         let groups = self.get_step_groups(&opts);
         let stash_method = self.resolve_stash_method_for_opts(&opts);
         let total_steps: usize = groups.iter().map(|g| g.steps.len()).sum();
@@ -1035,6 +1083,14 @@ impl Hook {
         // dangling stash and a stripped worktree. See #1105.
         if total_steps == 0 {
             info!("no steps to run");
+            crate::structured_output::emit_noop_run(
+                output_format,
+                &self.name,
+                started_at,
+                run_started.elapsed().as_millis(),
+                vec![],
+                "no configured steps",
+            )?;
             return Ok(());
         }
         let hk_progress = self.start_hk_progress(run_type, total_steps);
@@ -1043,8 +1099,22 @@ impl Hook {
         )
         .prop("message", "Fetching git status")
         .start();
-        let git_status = repo.lock().await.status(None)?;
-        let files = self
+        let git_status = match repo.lock().await.status(None) {
+            Ok(status) => status,
+            Err(err) => {
+                if let Err(emit_err) = crate::structured_output::emit_error_run(
+                    output_format,
+                    &self.name,
+                    started_at,
+                    run_started.elapsed().as_millis(),
+                    err.to_string(),
+                ) {
+                    warn!("failed to emit structured setup failure: {emit_err}");
+                }
+                return Err(err);
+            }
+        };
+        let files = match self
             .file_list(
                 &opts,
                 repo.clone(),
@@ -1052,14 +1122,39 @@ impl Hook {
                 stash_method,
                 &file_progress,
             )
-            .await?;
+            .await
+        {
+            Ok(files) => files,
+            Err(err) => {
+                if let Err(emit_err) = crate::structured_output::emit_error_run(
+                    output_format,
+                    &self.name,
+                    started_at,
+                    run_started.elapsed().as_millis(),
+                    err.to_string(),
+                ) {
+                    warn!("failed to emit structured setup failure: {emit_err}");
+                }
+                return Err(err);
+            }
+        };
 
         let skip_steps = build_skip_steps(&settings, &opts);
-        if files.is_empty() && can_exit_early(&groups, &files, run_type, &skip_steps) {
+        if files.is_empty()
+            && let Some(noop_steps) = early_exit_steps(&groups, &files, run_type, &skip_steps)
+        {
             info!("no files to run");
             if let Some(hk_progress) = &hk_progress {
                 hk_progress.set_status(ProgressStatus::Hide);
             }
+            crate::structured_output::emit_noop_run(
+                output_format,
+                &self.name,
+                started_at,
+                run_started.elapsed().as_millis(),
+                noop_steps,
+                "no matching files",
+            )?;
             return Ok(());
         }
         // Enrich Tera and expr contexts with git status for template/condition use
@@ -1236,7 +1331,7 @@ impl Hook {
         let force_summary = *env::HK_SUMMARY_TEXT;
         let failed_steps = hook_ctx.failed_steps.lock().unwrap().clone();
         let only_failed = settings.quiet || (in_text_mode && !force_summary);
-        if !settings.silent && (!only_failed || !failed_steps.is_empty()) {
+        if !machine_output && !settings.silent && (!only_failed || !failed_steps.is_empty()) {
             let outputs = hook_ctx.output_by_step.lock().unwrap().clone();
             for (step_name, (mode, output)) in outputs.into_iter() {
                 if only_failed && !failed_steps.contains(&step_name) {
@@ -1257,7 +1352,7 @@ impl Hook {
             }
         }
 
-        if !settings.silent && hook_ctx.saw_git_index_lock_contention() {
+        if !machine_output && !settings.silent && hook_ctx.saw_git_index_lock_contention() {
             eprintln!(
                 "\n{}",
                 style::eyellow(
@@ -1272,7 +1367,8 @@ impl Hook {
 
         // Display summary of profile-skipped steps
         // Only show summary if user has enabled the warning tag and it's not hidden
-        if settings.warnings.contains("missing-profiles")
+        if !machine_output
+            && settings.warnings.contains("missing-profiles")
             && !settings.hide_warnings.contains("missing-profiles")
         {
             let skipped_steps = hook_ctx.get_skipped_steps();
@@ -1368,6 +1464,21 @@ impl Hook {
             }
         } else {
             debug!("{self}: hook finished successfully");
+        }
+        let failure = result.as_ref().err().map(ToString::to_string);
+        if let Err(emit_err) = crate::structured_output::emit_run(
+            output_format,
+            &self.name,
+            started_at,
+            run_started.elapsed().as_millis(),
+            &hook_ctx,
+            failure,
+        ) {
+            if result.is_err() {
+                warn!("failed to emit structured run result: {emit_err}");
+            } else {
+                return Err(emit_err);
+            }
         }
         result
     }
@@ -1648,20 +1759,38 @@ fn build_expr_ctx(git_status: &GitStatus) -> expr::Context {
     expr_ctx
 }
 
-fn can_exit_early(
+fn early_exit_steps(
     groups: &[StepGroup],
     files: &BTreeSet<PathBuf>,
     run_type: RunType,
     skip_steps: &IndexMap<String, SkipReason>,
-) -> bool {
+) -> Option<Vec<(String, String)>> {
     let files = files.iter().cloned().collect::<Vec<_>>();
-    groups.iter().all(|g| {
-        g.steps.iter().all(|(_, s)| {
-            // Reuse job builder to determine if this step has any runnable work
-            s.build_step_jobs(&files, run_type, &Default::default(), skip_steps)
-                .is_ok_and(|jobs| jobs.iter().all(|j| j.skip_reason.is_some()))
+    groups
+        .iter()
+        .flat_map(|group| group.steps.iter())
+        .map(|(name, step)| {
+            // Conditions are evaluated at execution time and can take
+            // precedence over the no-files reason. Let normal execution record
+            // their authoritative result instead of guessing here.
+            if step.step_condition.is_some() || step.job_condition.is_some() {
+                return None;
+            }
+            // Reuse job builder so machine output reports the same reason that
+            // execution would have tracked for each skipped step.
+            let jobs = step
+                .build_step_jobs(&files, run_type, &Default::default(), skip_steps)
+                .ok()?;
+            if jobs.is_empty() {
+                return Some((name.clone(), SkipReason::NoFilesToProcess.message()));
+            }
+            if jobs.iter().any(|job| job.skip_reason.is_none()) {
+                return None;
+            }
+            let reason = jobs.first()?.skip_reason.as_ref()?.message();
+            Some((name.clone(), reason))
         })
-    })
+        .collect()
 }
 
 fn skip_reason_to_reason(reason: &SkipReason) -> Reason {

--- a/src/hook_options.rs
+++ b/src/hook_options.rs
@@ -45,6 +45,9 @@ pub(crate) struct HookOptions {
         conflicts_with_all = &["files", "all", "from_ref", "glob", "pr", "staged", "to_ref", "unstaged"]
     )]
     pub files0_from: Option<PathBuf>,
+    /// Select human or machine-readable execution output
+    #[clap(long, value_enum)]
+    pub format: Option<crate::structured_output::OutputFormat>,
     /// Invoked by an installed git hook — gracefully exit 0 when no hk.pkl is
     /// present or the event isn't defined. Set automatically by `hk install`.
     #[clap(long, hide = true)]
@@ -168,6 +171,14 @@ impl HookOptions {
         // main risk under `hk install --global`.
         if self.from_hook && !Config::project_config_exists() {
             log::debug!("no hk config found for {name}, skipping (--from-hook)");
+            crate::structured_output::emit_noop_run(
+                Settings::cli_output_format(),
+                name,
+                chrono::Utc::now().to_rfc3339(),
+                0,
+                vec![],
+                "no project configuration found for installed hook",
+            )?;
             return Ok(());
         }
         let config = Config::get()?;
@@ -211,6 +222,14 @@ impl HookOptions {
                         "hook '{name}' not defined in {}, skipping (--from-hook)",
                         config.path.display()
                     );
+                    crate::structured_output::emit_noop_run(
+                        Settings::cli_output_format(),
+                        name,
+                        chrono::Utc::now().to_rfc3339(),
+                        0,
+                        vec![],
+                        "hook not defined in project configuration",
+                    )?;
                     return Ok(());
                 }
                 let hook_names: Vec<&str> = config.hooks.keys().map(|s| s.as_str()).collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod step_group;
 mod step_job;
 mod step_locks;
 mod step_test;
+mod structured_output;
 mod tera;
 mod test_runner;
 mod timings;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -40,6 +40,7 @@ pub struct CliSnapshot {
     pub quiet: bool,
     pub silent: bool,
     pub trace: bool,
+    pub output_format: crate::structured_output::OutputFormat,
 }
 
 static CLI_SNAPSHOT: Lazy<Mutex<Option<CliSnapshot>>> = Lazy::new(|| Mutex::new(None));
@@ -94,6 +95,15 @@ impl Settings {
             .as_ref()
             .map(|s| s.trace)
             .unwrap_or(false)
+    }
+
+    pub fn cli_output_format() -> crate::structured_output::OutputFormat {
+        CLI_SNAPSHOT
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|snapshot| snapshot.output_format)
+            .unwrap_or_default()
     }
 
     pub fn get() -> Arc<Settings> {

--- a/src/step_context.rs
+++ b/src/step_context.rs
@@ -100,6 +100,7 @@ impl StepContext {
             StepStatus::Pending | StepStatus::Started => {
                 *status = StepStatus::Aborted;
                 drop(status);
+                self.hook_ctx.mark_step_cancelled(&self.step.name);
                 self.progress.prop("show_step_progress", &false);
                 self.update_progress();
             }
@@ -113,6 +114,7 @@ impl StepContext {
             StepStatus::Pending | StepStatus::Started => {
                 *status = StepStatus::Errored(err.to_string());
                 drop(status);
+                self.hook_ctx.mark_step_failed(&self.step.name);
                 self.progress.prop("show_step_progress", &false);
                 self.update_progress();
             }
@@ -126,6 +128,7 @@ impl StepContext {
             StepStatus::Started => {
                 *status = StepStatus::Finished;
                 drop(status);
+                self.hook_ctx.mark_step_finished(&self.step.name);
                 self.progress.prop("show_step_progress", &false);
                 self.update_progress();
             }

--- a/src/structured_output.rs
+++ b/src/structured_output.rs
@@ -1,0 +1,269 @@
+use crate::{Result, hook::HookContext, step::OutputSummary};
+use serde::Serialize;
+use std::io::Write;
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    Eq,
+    PartialEq,
+    clap::ValueEnum,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum OutputFormat {
+    #[default]
+    Human,
+    Json,
+    Jsonl,
+}
+
+#[derive(Debug, Serialize)]
+struct RunResult {
+    schema_version: u8,
+    kind: &'static str,
+    hook: String,
+    status: &'static str,
+    started_at: String,
+    duration_ms: u128,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    failure: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    steps: Vec<StepResult>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StepResult {
+    name: String,
+    status: &'static str,
+    duration_ms: u128,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_kind: Option<OutputSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skip_reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct Event<'a, T: Serialize> {
+    schema_version: u8,
+    event: &'a str,
+    sequence: usize,
+    data: T,
+}
+
+pub fn emit_run(
+    format: OutputFormat,
+    hook: &str,
+    started_at: String,
+    duration_ms: u128,
+    ctx: &HookContext,
+    failure: Option<String>,
+) -> Result<()> {
+    if format == OutputFormat::Human {
+        return Ok(());
+    }
+
+    let failed = ctx.failed_steps.lock().unwrap();
+    let finished = ctx.finished_steps.lock().unwrap();
+    let cancelled = ctx.cancelled_steps.lock().unwrap();
+    let run_was_cancelled = !cancelled.is_empty();
+    let skipped = ctx.get_skipped_steps();
+    let outputs = ctx.output_by_step.lock().unwrap();
+    let timings = ctx.timing.step_wall_times();
+    let mut steps = Vec::new();
+    for group in &ctx.groups {
+        for name in group.steps.keys() {
+            let skip_reason = skipped.get(name).map(|reason| reason.message());
+            let status = if failed.contains(name) {
+                "failed"
+            } else if skip_reason.is_some() {
+                "skipped"
+            } else if cancelled.contains(name) {
+                "cancelled"
+            } else if finished.contains(name) {
+                "passed"
+            } else {
+                "cancelled"
+            };
+            let (output_kind, output) = outputs
+                .get(name)
+                .map(|(kind, output)| (Some(kind.clone()), Some(output.clone())))
+                .unwrap_or((None, None));
+            steps.push(StepResult {
+                name: name.clone(),
+                status,
+                duration_ms: timings.get(name).copied().unwrap_or(0),
+                output_kind,
+                output,
+                skip_reason,
+            });
+        }
+    }
+    drop(outputs);
+    drop(cancelled);
+    drop(finished);
+    drop(failed);
+
+    let result = RunResult {
+        schema_version: 1,
+        kind: "run_result",
+        hook: hook.to_string(),
+        status: run_status(failure.as_deref(), run_was_cancelled),
+        started_at,
+        duration_ms,
+        failure,
+        reason: None,
+        steps,
+    };
+    emit_result(format, &result)
+}
+
+/// Emit a complete machine-readable result for a successful run that did not
+/// start any commands (for example, because there were no matching files).
+pub fn emit_noop_run(
+    format: OutputFormat,
+    hook: &str,
+    started_at: String,
+    duration_ms: u128,
+    steps: Vec<(String, String)>,
+    reason: &str,
+) -> Result<()> {
+    if format == OutputFormat::Human {
+        return Ok(());
+    }
+    let result = RunResult {
+        schema_version: 1,
+        kind: "run_result",
+        hook: hook.to_string(),
+        status: "passed",
+        started_at,
+        duration_ms,
+        failure: None,
+        reason: Some(reason.to_string()),
+        steps: steps
+            .into_iter()
+            .map(|(name, skip_reason)| StepResult {
+                name,
+                status: "skipped",
+                duration_ms: 0,
+                output_kind: None,
+                output: None,
+                skip_reason: Some(skip_reason),
+            })
+            .collect(),
+    };
+    emit_result(format, &result)
+}
+
+pub fn emit_error_run(
+    format: OutputFormat,
+    hook: &str,
+    started_at: String,
+    duration_ms: u128,
+    failure: String,
+) -> Result<()> {
+    if format == OutputFormat::Human {
+        return Ok(());
+    }
+    emit_result(
+        format,
+        &RunResult {
+            schema_version: 1,
+            kind: "run_result",
+            hook: hook.to_string(),
+            status: "failed",
+            started_at,
+            duration_ms,
+            failure: Some(failure),
+            reason: None,
+            steps: vec![],
+        },
+    )
+}
+
+fn emit_result(format: OutputFormat, result: &RunResult) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    match format {
+        OutputFormat::Human => {}
+        OutputFormat::Json => {
+            serde_json::to_writer_pretty(&mut stdout, result)?;
+            writeln!(stdout)?;
+        }
+        OutputFormat::Jsonl => {
+            write_event(
+                &mut stdout,
+                &Event {
+                    schema_version: 1,
+                    event: "run_started",
+                    sequence: 0,
+                    data: serde_json::json!({
+                        "hook": result.hook,
+                        "started_at": result.started_at,
+                    }),
+                },
+            )?;
+            for (index, step) in result.steps.iter().enumerate() {
+                write_event(
+                    &mut stdout,
+                    &Event {
+                        schema_version: 1,
+                        event: "step_completed",
+                        sequence: index + 1,
+                        data: step,
+                    },
+                )?;
+            }
+            write_event(
+                &mut stdout,
+                &Event {
+                    schema_version: 1,
+                    event: "run_completed",
+                    sequence: result.steps.len() + 1,
+                    data: serde_json::json!({
+                        "hook": result.hook,
+                        "status": result.status,
+                        "duration_ms": result.duration_ms,
+                        "failure": result.failure,
+                        "reason": result.reason,
+                    }),
+                },
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn write_event(writer: &mut impl Write, event: &impl Serialize) -> Result<()> {
+    serde_json::to_writer(&mut *writer, event)?;
+    writeln!(writer)?;
+    Ok(())
+}
+
+fn run_status(failure: Option<&str>, cancelled: bool) -> &'static str {
+    if failure.is_some() {
+        "failed"
+    } else if cancelled {
+        "cancelled"
+    } else {
+        "passed"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_status;
+
+    #[test]
+    fn cancellation_is_a_top_level_terminal_status() {
+        assert_eq!(run_status(None, true), "cancelled");
+        assert_eq!(run_status(Some("step failed"), true), "failed");
+        assert_eq!(run_status(None, false), "passed");
+    }
+}

--- a/src/timings.rs
+++ b/src/timings.rs
@@ -47,6 +47,13 @@ impl TimingRecorder {
         self.start_instant.elapsed().as_millis()
     }
 
+    pub fn step_wall_times(&self) -> BTreeMap<String, u128> {
+        let mut map = self.intervals_by_step.lock().unwrap().clone();
+        map.iter_mut()
+            .map(|(name, intervals)| (name.clone(), Self::merge_and_sum(intervals.as_mut_slice())))
+            .collect()
+    }
+
     pub fn add_interval(&self, step: &str, start_ms: u128, end_ms: u128) {
         if end_ms < start_ms {
             return;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -19,7 +19,7 @@ pub fn enabled() -> bool {
 }
 
 /// Initialize the tracing subscriber
-pub fn init_tracing(json_output: bool) -> Result<()> {
+pub fn init_tracing(json_output: bool, json_to_stderr: bool) -> Result<()> {
     use tracing_subscriber::prelude::*;
 
     TRACE_ENABLED.store(true, Ordering::Relaxed);
@@ -32,7 +32,7 @@ pub fn init_tracing(json_output: bool) -> Result<()> {
     // Try to set our subscriber, but handle the case where one is already set
     let result = if json_output {
         // JSON Lines output to stdout
-        let json_layer = JsonLayer::new();
+        let json_layer = JsonLayer::new(json_to_stderr);
         tracing_subscriber::registry().with(json_layer).try_init()
     } else {
         // Pretty console output to stderr with hierarchical spans
@@ -79,13 +79,17 @@ pub fn init_tracing(json_output: bool) -> Result<()> {
 
 /// JSON Lines layer for tracing output
 struct JsonLayer {
-    writer: Mutex<std::io::Stdout>,
+    writer: Mutex<Box<dyn Write + Send>>,
 }
 
 impl JsonLayer {
-    fn new() -> Self {
+    fn new(to_stderr: bool) -> Self {
         // Write metadata line
-        let mut stdout = std::io::stdout();
+        let mut writer: Box<dyn Write + Send> = if to_stderr {
+            Box::new(std::io::stderr())
+        } else {
+            Box::new(std::io::stdout())
+        };
         let meta = JsonMeta {
             r#type: "meta",
             span_schema_version: 1,
@@ -93,11 +97,11 @@ impl JsonLayer {
             pid: std::process::id(),
         };
         if let Ok(json) = serde_json::to_string(&meta) {
-            let _ = writeln!(stdout, "{}", json);
+            let _ = writeln!(writer, "{}", json);
         }
 
         Self {
-            writer: Mutex::new(stdout),
+            writer: Mutex::new(writer),
         }
     }
 

--- a/test/structured_output.bats
+++ b/test/structured_output.bats
@@ -1,0 +1,289 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+write_config() {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+fail_fast = false
+hooks {
+    ["check"] {
+        steps {
+            ["pass"] {
+                check = "echo passed"
+                output_summary = "combined"
+            }
+            ["fail"] {
+                check = "echo diagnostic >&2; exit 1"
+                output_summary = "combined"
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+}
+
+@test "--format json emits one versioned run result" {
+    write_config
+
+    run bash -c "hk --format json check --all 2>machine-errors.log"
+    assert_failure
+    json="$output"
+    run jq -r '.schema_version, .kind, .hook, .status, (.steps | length)' <<<"$json"
+    assert_success
+    assert_output $'1\nrun_result\ncheck\nfailed\n2'
+    run jq -r '.steps[] | select(.name == "fail") | [.status, (.output | contains("diagnostic"))] | @tsv' <<<"$json"
+    assert_output $'failed\ttrue'
+}
+
+@test "--format is accepted after check and run subcommands" {
+    write_config
+
+    run bash -c "hk check --format json --all 2>/dev/null"
+    assert_failure
+    run jq -e '.kind == "run_result"' <<<"$output"
+    assert_success
+
+    run bash -c "hk run check --format json --all 2>/dev/null"
+    assert_failure
+    run jq -e '.kind == "run_result"' <<<"$output"
+    assert_success
+}
+
+@test "--format jsonl emits ordered lifecycle events" {
+    write_config
+
+    run bash -c "hk --format jsonl check --all 2>machine-errors.log"
+    assert_failure
+    jsonl="$output"
+    run jq -s -r 'map(.event) | join(",")' <<<"$jsonl"
+    assert_success
+    assert_output "run_started,step_completed,step_completed,run_completed"
+    run jq -s -e '.[].sequence' <<<"$jsonl"
+    assert_success
+    run jq -s -e 'last.data.status == "failed" and (last.data.failure | length > 0)' <<<"$jsonl"
+    assert_success
+}
+
+@test "human output remains the default" {
+    write_config
+
+    run hk check --all
+    assert_failure
+    run jq -e . <<<"$output"
+    assert_failure
+}
+
+@test "global execution format coexists with config dump format" {
+    run hk config dump --format json
+    assert_success
+    run jq -e . <<<"$output"
+    assert_success
+
+    run hk config dump --format toml --help
+    assert_success
+
+    run hk --format json config dump --format json
+    assert_success
+    run jq -e . <<<"$output"
+    assert_success
+}
+
+@test "fail-fast marks unrun steps cancelled" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+fail_fast = true
+hooks {
+    ["check"] {
+        steps {
+            ["fail"] {
+                check = "exit 1"
+            }
+            ["unrun"] {
+                depends = List("fail")
+                check = "true"
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run bash -c "hk --format json check --all 2>machine-errors.log"
+    assert_failure
+    run jq -r '.steps[] | select(.name == "unrun") | .status' <<<"$output"
+    assert_success
+    assert_output "cancelled"
+}
+
+@test "fail-fast marks an in-flight timed step cancelled" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+fail_fast = true
+hooks {
+    ["check"] {
+        steps {
+            ["parallel"] = new Group {
+                steps {
+                    ["slow"] { check = "touch slow-started; sleep 2" }
+                    ["fail"] { check = "sleep 0.5; exit 1" }
+                }
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run bash -c "hk --format json check --all 2>machine-errors.log"
+    assert_failure
+    assert_file_exists slow-started
+    run jq -r '.steps[] | select(.name == "slow") | .status' <<<"$output"
+    assert_success
+    assert_output "cancelled"
+}
+
+@test "installed-hook no-ops emit a structured reason before config loading" {
+    rm -f hk.pkl
+
+    run bash -c "hk --format json run pre-commit --from-hook 2>machine-errors.log"
+    assert_success
+    run jq -r '[.status, (.steps | length), .reason] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'passed\t0\tno project configuration found for installed hook'
+}
+
+@test "no-op runs still emit a complete result" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {}
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run bash -c "hk --format json check --all 2>machine-errors.log"
+    assert_success
+    run jq -r '[.status, (.steps | length), .reason] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'passed\t0\tno configured steps'
+}
+
+@test "early no-file exit preserves each step's skip reason" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["files"] {
+                check = "true"
+                glob = List("*.rs")
+            }
+            ["profile"] {
+                check = "true"
+                profiles = List("slow")
+            }
+        }
+    }
+}
+EOF
+    git add .
+    git commit -m init
+
+    run bash -c "hk --format json check --all 2>machine-errors.log"
+    assert_success
+    run jq -r '.steps[] | [.name, .skip_reason] | @tsv' <<<"$output"
+    assert_success
+    assert_output --partial $'files\tskipped: no files to process'
+    assert_output --partial $'profile\tskipped: profile not enabled (slow)'
+}
+
+@test "conditions take precedence over an early no-files reason" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["conditional"] {
+                check = "true"
+                glob = List("*.rs")
+                step_condition = "false"
+            }
+        }
+    }
+}
+EOF
+    git add .
+    git commit -m init
+
+    run bash -c "hk --format json check --all 2>machine-errors.log"
+    assert_success
+    run jq -r '.steps[0] | [.status, .skip_reason] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'skipped\tskipped: condition is false'
+}
+
+@test "empty batch jobs remain a no-op with a skip reason" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["batch"] {
+                check = "true"
+                batch = true
+            }
+        }
+    }
+}
+EOF
+    git add .
+    git commit -m init
+    : >files.list
+
+    run bash -c "hk --format json check --files0-from files.list 2>/dev/null"
+    assert_success
+    run jq -r '.steps[0] | [.status, .skip_reason] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'skipped\tskipped: no files to process'
+}
+
+@test "JSON tracing cannot contaminate structured stdout" {
+    write_config
+
+    run bash -c "HK_TRACE=json hk --format json check --all 2>machine-errors.log"
+    assert_failure
+    run jq -e '.kind == "run_result"' <<<"$output"
+    assert_success
+    run bash -c "grep '\"type\":\"meta\"' machine-errors.log | jq -e '.type == \"meta\"'"
+    assert_success
+}
+
+@test "setup failures still emit a versioned failed result" {
+    write_config
+    mv .git .git.saved
+
+    run bash -c "hk --format json check --all 2>machine-errors.log"
+    assert_failure
+    run jq -r '[.schema_version, .status, (.failure | length > 0)] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'1\tfailed\ttrue'
+}


### PR DESCRIPTION
## Summary

- add `--format human|json|jsonl` while preserving the existing `--json` compatibility path
- emit versioned run results and ordered JSONL lifecycle events with step status, timing, output, cancellation, skip reasons, and final summaries
- keep structured stdout clean by routing logs and JSON tracing to stderr
- cover success, failure, no-op, skip, fail-fast cancellation, setup failure, tracing, and command-placement compatibility

## Stack

Depends on #1162 (`feat(run): add agent-friendly execution scoping`). This is layer 2 of the agent-native hk stack.

## Test evidence

- `mise run test:cargo` (240 passed at stack tip)
- `mise run test:bats test/structured_output.bats`
- `mise run render` followed by `git diff --exit-code`
- full Git-backed bats suites pass locally; the complete local wrapper is limited only by optional missing tool runtimes in the no-Git builtin matrix

## Rollout notes

Human output remains the default. Structured formats are opt-in and own stdout; progress, logs, and tracing remain on stderr. The instruction-count gate reports the accepted CLI-argument cost (`builtins` and `usage`); no workaround is applied.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core hook run paths, stdout/stderr contracts, and CLI flag resolution; behavior is opt-in but agents and CI may depend on the new JSON schema.
> 
> **Overview**
> Adds **`--format human|json|jsonl`** (global default `human`, overridable on `check` / `fix` / `run` and hook subcommands) so hook runs can emit **versioned machine-readable results** on stdout instead of only human progress and summaries.
> 
> **`json`** writes a single `run_result` document (hook status, timing, per-step status/duration/output/skip reasons). **`jsonl`** streams ordered lifecycle events (`run_started`, `step_completed`, `run_completed`). Human mode is unchanged; progress, logs, and step summaries are suppressed when a machine format is active.
> 
> Structured output is wired through hook execution end-to-end: no-op paths (skipped hook, no steps, no matching files, `--from-hook` short-circuits), setup failures, and normal completion all emit results. Early no-file exits now derive per-step skip reasons via the same job builder as execution (with conditions left to a real run). **Fail-fast** and cancellation mark unrun or aborted steps as **cancelled** via new finished/cancelled step tracking on **`HookContext`**.
> 
> **JSON trace** is redirected to **stderr** when structured execution owns stdout so JSON stays one document and JSONL stays lifecycle-only. CLI/docs/usage metadata are regenerated; **`test/structured_output.bats`** covers formats, fail-fast, no-ops, tracing, and setup failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbbc8de980c147e0a4ca65e383db4328b7ae176d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->