### PR TITLE
feat(step): add command effect safety

### DIFF
--- a/docs/cli/check.md
+++ b/docs/cli/check.md
@@ -85,6 +85,10 @@ Disable auto-staging of fixed files
 
 Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
 
+### `--safe`
+
+Reject commands with unknown or destructive effects before execution
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -295,6 +295,16 @@
             "global": false
           },
           {
+            "name": "safe",
+            "usage": "--safe",
+            "help": "Reject commands with unknown or destructive effects before execution",
+            "help_first_line": "Reject commands with unknown or destructive effects before execution",
+            "short": [],
+            "long": ["safe"],
+            "hide": false,
+            "global": false
+          },
+          {
             "name": "skip-step",
             "usage": "--skip-step… <STEP>",
             "help": "Skip specific step(s)",
@@ -786,6 +796,16 @@
             "help_first_line": "Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)",
             "short": [],
             "long": ["pr"],
+            "hide": false,
+            "global": false
+          },
+          {
+            "name": "safe",
+            "usage": "--safe",
+            "help": "Reject commands with unknown or destructive effects before execution",
+            "help_first_line": "Reject commands with unknown or destructive effects before execution",
+            "short": [],
+            "long": ["safe"],
             "hide": false,
             "global": false
           },
@@ -1350,6 +1370,16 @@
                 "global": false
               },
               {
+                "name": "safe",
+                "usage": "--safe",
+                "help": "Reject commands with unknown or destructive effects before execution",
+                "help_first_line": "Reject commands with unknown or destructive effects before execution",
+                "short": [],
+                "long": ["safe"],
+                "hide": false,
+                "global": false
+              },
+              {
                 "name": "skip-step",
                 "usage": "--skip-step… <STEP>",
                 "help": "Skip specific step(s)",
@@ -1722,6 +1752,16 @@
                 "global": false
               },
               {
+                "name": "safe",
+                "usage": "--safe",
+                "help": "Reject commands with unknown or destructive effects before execution",
+                "help_first_line": "Reject commands with unknown or destructive effects before execution",
+                "short": [],
+                "long": ["safe"],
+                "hide": false,
+                "global": false
+              },
+              {
                 "name": "skip-step",
                 "usage": "--skip-step… <STEP>",
                 "help": "Skip specific step(s)",
@@ -2063,6 +2103,16 @@
                 "help_first_line": "Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)",
                 "short": [],
                 "long": ["pr"],
+                "hide": false,
+                "global": false
+              },
+              {
+                "name": "safe",
+                "usage": "--safe",
+                "help": "Reject commands with unknown or destructive effects before execution",
+                "help_first_line": "Reject commands with unknown or destructive effects before execution",
+                "short": [],
+                "long": ["safe"],
                 "hide": false,
                 "global": false
               },
@@ -2421,6 +2471,16 @@
                 "global": false
               },
               {
+                "name": "safe",
+                "usage": "--safe",
+                "help": "Reject commands with unknown or destructive effects before execution",
+                "help_first_line": "Reject commands with unknown or destructive effects before execution",
+                "short": [],
+                "long": ["safe"],
+                "hide": false,
+                "global": false
+              },
+              {
                 "name": "skip-step",
                 "usage": "--skip-step… <STEP>",
                 "help": "Skip specific step(s)",
@@ -2775,6 +2835,16 @@
                 "global": false
               },
               {
+                "name": "safe",
+                "usage": "--safe",
+                "help": "Reject commands with unknown or destructive effects before execution",
+                "help_first_line": "Reject commands with unknown or destructive effects before execution",
+                "short": [],
+                "long": ["safe"],
+                "hide": false,
+                "global": false
+              },
+              {
                 "name": "skip-step",
                 "usage": "--skip-step… <STEP>",
                 "help": "Skip specific step(s)",
@@ -3116,6 +3186,16 @@
                 "help_first_line": "Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)",
                 "short": [],
                 "long": ["pr"],
+                "hide": false,
+                "global": false
+              },
+              {
+                "name": "safe",
+                "usage": "--safe",
+                "help": "Reject commands with unknown or destructive effects before execution",
+                "help_first_line": "Reject commands with unknown or destructive effects before execution",
+                "short": [],
+                "long": ["safe"],
                 "hide": false,
                 "global": false
               },
@@ -3484,6 +3564,16 @@
                 "global": false
               },
               {
+                "name": "safe",
+                "usage": "--safe",
+                "help": "Reject commands with unknown or destructive effects before execution",
+                "help_first_line": "Reject commands with unknown or destructive effects before execution",
+                "short": [],
+                "long": ["safe"],
+                "hide": false,
+                "global": false
+              },
+              {
                 "name": "skip-step",
                 "usage": "--skip-step… <STEP>",
                 "help": "Skip specific step(s)",
@@ -3843,6 +3933,16 @@
                 "help_first_line": "Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)",
                 "short": [],
                 "long": ["pr"],
+                "hide": false,
+                "global": false
+              },
+              {
+                "name": "safe",
+                "usage": "--safe",
+                "help": "Reject commands with unknown or destructive effects before execution",
+                "help_first_line": "Reject commands with unknown or destructive effects before execution",
+                "short": [],
+                "long": ["safe"],
                 "hide": false,
                 "global": false
               },
