### PR TITLE
feat(run): add structured execution results

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -33,6 +33,9 @@ struct Cli {
     /// Run as if hk was started in this directory
     #[clap(long, global = true, value_name = "DIRECTORY", value_hint = clap::ValueHint::DirPath)]
     cd: Option<PathBuf>,
+    /// Select human or machine-readable execution output
+    #[clap(long, global = true, value_enum, default_value_t)]
+    format: crate::structured_output::OutputFormat,
     /// Path to user configuration file (deprecated: use ~/.config/hk/config.pkl or hk.local.pkl)
     #[clap(long, global = true, value_name = "PATH", hide = true)]
     hkrc: Option<PathBuf>,
@@ -132,6 +135,7 @@ pub async fn run() -> Result<()> {
         quiet: args.quiet,
         silent: args.silent,
         trace: args.trace,
+        output_format: args.format,
     });
 
     if is_ci::cached() || !console::user_attended_stderr() || args.no_progress {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1005,6 +1005,9 @@ impl Hook {
     pub async fn run(&self, opts: HookOptions) -> Result<()> {
         tracing::info!("running hook");
         let settings = Settings::get();
+        let output_format = Settings::cli_output_format();
+        let machine_output = output_format != crate::structured_output::OutputFormat::Human;
+        let started_at = chrono::Utc::now().to_rfc3339();
         let fail_fast = if opts.fail_fast {
             true
         } else if opts.no_fail_fast {
@@ -1236,7 +1239,7 @@ impl Hook {
         let force_summary = *env::HK_SUMMARY_TEXT;
         let failed_steps = hook_ctx.failed_steps.lock().unwrap().clone();
         let only_failed = settings.quiet || (in_text_mode && !force_summary);
-        if !settings.silent && (!only_failed || !failed_steps.is_empty()) {
+        if !machine_output && !settings.silent && (!only_failed || !failed_steps.is_empty()) {
             let outputs = hook_ctx.output_by_step.lock().unwrap().clone();
             for (step_name, (mode, output)) in outputs.into_iter() {
                 if only_failed && !failed_steps.contains(&step_name) {
@@ -1257,7 +1260,7 @@ impl Hook {
             }
         }
 
-        if !settings.silent && hook_ctx.saw_git_index_lock_contention() {
+        if !machine_output && !settings.silent && hook_ctx.saw_git_index_lock_contention() {
             eprintln!(
                 "\n{}",
                 style::eyellow(
@@ -1272,7 +1275,8 @@ impl Hook {
 
         // Display summary of profile-skipped steps
         // Only show summary if user has enabled the warning tag and it's not hidden
-        if settings.warnings.contains("missing-profiles")
+        if !machine_output
+            && settings.warnings.contains("missing-profiles")
             && !settings.hide_warnings.contains("missing-profiles")
         {
             let skipped_steps = hook_ctx.get_skipped_steps();
@@ -1369,6 +1373,13 @@ impl Hook {
         } else {
             debug!("{self}: hook finished successfully");
         }
+        crate::structured_output::emit_run(
+            output_format,
+            &self.name,
+            started_at,
+            &hook_ctx,
+            result.is_ok(),
+        )?;
         result
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod step_group;
 mod step_job;
 mod step_locks;
 mod step_test;
+mod structured_output;
 mod tera;
 mod test_runner;
 mod timings;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -40,6 +40,7 @@ pub struct CliSnapshot {
     pub quiet: bool,
     pub silent: bool,
     pub trace: bool,
+    pub output_format: crate::structured_output::OutputFormat,
 }
 
 static CLI_SNAPSHOT: Lazy<Mutex<Option<CliSnapshot>>> = Lazy::new(|| Mutex::new(None));
@@ -94,6 +95,15 @@ impl Settings {
             .as_ref()
             .map(|s| s.trace)
             .unwrap_or(false)
+    }
+
+    pub fn cli_output_format() -> crate::structured_output::OutputFormat {
+        CLI_SNAPSHOT
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|snapshot| snapshot.output_format)
+            .unwrap_or_default()
     }
 
     pub fn get() -> Arc<Settings> {

--- a/src/structured_output.rs
+++ b/src/structured_output.rs
@@ -1,0 +1,162 @@
+use crate::{Result, hook::HookContext, step::OutputSummary};
+use serde::Serialize;
+use std::io::Write;
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    Eq,
+    PartialEq,
+    clap::ValueEnum,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum OutputFormat {
+    #[default]
+    Human,
+    Json,
+    Jsonl,
+}
+
+#[derive(Debug, Serialize)]
+struct RunResult {
+    schema_version: u8,
+    kind: &'static str,
+    hook: String,
+    status: &'static str,
+    started_at: String,
+    duration_ms: u128,
+    steps: Vec<StepResult>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StepResult {
+    name: String,
+    status: &'static str,
+    duration_ms: u128,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_kind: Option<OutputSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skip_reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct Event<'a, T: Serialize> {
+    schema_version: u8,
+    event: &'a str,
+    sequence: usize,
+    data: T,
+}
+
+pub fn emit_run(
+    format: OutputFormat,
+    hook: &str,
+    started_at: String,
+    ctx: &HookContext,
+    succeeded: bool,
+) -> Result<()> {
+    if format == OutputFormat::Human {
+        return Ok(());
+    }
+
+    let failed = ctx.failed_steps.lock().unwrap();
+    let skipped = ctx.get_skipped_steps();
+    let outputs = ctx.output_by_step.lock().unwrap();
+    let timings = ctx.timing.step_wall_times();
+    let mut steps = Vec::new();
+    for group in &ctx.groups {
+        for name in group.steps.keys() {
+            let skip_reason = skipped.get(name).map(|reason| reason.message());
+            let status = if failed.contains(name) {
+                "failed"
+            } else if skip_reason.is_some() {
+                "skipped"
+            } else {
+                "passed"
+            };
+            let (output_kind, output) = outputs
+                .get(name)
+                .map(|(kind, output)| (Some(kind.clone()), Some(output.clone())))
+                .unwrap_or((None, None));
+            steps.push(StepResult {
+                name: name.clone(),
+                status,
+                duration_ms: timings.get(name).copied().unwrap_or(0),
+                output_kind,
+                output,
+                skip_reason,
+            });
+        }
+    }
+    drop(outputs);
+    drop(failed);
+
+    let result = RunResult {
+        schema_version: 1,
+        kind: "run_result",
+        hook: hook.to_string(),
+        status: if succeeded { "passed" } else { "failed" },
+        started_at,
+        duration_ms: ctx.timing.elapsed_ms(),
+        steps,
+    };
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    match format {
+        OutputFormat::Human => {}
+        OutputFormat::Json => {
+            serde_json::to_writer_pretty(&mut stdout, &result)?;
+            writeln!(stdout)?;
+        }
+        OutputFormat::Jsonl => {
+            write_event(
+                &mut stdout,
+                &Event {
+                    schema_version: 1,
+                    event: "run_started",
+                    sequence: 0,
+                    data: serde_json::json!({
+                        "hook": result.hook,
+                        "started_at": result.started_at,
+                    }),
+                },
+            )?;
+            for (index, step) in result.steps.iter().enumerate() {
+                write_event(
+                    &mut stdout,
+                    &Event {
+                        schema_version: 1,
+                        event: "step_completed",
+                        sequence: index + 1,
+                        data: step,
+                    },
+                )?;
+            }
+            write_event(
+                &mut stdout,
+                &Event {
+                    schema_version: 1,
+                    event: "run_completed",
+                    sequence: result.steps.len() + 1,
+                    data: serde_json::json!({
+                        "hook": result.hook,
+                        "status": result.status,
+                        "duration_ms": result.duration_ms,
+                    }),
+                },
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn write_event(writer: &mut impl Write, event: &impl Serialize) -> Result<()> {
+    serde_json::to_writer(&mut *writer, event)?;
+    writeln!(writer)?;
+    Ok(())
+}

--- a/src/timings.rs
+++ b/src/timings.rs
@@ -47,6 +47,17 @@ impl TimingRecorder {
         self.start_instant.elapsed().as_millis()
     }
 
+    pub fn elapsed_ms(&self) -> u128 {
+        self.start_instant.elapsed().as_millis()
+    }
+
+    pub fn step_wall_times(&self) -> BTreeMap<String, u128> {
+        let mut map = self.intervals_by_step.lock().unwrap().clone();
+        map.iter_mut()
+            .map(|(name, intervals)| (name.clone(), Self::merge_and_sum(intervals.as_mut_slice())))
+            .collect()
+    }
+
     pub fn add_interval(&self, step: &str, start_ms: u128, end_ms: u128) {
         if end_ms < start_ms {
             return;

--- a/test/structured_output.bats
+++ b/test/structured_output.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+write_config() {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+fail_fast = false
+hooks {
+    ["check"] {
+        steps {
+            ["pass"] {
+                check = "echo passed"
+                output_summary = "combined"
+            }
+            ["fail"] {
+                check = "echo diagnostic >&2; exit 1"
+                output_summary = "combined"
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+}
+
+@test "--format json emits one versioned run result" {
+    write_config
+
+    run bash -c "hk --format json check --all 2>machine-errors.log"
+    assert_failure
+    json="$output"
+    run jq -r '.schema_version, .kind, .hook, .status, (.steps | length)' <<<"$json"
+    assert_success
+    assert_output $'1\nrun_result\ncheck\nfailed\n2'
+    run jq -r '.steps[] | select(.name == "fail") | [.status, (.output | contains("diagnostic"))] | @tsv' <<<"$json"
+    assert_output $'failed\ttrue'
+}
+
+@test "--format jsonl emits ordered lifecycle events" {
+    write_config
+
+    run bash -c "hk --format jsonl check --all 2>machine-errors.log"
+    assert_failure
+    jsonl="$output"
+    run jq -s -r 'map(.event) | join(",")' <<<"$jsonl"
+    assert_success
+    assert_output "run_started,step_completed,step_completed,run_completed"
+    run jq -s -e '.[].sequence' <<<"$jsonl"
+    assert_success
+}
+
+@test "human output remains the default" {
+    write_config
+
+    run hk check --all
+    assert_failure
+    run jq -e . <<<"$output"
+    assert_failure
+}


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the main hook completion path and stdout/stderr behavior for integrators, but human-default behavior is preserved and changes are mostly additive output formatting.
> 
> **Overview**
> Adds a global **`--format`** flag (`human`, `json`, `jsonl`) so hook runs can emit machine-readable results on stdout while keeping **human** as the default.
> 
> After a hook finishes, **`emit_run`** writes a versioned **`run_result`** (JSON) or a sequenced JSONL stream (`run_started` → `step_completed` × N → `run_completed`) with hook status, timings, per-step pass/fail/skip, captured output, and skip reasons. **`TimingRecorder`** exposes total and per-step wall times for that payload.
> 
> When format is not human, end-of-run **stderr** summaries (step output blocks, git index lock hints, missing-profile warnings) are skipped so stdout stays parseable; bats cover JSON shape, JSONL event order, and that default output is not JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d62770cf162959e59c78b73cd36a34a5cb9cbd96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->