@@ -4219,6 +4319,16 @@
                 "global": false
               },
               {
+                "name": "safe",
+                "usage": "--safe",
+                "help": "Reject commands with unknown or destructive effects before execution",
+                "help_first_line": "Reject commands with unknown or destructive effects before execution",
+                "short": [],
+                "long": ["safe"],
+                "hide": false,
+                "global": false
+              },
+              {
                 "name": "skip-step",
                 "usage": "--skip-step… <STEP>",
                 "help": "Skip specific step(s)",
@@ -4564,6 +4674,16 @@
             "help_first_line": "Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)",
             "short": [],
             "long": ["pr"],
+            "hide": false,
+            "global": false
+          },
+          {
+            "name": "safe",
+            "usage": "--safe",
+            "help": "Reject commands with unknown or destructive effects before execution",
+            "help_first_line": "Reject commands with unknown or destructive effects before execution",
+            "short": [],
+            "long": ["safe"],
             "hide": false,
             "global": false
           },

--- a/docs/cli/fix.md
+++ b/docs/cli/fix.md
@@ -85,6 +85,10 @@ Disable auto-staging of fixed files
 
 Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
 
+### `--safe`
+
+Reject commands with unknown or destructive effects before execution
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -85,6 +85,10 @@ Disable auto-staging of fixed files
 
 Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
 
+### `--safe`
+
+Reject commands with unknown or destructive effects before execution
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/commit-msg.md
+++ b/docs/cli/run/commit-msg.md
@@ -87,6 +87,10 @@ Disable auto-staging of fixed files
 
 Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
 
+### `--safe`
+
+Reject commands with unknown or destructive effects before execution
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/post-checkout.md
+++ b/docs/cli/run/post-checkout.md
@@ -94,6 +94,10 @@ Disable auto-staging of fixed files
 
 Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
 
+### `--safe`
+
+Reject commands with unknown or destructive effects before execution
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/post-commit.md
+++ b/docs/cli/run/post-commit.md
@@ -82,6 +82,10 @@ Disable auto-staging of fixed files
 
 Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
 
+### `--safe`
+
+Reject commands with unknown or destructive effects before execution
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/post-merge.md
+++ b/docs/cli/run/post-merge.md
@@ -86,6 +86,10 @@ Disable auto-staging of fixed files
 
 Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
 
+### `--safe`
+
+Reject commands with unknown or destructive effects before execution
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/post-rewrite.md
+++ b/docs/cli/run/post-rewrite.md
@@ -86,6 +86,10 @@ Disable auto-staging of fixed files
 
 Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
 
+### `--safe`
+
+Reject commands with unknown or destructive effects before execution
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/pre-commit.md
+++ b/docs/cli/run/pre-commit.md
@@ -85,6 +85,10 @@ Disable auto-staging of fixed files
 
 Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
 
+### `--safe`
+
+Reject commands with unknown or destructive effects before execution
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/pre-push.md
+++ b/docs/cli/run/pre-push.md
@@ -91,6 +91,10 @@ Disable auto-staging of fixed files
 
 Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
 
+### `--safe`
+
+Reject commands with unknown or destructive effects before execution
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/pre-rebase.md
+++ b/docs/cli/run/pre-rebase.md
@@ -90,6 +90,10 @@ Disable auto-staging of fixed files
 
 Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
 
+### `--safe`
+
+Reject commands with unknown or destructive effects before execution
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/prepare-commit-msg.md
+++ b/docs/cli/run/prepare-commit-msg.md
@@ -95,6 +95,10 @@ Disable auto-staging of fixed files
 
 Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
 
+### `--safe`
+
+Reject commands with unknown or destructive effects before execution
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -68,6 +68,7 @@ cmd check help="Checks code" {
     flag --no-fail-fast help="Continue on failures (opposite of --fail-fast)"
     flag --no-stage help="Disable auto-staging of fixed files"
     flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
+    flag --safe help="Reject commands with unknown or destructive effects before execution"
     flag --skip-step help="Skip specific step(s)" var=#true {
         arg <STEP>
     }
@@ -170,6 +171,7 @@ cmd fix help="Fixes code" {
     flag --no-fail-fast help="Continue on failures (opposite of --fail-fast)"
     flag --no-stage help="Disable auto-staging of fixed files"
     flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
+    flag --safe help="Reject commands with unknown or destructive effects before execution"
     flag --skip-step help="Skip specific step(s)" var=#true {
         arg <STEP>
     }
@@ -288,6 +290,7 @@ cmd run help="Run a hook" {
     flag --no-fail-fast help="Continue on failures (opposite of --fail-fast)"
     flag --no-stage help="Disable auto-staging of fixed files"
     flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
+    flag --safe help="Reject commands with unknown or destructive effects before execution"
     flag --skip-step help="Skip specific step(s)" var=#true {
         arg <STEP>
     }
@@ -340,6 +343,7 @@ cmd run help="Run a hook" {
         flag --no-fail-fast help="Continue on failures (opposite of --fail-fast)"
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
+        flag --safe help="Reject commands with unknown or destructive effects before execution"
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -392,6 +396,7 @@ cmd run help="Run a hook" {
         flag --no-fail-fast help="Continue on failures (opposite of --fail-fast)"
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
+        flag --safe help="Reject commands with unknown or destructive effects before execution"
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -446,6 +451,7 @@ cmd run help="Run a hook" {
         flag --no-fail-fast help="Continue on failures (opposite of --fail-fast)"
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
+        flag --safe help="Reject commands with unknown or destructive effects before execution"
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -497,6 +503,7 @@ cmd run help="Run a hook" {
         flag --no-fail-fast help="Continue on failures (opposite of --fail-fast)"
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
+        flag --safe help="Reject commands with unknown or destructive effects before execution"
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -549,6 +556,7 @@ cmd run help="Run a hook" {
         flag --no-fail-fast help="Continue on failures (opposite of --fail-fast)"
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
+        flag --safe help="Reject commands with unknown or destructive effects before execution"
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -602,6 +610,7 @@ cmd run help="Run a hook" {
         flag --no-fail-fast help="Continue on failures (opposite of --fail-fast)"
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
+        flag --safe help="Reject commands with unknown or destructive effects before execution"
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -654,6 +663,7 @@ cmd run help="Run a hook" {
         flag --no-fail-fast help="Continue on failures (opposite of --fail-fast)"
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
+        flag --safe help="Reject commands with unknown or destructive effects before execution"
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -707,6 +717,7 @@ cmd run help="Run a hook" {
         flag --no-fail-fast help="Continue on failures (opposite of --fail-fast)"
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
+        flag --safe help="Reject commands with unknown or destructive effects before execution"
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -761,6 +772,7 @@ cmd run help="Run a hook" {
         flag --no-fail-fast help="Continue on failures (opposite of --fail-fast)"
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
+        flag --safe help="Reject commands with unknown or destructive effects before execution"
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -40,6 +40,15 @@ class Command {
   argv: List<String>
 }
 
+typealias CommandEffect = "read" | "write" | "destructive"
+
+/// A command paired with its declared effect on user or project state.
+/// Commands that do not use CommandSpec remain valid and have an unknown effect.
+class CommandSpec {
+  command: String | Script | Command
+  effect: CommandEffect
+}
+
 /// Default: auto-detected
 ///
 /// Specifies the preferred default branch to compare against when hk needs a reference
@@ -459,7 +468,7 @@ class Step {
   ///   argv = List("wc", "-c", "{{files}}")
   /// }
   /// ```
-  check: (String | Script | Command)?
+  check: (String | Script | Command | CommandSpec)?
 
   /// A command that returns a list of files that need fixing.
   /// This is used to optimize the fix step when `check_first` is enabled.
@@ -474,7 +483,7 @@ class Step {
   ///     }
   /// }
   /// ```
-  check_list_files: (String | Script | Command)?
+  check_list_files: (String | Script | Command | CommandSpec)?
 
   /// A command that shows the diff of what would be changed.
   /// This is an alternative to `check` that can provide more detailed information about what would be changed.
@@ -484,7 +493,7 @@ class Step {
   /// produce standard unified diffs (black, ruff, shfmt, etc.).
   ///
   /// Falls back to running the fix command if patch application fails.
-  check_diff: (String | Script | Command)?
+  check_diff: (String | Script | Command | CommandSpec)?
 
   /// Default: `false`
   ///
@@ -510,7 +519,7 @@ class Step {
   ///
   /// By default, hk will use `fix` commands but this can be overridden by setting
   /// [`HK_FIX=0`](https://hk.jdx.dev/configuration#hk-fix) or running `hk run <HOOK> --check`.
-  fix: (String | Script | Command)?
+  fix: (String | Script | Command | CommandSpec)?
 
   /// If true, hk will run the check step first and only run the fix step if the check step fails.
   check_first: Boolean = true

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -28,7 +28,7 @@ use crate::{
     hook_options::HookOptions,
     plan::{ParallelGroup, Plan, PlannedStep, Reason, ReasonKind, StepStatus},
     settings::Settings,
-    step::{EXPR_CTX, EXPR_ENV, OutputSummary, RunType, Script, Step},
+    step::{CommandEffect, EXPR_CTX, EXPR_ENV, OutputSummary, RunType, Script, Step},
     step_context::StepContext,
     step_group::{StepGroup, StepGroupContext},
     timings::TimingRecorder,
@@ -300,6 +300,8 @@ mod tests {
     }
 }
 
+type CommandEffectsByStep = IndexMap<String, Vec<(String, Option<CommandEffect>)>>;
+
 pub struct HookContext {
     pub file_locks: FileRwLocks,
     pub git: Arc<Mutex<Git>>,
@@ -319,6 +321,8 @@ pub struct HookContext {
     skipped_steps: std::sync::Mutex<IndexMap<String, SkipReason>>,
     /// Aggregated output per step name (in insertion order)
     pub output_by_step: std::sync::Mutex<IndexMap<String, (OutputSummary, String)>>,
+    /// Command fields and effects actually selected for execution per step.
+    pub command_effects_by_step: std::sync::Mutex<CommandEffectsByStep>,
     /// Names of steps that failed during this run. Tracked here because
     /// `step_contexts` are shift_remove'd as soon as each step finishes, so
     /// status info is not available to the end-of-run summary.
@@ -381,6 +385,7 @@ impl HookContext {
             skip_steps,
             skipped_steps: StdMutex::new(IndexMap::new()),
             output_by_step: StdMutex::new(IndexMap::new()),
+            command_effects_by_step: StdMutex::new(IndexMap::new()),
             failed_steps: StdMutex::new(HashSet::new()),
             finished_steps: StdMutex::new(HashSet::new()),
             cancelled_steps: StdMutex::new(HashSet::new()),
@@ -472,6 +477,20 @@ impl HookContext {
         map.entry(step_name.to_string())
             .and_modify(|(_, s)| s.push_str(text))
             .or_insert_with(|| (mode, text.to_string()));
+    }
+
+    pub fn record_step_effect(
+        &self,
+        step_name: &str,
+        command: &str,
+        effect: Option<CommandEffect>,
+    ) {
+        let record = (command.to_string(), effect);
+        let mut effects = self.command_effects_by_step.lock().unwrap();
+        let records = effects.entry(step_name.to_string()).or_default();
+        if !records.contains(&record) {
+            records.push(record);
+        }
     }
 
     pub fn mark_step_failed(&self, step_name: &str) {
@@ -603,6 +622,7 @@ impl Hook {
         clx::progress::set_output(ProgressOutput::Text);
         let settings = Settings::get();
         let run_type = self.run_type(&opts);
+        let groups = self.get_step_groups(&opts);
         let repo = Arc::new(Mutex::new(Git::new()?));
         let git_status = repo.lock().await.status(None)?;
         let stash_method = self.resolve_stash_method_for_opts(&opts);
@@ -616,8 +636,10 @@ impl Hook {
             .collect();
 
         let skip_steps = build_skip_steps(&settings, &opts);
+        if opts.safe {
+            validate_safe_commands(&groups, &files, run_type, &skip_steps)?;
+        }
 
-        let groups = self.get_step_groups(&opts);
         let expr_ctx = build_expr_ctx(&git_status);
 
         let mut plan = Plan::new(self.name.clone(), run_type.as_str().to_string())
@@ -628,10 +650,23 @@ impl Hook {
             let group_id = format!("group_{}", group_idx);
             let multi = group.steps.len() > 1;
             let mut group_step_ids: Vec<String> = Vec::new();
+            let files_in_contention = group.files_in_contention_for(&files, run_type)?;
 
             for (step_name, step) in &group.steps {
                 let (status, reasons, file_count) =
                     self.analyze_step(step, &files, run_type, &skip_steps, &expr_ctx, &opts);
+
+                let jobs =
+                    step.build_step_jobs(&files, run_type, &files_in_contention, &skip_steps)?;
+                // A step may produce jobs with different check-first choices.
+                // Report the most restrictive selected effect so the single
+                // plan field remains conservative without describing commands
+                // that no runnable job will execute.
+                let selected_effect = step
+                    .commands_for_jobs(run_type, &jobs)
+                    .into_iter()
+                    .filter_map(|(_, command)| command.effect())
+                    .max();
 
                 let planned = PlannedStep {
                     name: step_name.clone(),
@@ -641,7 +676,14 @@ impl Hook {
                     depends_on: step.depends.clone(),
                     reasons,
                     file_count,
-                    metadata: HashMap::new(),
+                    metadata: selected_effect
+                        .map(|effect| {
+                            HashMap::from([(
+                                "effect".to_string(),
+                                serde_json::to_value(effect).expect("effect serializes"),
+                            )])
+                        })
+                        .unwrap_or_default(),
                 };
 
                 plan.add_step(planned);
@@ -1059,6 +1101,7 @@ impl Hook {
         let run_type = self.run_type(&opts);
         // fail_on_fix exists to surface fixes for review; staging would defeat that.
         let should_stage = should_stage && !(self.fail_on_fix && matches!(run_type, RunType::Fix));
+        let groups = self.get_step_groups(&opts);
         let repo = match Git::new() {
             Ok(repo) => Arc::new(Mutex::new(repo)),
             Err(err) => {
@@ -1074,7 +1117,6 @@ impl Hook {
                 return Err(err);
             }
         };
-        let groups = self.get_step_groups(&opts);
         let stash_method = self.resolve_stash_method_for_opts(&opts);
         let total_steps: usize = groups.iter().map(|g| g.steps.len()).sum();
         // Exit before any side effects (notably stashing) when there are no steps to run.
@@ -1156,6 +1198,14 @@ impl Hook {
                 "no matching files",
             )?;
             return Ok(());
+        }
+        if opts.safe {
+            validate_safe_commands(
+                &groups,
+                &files.iter().cloned().collect::<Vec<_>>(),
+                run_type,
+                &skip_steps,
+            )?;
         }
         // Enrich Tera and expr contexts with git status for template/condition use
         let git_status_for_ctx = git_status.clone();
@@ -1749,6 +1799,42 @@ fn build_skip_steps(settings: &Settings, opts: &HookOptions) -> IndexMap<String,
         );
     }
     m
+}
+
+fn validate_safe_commands(
+    groups: &[StepGroup],
+    files: &[PathBuf],
+    run_type: RunType,
+    skip_steps: &IndexMap<String, SkipReason>,
+) -> Result<()> {
+    let mut blockers = BTreeSet::new();
+    for group in groups {
+        let files_in_contention = group.files_in_contention_for(files, run_type)?;
+        for (step_name, step) in &group.steps {
+            let jobs = step.build_step_jobs(files, run_type, &files_in_contention, skip_steps)?;
+            if jobs.iter().all(|job| job.skip_reason.is_some()) {
+                continue;
+            }
+            for (field, command) in step.commands_for_jobs(run_type, &jobs) {
+                match command.effect() {
+                    None => {
+                        blockers.insert(format!("{step_name}.{field}: effect is unknown"));
+                    }
+                    Some(CommandEffect::Destructive) => {
+                        blockers.insert(format!("{step_name}.{field}: effect is destructive"));
+                    }
+                    Some(CommandEffect::Read | CommandEffect::Write) => {}
+                }
+            }
+        }
+    }
+    if !blockers.is_empty() {
+        eyre::bail!(
+            "--safe refused to run:\n  {}",
+            blockers.into_iter().join("\n  ")
+        );
+    }
+    Ok(())
 }
 
 fn build_expr_ctx(git_status: &GitStatus) -> expr::Context {

--- a/src/hook_options.rs
+++ b/src/hook_options.rs
@@ -64,6 +64,9 @@ pub(crate) struct HookOptions {
     /// Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)
     #[clap(long, conflicts_with_all = &["files", "all", "from_ref", "glob", "to_ref"])]
     pub pr: bool,
+    /// Reject commands with unknown or destructive effects before execution
+    #[clap(long)]
+    pub safe: bool,
     /// Skip specific step(s)
     #[clap(long, value_name = "STEP")]
     pub skip_step: Vec<String>,

--- a/src/step/mod.rs
+++ b/src/step/mod.rs
@@ -50,7 +50,9 @@ pub use shell::ShellType;
 pub(crate) use types::RenderedCommand;
 #[cfg(test)]
 pub(crate) use types::{ArgvCommand, Command};
-pub use types::{CommandPrefix, FileSelector, OutputSummary, Pattern, RunType, Script, Step};
+pub use types::{
+    CommandEffect, CommandPrefix, FileSelector, OutputSummary, Pattern, RunType, Script, Step,
+};
 
 // Re-export for potential external use (currently only used internally)
 #[allow(unused_imports)]

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -48,6 +48,62 @@ fn truncate_progress_message(s: &str, max_chars: usize) -> String {
 }
 
 impl Step {
+    pub fn commands_for_jobs<'a>(
+        &'a self,
+        run_type: RunType,
+        jobs: &[StepJob],
+    ) -> Vec<(&'static str, &'a Command)> {
+        let mut commands = Vec::new();
+        for job in jobs.iter().filter(|job| job.skip_reason.is_none()) {
+            let first = if job.check_first {
+                self.check_first_cmd().map(|command| command.command())
+            } else {
+                self.run_cmd(run_type)
+            };
+
+            // A failed check-first command falls through to the command for the
+            // requested run type. Include both possible commands in plans and
+            // safe-mode preflight even though a successful check-first command
+            // can make the fallback unnecessary at runtime.
+            let fallback = job.check_first.then(|| self.run_cmd(run_type)).flatten();
+            for command in [first, fallback]
+                .into_iter()
+                .flatten()
+                .filter(|command| !command.is_empty())
+            {
+                let field = self.command_field(command);
+                if !commands.iter().any(|(existing, _)| *existing == field) {
+                    commands.push((field, command));
+                }
+            }
+        }
+        commands
+    }
+
+    fn command_field(&self, command: &Command) -> &'static str {
+        if self
+            .check
+            .as_ref()
+            .is_some_and(|candidate| std::ptr::eq(candidate, command))
+        {
+            "check"
+        } else if self
+            .check_diff
+            .as_ref()
+            .is_some_and(|candidate| std::ptr::eq(candidate, command))
+        {
+            "check_diff"
+        } else if self
+            .check_list_files
+            .as_ref()
+            .is_some_and(|candidate| std::ptr::eq(candidate, command))
+        {
+            "check_list_files"
+        } else {
+            "fix"
+        }
+    }
+
     /// Execute a single job.
     ///
     /// This is the core execution function that runs a command for a step.
@@ -284,6 +340,23 @@ impl Step {
         let timing_guard = StepTimingGuard::new(ctx.hook_ctx.timing.clone(), self);
         let exec_result = cmd.execute().await;
         timing_guard.finish();
+        // Record only commands that reached a running process. Template,
+        // environment, mise, or spawn failures must not claim an effect that
+        // never occurred. Script failures, cancellation, and timeouts all
+        // happen after the child started and therefore do count.
+        if matches!(
+            &exec_result,
+            Ok(_)
+                | Err(ensembler::Error::ScriptFailed(_))
+                | Err(ensembler::Error::Cancelled)
+                | Err(ensembler::Error::TimedOut)
+        ) {
+            ctx.hook_ctx.record_step_effect(
+                &self.name,
+                self.command_field(run_cmd),
+                run_cmd.effect(),
+            );
+        }
         if self.interactive {
             clx::progress::resume();
         }

--- a/src/step/types.rs
+++ b/src/step/types.rs
@@ -341,6 +341,7 @@ pub enum OutputSummary {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde_as]
+#[serde(deny_unknown_fields)]
 pub struct Script {
     /// Command for Linux
     pub linux: Option<String>,
@@ -370,10 +371,44 @@ pub enum CommandPrefix {
     Argv(Vec<String>),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CommandEffect {
+    Read,
+    Write,
+    Destructive,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CommandSpec {
+    #[serde(deserialize_with = "deserialize_boxed_command")]
+    pub command: Box<Command>,
+    pub effect: CommandEffect,
+}
+
+fn deserialize_boxed_command<'de, D>(deserializer: D) -> std::result::Result<Box<Command>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+    let value = serde_json::Value::deserialize(deserializer)?;
+    if let serde_json::Value::String(command) = &value {
+        return command
+            .parse::<Command>()
+            .map(Box::new)
+            .map_err(D::Error::custom);
+    }
+    serde_json::from_value(value)
+        .map(Box::new)
+        .map_err(D::Error::custom)
+}
+
 /// A step command that either runs through a shell or executes an argv directly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Command {
+    Spec(CommandSpec),
     Argv(ArgvCommand),
     Shell(Script),
 }
@@ -387,13 +422,29 @@ pub(crate) enum RenderedCommand {
 impl Command {
     pub fn is_empty(&self) -> bool {
         match self {
+            Self::Spec(spec) => spec.command.is_empty(),
             Self::Shell(script) => script.to_string().trim().is_empty(),
             Self::Argv(command) => command.argv.is_empty() || command.argv[0].trim().is_empty(),
         }
     }
 
     pub fn is_argv(&self) -> bool {
-        matches!(self, Self::Argv(_))
+        match self {
+            Self::Spec(spec) => spec.command.is_argv(),
+            Self::Argv(_) => true,
+            Self::Shell(_) => false,
+        }
+    }
+
+    pub fn effect(&self) -> Option<CommandEffect> {
+        match self {
+            Self::Spec(spec) => Some(
+                spec.command
+                    .effect()
+                    .map_or(spec.effect, |inner| spec.effect.max(inner)),
+            ),
+            Self::Argv(_) | Self::Shell(_) => None,
+        }
     }
 
     pub(crate) fn render(
@@ -402,6 +453,7 @@ impl Command {
         prefix: Option<&CommandPrefix>,
     ) -> Result<RenderedCommand> {
         match self {
+            Self::Spec(spec) => spec.command.render(tctx, prefix),
             Self::Shell(script) => {
                 let script = script.to_string();
                 let script = match prefix {
@@ -511,6 +563,7 @@ impl FromStr for Command {
 impl Display for Command {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Spec(spec) => spec.command.fmt(f),
             Self::Shell(script) => script.fmt(f),
             Self::Argv(command) => write!(f, "{}", command.argv.join(" ")),
         }
@@ -563,6 +616,44 @@ impl<'a> CheckFirstCmd<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn command_spec_deserializes_shell_script_and_argv_commands() {
+        let shell: Command = serde_json::from_value(serde_json::json!({
+            "command": "tool --check",
+            "effect": "read"
+        }))
+        .unwrap();
+        assert_eq!(shell.effect(), Some(CommandEffect::Read));
+        assert_eq!(shell.to_string(), "tool --check");
+
+        let script: Command = serde_json::from_value(serde_json::json!({
+            "command": {"linux": "tool-linux", "other": "tool"},
+            "effect": "write"
+        }))
+        .unwrap();
+        assert_eq!(script.effect(), Some(CommandEffect::Write));
+
+        let argv: Command = serde_json::from_value(serde_json::json!({
+            "command": {"argv": ["tool", "{{files}}"]},
+            "effect": "destructive"
+        }))
+        .unwrap();
+        assert_eq!(argv.effect(), Some(CommandEffect::Destructive));
+        assert!(argv.is_argv());
+    }
+
+    #[test]
+    fn legacy_commands_have_unknown_effect() {
+        let shell: Command = "tool --check".parse().unwrap();
+        let argv: Command = serde_json::from_value(serde_json::json!({
+            "argv": ["tool", "--check"]
+        }))
+        .unwrap();
+
+        assert_eq!(shell.effect(), None);
+        assert_eq!(argv.effect(), None);
+    }
 
     #[test]
     fn structured_argv_expands_file_lists_as_distinct_arguments() {
@@ -665,6 +756,19 @@ mod tests {
         });
 
         assert!(command.is_empty());
+    }
+
+    #[test]
+    fn nested_command_specs_keep_the_most_restrictive_effect() {
+        let command = Command::Spec(CommandSpec {
+            effect: CommandEffect::Read,
+            command: Box::new(Command::Spec(CommandSpec {
+                effect: CommandEffect::Destructive,
+                command: Box::new("true".parse().unwrap()),
+            })),
+        });
+
+        assert_eq!(command.effect(), Some(CommandEffect::Destructive));
     }
 
     #[test]

--- a/src/step_group.rs
+++ b/src/step_group.rs
@@ -164,7 +164,8 @@ impl StepGroup {
                 )
             })
             .collect();
-        *ctx.hook_ctx.files_in_contention.lock().unwrap() = self.files_in_contention(&ctx)?;
+        *ctx.hook_ctx.files_in_contention.lock().unwrap() =
+            self.files_in_contention_for(&ctx.hook_ctx.files(), ctx.hook_ctx.run_type)?;
         if self.steps.values().any(|j| j.check_first) {
         } else {
             *ctx.hook_ctx.files_in_contention.lock().unwrap() = Default::default();
@@ -233,11 +234,14 @@ impl StepGroup {
         result
     }
 
-    fn files_in_contention(&self, ctx: &StepGroupContext) -> Result<HashSet<PathBuf>> {
-        if ctx.hook_ctx.run_type != RunType::Fix || !self.steps.values().any(|j| j.check_first) {
+    pub(crate) fn files_in_contention_for(
+        &self,
+        files: &[PathBuf],
+        run_type: RunType,
+    ) -> Result<HashSet<PathBuf>> {
+        if run_type != RunType::Fix || !self.steps.values().any(|j| j.check_first) {
             return Ok(Default::default());
         }
-        let files = ctx.hook_ctx.files();
         let step_map: HashMap<&str, &Step> = self
             .steps
             .values()
@@ -247,7 +251,7 @@ impl StepGroup {
             .steps
             .values()
             .map(|step| {
-                let step_files = step.filter_files(&files)?;
+                let step_files = step.filter_files(files)?;
 
                 Ok((step.name.as_str(), step_files))
             })

--- a/src/structured_output.rs
+++ b/src/structured_output.rs
@@ -1,4 +1,8 @@
-use crate::{Result, hook::HookContext, step::OutputSummary};
+use crate::{
+    Result,
+    hook::HookContext,
+    step::{CommandEffect, OutputSummary},
+};
 use serde::Serialize;
 use std::io::Write;
 
@@ -41,12 +45,20 @@ struct StepResult {
     name: String,
     status: &'static str,
     duration_ms: u128,
+    effects: Vec<ExecutedEffect>,
     #[serde(skip_serializing_if = "Option::is_none")]
     output_kind: Option<OutputSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
     output: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     skip_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ExecutedEffect {
+    command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effect: Option<CommandEffect>,
 }
 
 #[derive(Debug, Serialize)]
@@ -75,6 +87,7 @@ pub fn emit_run(
     let run_was_cancelled = !cancelled.is_empty();
     let skipped = ctx.get_skipped_steps();
     let outputs = ctx.output_by_step.lock().unwrap();
+    let executed_effects = ctx.command_effects_by_step.lock().unwrap();
     let timings = ctx.timing.step_wall_times();
     let mut steps = Vec::new();
     for group in &ctx.groups {
@@ -99,6 +112,15 @@ pub fn emit_run(
                 name: name.clone(),
                 status,
                 duration_ms: timings.get(name).copied().unwrap_or(0),
+                effects: executed_effects
+                    .get(name)
+                    .into_iter()
+                    .flatten()
+                    .map(|(command, effect)| ExecutedEffect {
+                        command: command.clone(),
+                        effect: *effect,
+                    })
+                    .collect(),
                 output_kind,
                 output,
                 skip_reason,
@@ -152,6 +174,7 @@ pub fn emit_noop_run(
                 name,
                 status: "skipped",
                 duration_ms: 0,
+                effects: vec![],
                 output_kind: None,
                 output: None,
                 skip_reason: Some(skip_reason),

--- a/test/command_effects.bats
+++ b/test/command_effects.bats
@@ -1,0 +1,251 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+write_config() {
+    local first_effect="$1"
+    local second_effect="$2"
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["first"] {
+                check = new CommandSpec {
+                    command = "touch first-ran"
+                    effect = "$first_effect"
+                }
+            }
+            ["second"] {
+                check = new CommandSpec {
+                    command = "touch second-ran"
+                    effect = "$second_effect"
+                }
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+}
+
+@test "safe mode permits read and write effects" {
+    write_config read write
+
+    run hk check --all --safe
+    assert_success
+    assert_file_exists first-ran
+    assert_file_exists second-ran
+}
+
+write_legacy_config() {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["known"] {
+                check = new CommandSpec {
+                    command = "touch known-ran"
+                    effect = "read"
+                }
+            }
+            ["legacy"] {
+                check = "touch legacy-ran"
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+}
+
+@test "safe mode rejects legacy commands before any step starts" {
+    write_legacy_config
+
+    run hk check --all --safe
+    assert_failure
+    assert_output --partial "legacy.check: effect is unknown"
+    assert_file_not_exists known-ran
+    assert_file_not_exists legacy-ran
+}
+
+@test "safe mode ignores explicitly skipped legacy commands" {
+    write_legacy_config
+
+    run hk check --all --safe --skip-step legacy
+    assert_success
+    assert_file_exists known-ran
+    assert_file_not_exists legacy-ran
+}
+
+@test "safe mode validates plans without running steps" {
+    write_legacy_config
+
+    run hk check --all --plan --safe
+
+    assert_failure
+    assert_output --partial "legacy.check: effect is unknown"
+    assert_file_not_exists legacy-ran
+}
+
+@test "safe mode rejects destructive commands before any step starts" {
+    write_config read destructive
+
+    run hk check --all --safe
+    assert_failure
+    assert_output --partial "second.check: effect is destructive"
+    assert_file_not_exists first-ran
+    assert_file_not_exists second-ran
+}
+
+@test "plans and structured results include effects" {
+    write_config read write
+
+    run bash -c "hk check --all --plan --json 2>/dev/null"
+    assert_success
+    run jq -r '.steps[] | [.name, .metadata.effect] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'first\tread\nsecond\twrite'
+
+    run bash -c "hk --format json check --all --safe 2>/dev/null"
+    assert_success
+    run jq -r '.steps[] | [.name, .effects[0].effect] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'first\tread\nsecond\twrite'
+}
+
+@test "safe mode validates dynamically enabled check-first commands" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["dynamic"] {
+                check_diff = new CommandSpec {
+                    command = "touch check-first-ran"
+                    effect = "destructive"
+                }
+                fix = new CommandSpec {
+                    command = "touch fix-ran"
+                    effect = "write"
+                }
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run hk check --fix --all --safe
+    assert_failure
+    assert_output --partial "dynamic.check_diff: effect is destructive"
+    assert_file_not_exists check-first-ran
+    assert_file_not_exists fix-ran
+}
+
+@test "safe mode ignores check-first commands that no job will use" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["dynamic"] {
+                check_first = true
+                check = "touch check-first-ran"
+                fix = new CommandSpec {
+                    command = "touch fix-ran"
+                    effect = "write"
+                }
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run hk check --fix --all --safe
+    assert_success
+    assert_file_not_exists check-first-ran
+    assert_file_exists fix-ran
+}
+
+@test "safe mode ignores a command unavailable on this platform" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["platform-only"] {
+                check = new CommandSpec {
+                    command = new Script { windows = "touch should-not-run" }
+                    effect = "destructive"
+                }
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run hk check --all --safe
+    assert_success
+    assert_file_not_exists should-not-run
+}
+
+@test "structured results report only commands selected for execution" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["dynamic"] {
+                check_diff = new CommandSpec {
+                    command = "true"
+                    effect = "read"
+                }
+                fix = new CommandSpec {
+                    command = "touch fix-ran"
+                    effect = "write"
+                }
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run bash -c "hk --format json check --fix --all --safe 2>/dev/null"
+    assert_success
+    run jq -r '.steps[0].effects | map([.command, .effect] | join(":")) | join(",")' <<<"$output"
+    assert_success
+    assert_output "check_diff:read"
+    assert_file_not_exists fix-ran
+
+    run bash -c "hk check --fix --all --plan --json 2>/dev/null"
+    assert_success
+    run jq -r '.steps[0].metadata.effect' <<<"$output"
+    assert_success
+    # The plan is conservative: check_diff can fail to apply and fall back to
+    # the write-effect fixer even though this successful run did not.
+    assert_output "write"
+}


### PR DESCRIPTION
## Summary

- add a backward-compatible `CommandSpec` for shell, OS-specific, and argv commands with `read`, `write`, or `destructive` effects
- add `--safe` preflight validation that rejects unknown and destructive commands before any step starts
- include declared effects in execution plans and structured run results
- preserve legacy commands as conservatively unknown and keep safety metadata coupled to the command value

## Stack

Depends on #1163 (`feat(run): add structured execution results`). This is layer 3 of the agent-native hk stack.

## Test evidence

- `cargo fmt --check`
- `cargo check`
- `cargo test cli::tests::test_subcommands_are_sorted`
- `mise run build`
- `mise run test:bats test/command_effects.bats`
- `mise run render`

## Rollout notes

Existing configurations continue to work without changes. Legacy commands have an unknown effect and therefore require an explicit `CommandSpec` only when `--safe` is requested. Read and write effects are permitted in safe mode; destructive and unknown effects are rejected as one all-or-nothing preflight.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes command execution preflight and hook config typing; mis-declared effects or overly strict safe mode could block legitimate hooks, but legacy configs behave unchanged unless --safe is used.
> 
> **Overview**
> Adds **declared command effects** and a **`--safe`** preflight so runs can refuse risky hooks before any step executes.
> 
> Hook steps can wrap shell, script, or argv commands in **`CommandSpec`** with `read`, `write`, or `destructive` effects (Pkl `CommandEffect` / `CommandSpec`). Plain string and legacy command forms still work but count as **unknown** effect. **`--safe`** on check/fix/run (and hook subcommands) runs **`validate_safe_commands`** before planning or execution: it allows read/write, blocks destructive and unknown effects, respects skipped steps and platform-only scripts, and considers check-first fallbacks conservatively.
> 
> **Plans** expose a conservative `metadata.effect` per step; **JSON run output** adds per-step `effects` for commands that actually started. Runtime recording ties effects to the command field (`check`, `fix`, etc.) after a child process is spawned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6524b58017cb8a8deee6c3bb0328a422ec87e6cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->