### PR TITLE
feat(builtins): classify command effects

### DIFF
--- a/pkl/builtins/actionlint.pkl
+++ b/pkl/builtins/actionlint.pkl
@@ -12,7 +12,10 @@ import "./test/helpers.pkl"
 const actionlint = new Config.Step {
   glob = List(".github/workflows/*.yml", ".github/workflows/*.yaml")
   batch = true
-  check = new Config.Command { argv = List("actionlint", "{{files}}") }
+  check = new Config.CommandSpec {
+    command = new Config.Command { argv = List("actionlint", "{{files}}") }
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = ".github/workflows/test.yml"

--- a/pkl/builtins/alejandra.pkl
+++ b/pkl/builtins/alejandra.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 alejandra = new Config.Step {
   glob = "**/*.nix"
-  check = "alejandra --check {{ files }}"
-  fix = "alejandra {{ files }}"
+  check = new Config.CommandSpec {
+    command = "alejandra --check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "alejandra {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/aqua_update_checksum.pkl
+++ b/pkl/builtins/aqua_update_checksum.pkl
@@ -19,7 +19,10 @@ const aqua_update_checksum = new Config.Step {
       "aqua-checksums.json",
       "{aqua,.aqua}/aqua-checksums.json",
     )
-  fix = "aqua update-checksum --prune"
+  fix = new Config.CommandSpec {
+    command = "aqua update-checksum --prune"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "aqua-checksums.json"

--- a/pkl/builtins/asciidoctor.pkl
+++ b/pkl/builtins/asciidoctor.pkl
@@ -10,7 +10,10 @@ const asciidoctor = new Config.Step {
   types = List("asciidoc")
   // The `failure-level` option ensures non-zero exit code when warnings occur
   // The `out-file=/dev/null` option prevents HTML file generation
-  check = "asciidoctor --failure-level=WARNING --out-file=/dev/null {{ files }}"
+  check = new Config.CommandSpec {
+    command = "asciidoctor --failure-level=WARNING --out-file=/dev/null {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.adoc"

--- a/pkl/builtins/astro.pkl
+++ b/pkl/builtins/astro.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 astro = new Config.Step {
   glob = "**/*.astro"
-  check = "astro check {{ files }}"
+  check = new Config.CommandSpec {
+    command = "astro check {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/betterleaks.pkl
+++ b/pkl/builtins/betterleaks.pkl
@@ -13,7 +13,10 @@ import "./test/helpers.pkl"
 betterleaks = new Config.Step {
   types = List("text")
   // Reference: https://github.com/betterleaks/betterleaks/blob/v1.5.0/.pre-commit-hooks.yaml#L4
-  check = "betterleaks dir --redact --verbose --no-banner {{ files }}"
+  check = new Config.CommandSpec {
+    command = "betterleaks dir --redact --verbose --no-banner {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "foo.txt" }
     // aws-access-token alone is not reported since betterleaks 1.2.0 (composite rule); use github-pat instead.

--- a/pkl/builtins/biome.pkl
+++ b/pkl/builtins/biome.pkl
@@ -12,11 +12,17 @@ import "./test/helpers.pkl"
 }
 biome = new Config.Step {
   glob = List("**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.json")
-  check = new Config.Command {
-    argv = List("biome", "check", "--no-errors-on-unmatched", "{{files}}")
+  check = new Config.CommandSpec {
+    command = new Config.Command {
+      argv = List("biome", "check", "--no-errors-on-unmatched", "{{files}}")
+    }
+    effect = "write"
   }
-  fix = new Config.Command {
-    argv = List("biome", "check", "--write", "--no-errors-on-unmatched", "{{files}}")
+  fix = new Config.CommandSpec {
+    command = new Config.Command {
+      argv = List("biome", "check", "--write", "--no-errors-on-unmatched", "{{files}}")
+    }
+    effect = "write"
   }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.ts" }

--- a/pkl/builtins/black.pkl
+++ b/pkl/builtins/black.pkl
@@ -11,8 +11,14 @@ import "./test/helpers.pkl"
 }
 black = new Config.Step {
   glob = List("**/*.py")
-  check_diff = "black --check --diff {{ files }}"
-  fix = "black {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "black --check --diff {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "black {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.py" }
     local const before = "x=1"

--- a/pkl/builtins/brakeman.pkl
+++ b/pkl/builtins/brakeman.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 brakeman = new Config.Step {
   types = List("ruby")
-  check = "brakeman -q -w2 {{ files }}"
+  check = new Config.CommandSpec {
+    command = "brakeman -q -w2 {{ files }}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/buf_format.pkl
+++ b/pkl/builtins/buf_format.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 buf_format = new Config.Step {
   glob = "**/*.proto"
-  check_diff = "buf format {{workspace}} --diff --exit-code"
-  fix = "buf format {{workspace}} --write"
+  check_diff = new Config.CommandSpec {
+    command = "buf format {{workspace}} --diff --exit-code"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "buf format {{workspace}} --write"
+    effect = "write"
+  }
   workspace_indicator = "buf.yaml"
   tests {
     local const testMaker = new helpers.TestMaker {

--- a/pkl/builtins/buf_lint.pkl
+++ b/pkl/builtins/buf_lint.pkl
@@ -8,7 +8,10 @@ import "./test/helpers.pkl"
 }
 buf_lint = new Config.Step {
   glob = "**/*.proto"
-  check = "buf lint {{workspace}}"
+  check = new Config.CommandSpec {
+    command = "buf lint {{workspace}}"
+    effect = "read"
+  }
   workspace_indicator = "buf.yaml"
   tests {
     local const testMaker = new helpers.TestMaker {

--- a/pkl/builtins/buildifier_format.pkl
+++ b/pkl/builtins/buildifier_format.pkl
@@ -24,8 +24,14 @@ buildifier_format = new Config.Step {
       "**/*.star",
       "**/*.sky",
     )
-  check = "buildifier -mode=check {{ files }}"
-  fix = "buildifier {{ files }}"
+  check = new Config.CommandSpec {
+    command = "buildifier -mode=check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "buildifier {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "BUILD.bazel" }
     local const before =

--- a/pkl/builtins/buildifier_lint.pkl
+++ b/pkl/builtins/buildifier_lint.pkl
@@ -24,8 +24,14 @@ buildifier_lint = new Config.Step {
       "**/*.star",
       "**/*.sky",
     )
-  check = "buildifier -mode=check -lint=warn {{ files }}"
-  fix = "buildifier -lint=fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "buildifier -mode=check -lint=warn {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "buildifier -lint=fix {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "BUILD.bazel" }
     local const before =

--- a/pkl/builtins/bundle_audit.pkl
+++ b/pkl/builtins/bundle_audit.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 bundle_audit = new Config.Step {
   glob = "**/Gemfile.lock"
-  check = "bundle-audit check {{ files }}"
-  fix = "bundle-audit update"
+  check = new Config.CommandSpec {
+    command = "bundle-audit check {{ files }}"
+    effect = "write"
+  }
+  fix = new Config.CommandSpec {
+    command = "bundle-audit update"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/byte_order_marker.pkl
+++ b/pkl/builtins/byte_order_marker.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 byte_order_marker = new Config.Step {
   types = List("text")
-  check_diff = "hk util check-byte-order-marker --diff {{files}}"
-  fix = "hk util fix-byte-order-marker {{files}}"
+  check_diff = new Config.CommandSpec {
+    command = "hk util check-byte-order-marker --diff {{files}}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "hk util fix-byte-order-marker {{files}}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.txt" }
     ["detects BOM"] = testMaker.checkFail("\u{FEFF}Hello, world!", 1)

--- a/pkl/builtins/cargo_check.pkl
+++ b/pkl/builtins/cargo_check.pkl
@@ -10,8 +10,14 @@ cargo_check = new Config.Step {
   glob = "**/*.rs"
   // NB: We need nightly to enable `warnings` unstable feature: https://doc.rust-lang.org/cargo/reference/unstable.html#warnings
   // (See the comment for `CARGO_BUILD_WARNINGS` below)
-  check = "cargo +nightly check -Zwarnings --quiet"
-  fix = "cargo fix --allow-dirty --allow-staged --quiet"
+  check = new Config.CommandSpec {
+    command = "cargo +nightly check -Zwarnings --quiet"
+    effect = "write"
+  }
+  fix = new Config.CommandSpec {
+    command = "cargo fix --allow-dirty --allow-staged --quiet"
+    effect = "write"
+  }
   env {
     ["CARGO_TERM_COLOR"] = "{% if color %}always{% else %}never{% endif %}"
     // NB: This is needed to treat warnings as errors.

--- a/pkl/builtins/cargo_clippy.pkl
+++ b/pkl/builtins/cargo_clippy.pkl
@@ -11,9 +11,15 @@ import "../Config.pkl"
 cargo_clippy = new Config.Step {
   glob = "**/*.rs"
   workspace_indicator = "Cargo.toml"
-  check = "cargo clippy --manifest-path {{workspace_indicator}} --quiet"
-  fix =
-    "cargo clippy --manifest-path {{workspace_indicator}} --fix --allow-dirty --allow-staged --quiet"
+  check = new Config.CommandSpec {
+    command = "cargo clippy --manifest-path {{workspace_indicator}} --quiet"
+    effect = "write"
+  }
+  fix = new Config.CommandSpec {
+    command =
+      "cargo clippy --manifest-path {{workspace_indicator}} --fix --allow-dirty --allow-staged --quiet"
+    effect = "write"
+  }
   check_first = false
   env {
     ["CARGO_TERM_PROGRESS_WHEN"] = "never"

--- a/pkl/builtins/cargo_deny.pkl
+++ b/pkl/builtins/cargo_deny.pkl
@@ -25,7 +25,10 @@ cargo_deny = new Config.Step {
       "**/.deny.exceptions.toml",
     )
   workspace_indicator = "Cargo.toml"
-  check = "cd {{workspace}} && cargo-deny --locked --workspace check"
+  check = new Config.CommandSpec {
+    command = "cd {{workspace}} && cargo-deny --locked --workspace check"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "deny.toml"

--- a/pkl/builtins/cargo_fmt.pkl
+++ b/pkl/builtins/cargo_fmt.pkl
@@ -12,10 +12,18 @@ import "./test/helpers.pkl"
 cargo_fmt = new Config.Step {
   glob = "**/*.rs"
   workspace_indicator = "Cargo.toml"
-  check = "cargo fmt --check --manifest-path {{workspace_indicator}}"
-  check_list_files =
-    "cargo fmt --check --manifest-path {{workspace_indicator}} -- --files-with-diff"
-  fix = "cargo fmt --manifest-path {{workspace_indicator}}"
+  check = new Config.CommandSpec {
+    command = "cargo fmt --check --manifest-path {{workspace_indicator}}"
+    effect = "read"
+  }
+  check_list_files = new Config.CommandSpec {
+    command = "cargo fmt --check --manifest-path {{workspace_indicator}} -- --files-with-diff"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "cargo fmt --manifest-path {{workspace_indicator}}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "src/main.rs"

--- a/pkl/builtins/check_added_large_files.pkl
+++ b/pkl/builtins/check_added_large_files.pkl
@@ -7,7 +7,10 @@ import "../Config.pkl"
 }
 check_added_large_files = new Config.Step {
   glob = "**/*"
-  check = "hk util check-added-large-files {{files}}"
+  check = new Config.CommandSpec {
+    command = "hk util check-added-large-files {{files}}"
+    effect = "read"
+  }
   tests {
     ["detects large file with default 500KB limit"] {
       run = "check"

--- a/pkl/builtins/check_case_conflict.pkl
+++ b/pkl/builtins/check_case_conflict.pkl
@@ -7,7 +7,10 @@ import "../Config.pkl"
 }
 check_case_conflict = new Config.Step {
   glob = "**/*"
-  check = "hk util check-case-conflict {{files}}"
+  check = new Config.CommandSpec {
+    command = "hk util check-case-conflict {{files}}"
+    effect = "read"
+  }
   tests {
     ["detects case conflicts"] {
       run = "check"

--- a/pkl/builtins/check_conventional_commit.pkl
+++ b/pkl/builtins/check_conventional_commit.pkl
@@ -6,5 +6,8 @@ import "../Config.pkl"
   description = "Verify commit message matches conventional commits formatting"
 }
 check_conventional_commit = new Config.Step {
-  check = "hk util check-conventional-commit {{commit_msg_file}}"
+  check = new Config.CommandSpec {
+    command = "hk util check-conventional-commit {{commit_msg_file}}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/check_executables_have_shebangs.pkl
+++ b/pkl/builtins/check_executables_have_shebangs.pkl
@@ -7,7 +7,10 @@ import "../Config.pkl"
 }
 check_executables_have_shebangs = new Config.Step {
   types = List("text")
-  check = "hk util check-executables-have-shebangs {{files}}"
+  check = new Config.CommandSpec {
+    command = "hk util check-executables-have-shebangs {{files}}"
+    effect = "read"
+  }
   tests {
     ["detects executable without shebang"] {
       run = "check"

--- a/pkl/builtins/check_merge_conflict.pkl
+++ b/pkl/builtins/check_merge_conflict.pkl
@@ -8,7 +8,10 @@ import "./test/helpers.pkl"
 }
 check_merge_conflict = new Config.Step {
   types = List("text")
-  check = "hk util check-merge-conflict --assume-in-merge {{files}}"
+  check = new Config.CommandSpec {
+    command = "hk util check-merge-conflict --assume-in-merge {{files}}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {}
     ["check bad file"] = testMaker.checkFail("<<<<<<< HEAD\nconflict\n", 1)

--- a/pkl/builtins/check_symlinks.pkl
+++ b/pkl/builtins/check_symlinks.pkl
@@ -8,7 +8,10 @@ import "../Config.pkl"
 check_symlinks = new Config.Step {
   glob = "**/*"
   allow_symlinks = true
-  check = "hk util check-symlinks {{files}}"
+  check = new Config.CommandSpec {
+    command = "hk util check-symlinks {{files}}"
+    effect = "read"
+  }
   tests {
     ["detects broken symlink"] {
       run = "check"

--- a/pkl/builtins/clang_format.pkl
+++ b/pkl/builtins/clang_format.pkl
@@ -8,6 +8,12 @@ import "../Config.pkl"
 clang_format = new Config.Step {
   glob =
     List("**/*.c", "**/*.h", "**/*.cpp", "**/*.hpp", "**/*.cc", "**/*.hh", "**/*.cxx", "**/*.hxx")
-  check = "clang-format --dry-run -Werror {{ files }}"
-  fix = "clang-format -i {{ files }}"
+  check = new Config.CommandSpec {
+    command = "clang-format --dry-run -Werror {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "clang-format -i {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/cmake_format.pkl
+++ b/pkl/builtins/cmake_format.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 cmake_format = new Config.Step {
   glob = List("**/CMakeLists.txt", "**/*.cmake")
-  check = "cmake-format --check {{ files }}"
-  fix = "cmake-format --in-place {{ files }}"
+  check = new Config.CommandSpec {
+    command = "cmake-format --check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "cmake-format --in-place {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/cocogitto_commit_msg.pkl
+++ b/pkl/builtins/cocogitto_commit_msg.pkl
@@ -10,5 +10,8 @@ import "../Config.pkl"
 }
 cocogitto_commit_msg = new Config.Step {
   // Reference: https://github.com/cocogitto/cocogitto/blob/7.0.0/cog.toml#L62-L63
-  check = "cog --quiet verify --file {{commit_msg_file}}"
+  check = new Config.CommandSpec {
+    command = "cog --quiet verify --file {{commit_msg_file}}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/contextlint.pkl
+++ b/pkl/builtins/contextlint.pkl
@@ -12,7 +12,10 @@ import "./test/helpers.pkl"
 contextlint = new Config.Step {
   workspace_indicator = "contextlint.config.json"
   types = List("markdown")
-  check = "contextlint {{ files }}"
+  check = new Config.CommandSpec {
+    command = "contextlint {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "foo.md"

--- a/pkl/builtins/cpp_lint.pkl
+++ b/pkl/builtins/cpp_lint.pkl
@@ -8,5 +8,8 @@ import "../Config.pkl"
 cpp_lint = new Config.Step {
   glob =
     List("**/*.c", "**/*.h", "**/*.cpp", "**/*.hpp", "**/*.cc", "**/*.hh", "**/*.cxx", "**/*.hxx")
-  check = "cpplint {{ files }}"
+  check = new Config.CommandSpec {
+    command = "cpplint {{ files }}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/dclint.pkl
+++ b/pkl/builtins/dclint.pkl
@@ -21,8 +21,14 @@ dclint = new Config.Step {
       "**/docker-compose*.yaml",
     )
   batch = true
-  check = "dclint {{files}}"
-  fix = "dclint --fix {{files}}"
+  check = new Config.CommandSpec {
+    command = "dclint {{files}}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "dclint --fix {{files}}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "docker-compose.yml"

--- a/pkl/builtins/deadnix.pkl
+++ b/pkl/builtins/deadnix.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 deadnix = new Config.Step {
   glob = "**/*.nix"
-  check = "deadnix --fail {{ files }}"
-  fix = "deadnix --edit {{ files }}"
+  check = new Config.CommandSpec {
+    command = "deadnix --fail {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "deadnix --edit {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/deno.pkl
+++ b/pkl/builtins/deno.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 deno = new Config.Step {
   glob = List("**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx")
-  check = "deno fmt --check {{ files }}"
-  fix = "deno fmt {{ files }}"
+  check = new Config.CommandSpec {
+    command = "deno fmt --check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "deno fmt {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/deno_check.pkl
+++ b/pkl/builtins/deno_check.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 deno_check = new Config.Step {
   glob = List("**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx")
-  check = "deno check {{ files }}"
+  check = new Config.CommandSpec {
+    command = "deno check {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/detect_private_key.pkl
+++ b/pkl/builtins/detect_private_key.pkl
@@ -8,7 +8,10 @@ import "./test/helpers.pkl"
 }
 detect_private_key = new Config.Step {
   types = List("text")
-  check = "hk util detect-private-key {{files}}"
+  check = new Config.CommandSpec {
+    command = "hk util detect-private-key {{files}}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {}
     ["check RSA private key"] =

--- a/pkl/builtins/dprint.pkl
+++ b/pkl/builtins/dprint.pkl
@@ -7,7 +7,16 @@ import "../Config.pkl"
 }
 dprint = new Config.Step {
   types = List("text")
-  check = "dprint check --allow-no-files {{ files }}"
-  check_list_files = "dprint check --allow-no-files --list-different {{ files }}"
-  fix = "dprint fmt --allow-no-files {{ files }}"
+  check = new Config.CommandSpec {
+    command = "dprint check --allow-no-files {{ files }}"
+    effect = "read"
+  }
+  check_list_files = new Config.CommandSpec {
+    command = "dprint check --allow-no-files --list-different {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "dprint fmt --allow-no-files {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/editorconfig-checker.pkl
+++ b/pkl/builtins/editorconfig-checker.pkl
@@ -8,7 +8,10 @@ import "./test/helpers.pkl"
 }
 editorconfig_checker = new Config.Step {
   types = List("text")
-  check = "ec {{ files }}"
+  check = new Config.CommandSpec {
+    command = "ec {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.txt"

--- a/pkl/builtins/erb.pkl
+++ b/pkl/builtins/erb.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 erb = new Config.Step {
   glob = "**/*.erb"
-  check = "erb -P -x -T - {{ files }} | ruby -c"
+  check = new Config.CommandSpec {
+    command = "erb -P -x -T - {{ files }} | ruby -c"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/err_check.pkl
+++ b/pkl/builtins/err_check.pkl
@@ -8,5 +8,8 @@ import "../Config.pkl"
 err_check = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
-  check = "cd {{workspace}} && errcheck ./..."
+  check = new Config.CommandSpec {
+    command = "cd {{workspace}} && errcheck ./..."
+    effect = "read"
+  }
 }

--- a/pkl/builtins/err_check.pkl
+++ b/pkl/builtins/err_check.pkl
@@ -10,6 +10,6 @@ err_check = new Config.Step {
   workspace_indicator = "go.mod"
   check = new Config.CommandSpec {
     command = "cd {{workspace}} && errcheck ./..."
-    effect = "read"
+    effect = "write"
   }
 }

--- a/pkl/builtins/eslint.pkl
+++ b/pkl/builtins/eslint.pkl
@@ -11,6 +11,12 @@ import "../Config.pkl"
 eslint = new Config.Step {
   glob = List("**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx")
   batch = true
-  check = "eslint {{ files }}"
-  fix = "eslint --fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "eslint {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "eslint --fix {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/fasterer.pkl
+++ b/pkl/builtins/fasterer.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 fasterer = new Config.Step {
   types = List("ruby")
-  check = "fasterer {{ files }}"
+  check = new Config.CommandSpec {
+    command = "fasterer {{ files }}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/fix_smart_quotes.pkl
+++ b/pkl/builtins/fix_smart_quotes.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 fix_smart_quotes = new Config.Step {
   types = List("text")
-  check_diff = "hk util fix-smart-quotes --diff {{files}}"
-  fix = "hk util fix-smart-quotes {{files}}"
+  check_diff = new Config.CommandSpec {
+    command = "hk util fix-smart-quotes --diff {{files}}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "hk util fix-smart-quotes {{files}}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {}
     ["check file with smart quotes"] = testMaker.checkFail("\u{FF02}Hello, world!\u{FF02}", 1)

--- a/pkl/builtins/flake8.pkl
+++ b/pkl/builtins/flake8.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 flake8 = new Config.Step {
   glob = "**/*.py"
-  check = "flake8 {{ files }}"
+  check = new Config.CommandSpec {
+    command = "flake8 {{ files }}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/ghalint_action.pkl
+++ b/pkl/builtins/ghalint_action.pkl
@@ -9,7 +9,10 @@ import "./test/helpers.pkl"
 const ghalint_action = new Config.Step {
   glob = List("**/action.*")
   types = List("yaml")
-  check = "ghalint run-action {{ files }}"
+  check = new Config.CommandSpec {
+    command = "ghalint run-action {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "action.yml"

--- a/pkl/builtins/ghalint_workflow.pkl
+++ b/pkl/builtins/ghalint_workflow.pkl
@@ -9,7 +9,10 @@ import "./test/helpers.pkl"
 const ghalint_workflow = new Config.Step {
   glob = List(".github/workflows/*")
   types = List("yaml")
-  check = "ghalint run"
+  check = new Config.CommandSpec {
+    command = "ghalint run"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = ".github/workflows/test.yml"

--- a/pkl/builtins/gitleaks.pkl
+++ b/pkl/builtins/gitleaks.pkl
@@ -12,7 +12,10 @@ import "./test/helpers.pkl"
 gitleaks = new Config.Step {
   types = List("text")
   // Reference: https://github.com/gitleaks/gitleaks/blob/v8.30.1/.pre-commit-hooks.yaml#L4
-  check = "gitleaks dir --redact --verbose --no-banner {{ files }}"
+  check = new Config.CommandSpec {
+    command = "gitleaks dir --redact --verbose --no-banner {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "foo.txt" }
     // Reference: https://github.com/gitleaks/gitleaks/blob/v8.30.1/testdata/repos/nogit/api.go#L20

--- a/pkl/builtins/go_fmt.pkl
+++ b/pkl/builtins/go_fmt.pkl
@@ -11,23 +11,32 @@ import "./test/helpers.pkl"
 }
 go_fmt = new Config.Step {
   glob = "**/*.go"
-  check_list_files =
-    """
-    FILES=$(gofmt -s -l {{files}})
-    if [ -n "$FILES" ]; then
+  check_list_files = new Config.CommandSpec {
+    command =
+      """
+      FILES=$(gofmt -s -l {{files}})
+      if [ -n "$FILES" ]; then
       echo "$FILES"
       exit 1
-    fi
-    """
-  check_diff =
-    """
-    DIFF=$(gofmt -s -d {{files}})
-    if [ -n "$DIFF" ]; then
+      fi
+      """
+    effect = "read"
+  }
+  check_diff = new Config.CommandSpec {
+    command =
+      """
+      DIFF=$(gofmt -s -d {{files}})
+      if [ -n "$DIFF" ]; then
       echo "$DIFF"
       exit 1
-    fi
-    """
-  fix = "gofmt -s -w {{files}}"
+      fi
+      """
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "gofmt -s -w {{files}}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.go" }
     local const before = "package name"

--- a/pkl/builtins/go_fumpt.pkl
+++ b/pkl/builtins/go_fumpt.pkl
@@ -10,5 +10,8 @@ go_fumpt = new Config.Step {
   // check = "gofumpt -l {{ files }}" // broken, gofumpt always exits with 0
   // check_list_files = "gofumpt -l {{ files }}" // broken, gofumpt always exits with 0
   // check_diff = "gofumpt -d {{ files }}" // won't work until #640 is merged
-  fix = "gofumpt -w {{ files }}"
+  fix = new Config.CommandSpec {
+    command = "gofumpt -w {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/go_imports.pkl
+++ b/pkl/builtins/go_imports.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 go_imports = new Config.Step {
   glob = "**/*.go"
-  check = "goimports -l {{ files }}"
-  fix = "goimports -w {{ files }}"
+  check = new Config.CommandSpec {
+    command = "goimports -l {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "goimports -w {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/go_lines.pkl
+++ b/pkl/builtins/go_lines.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 go_lines = new Config.Step {
   glob = "**/*.go"
-  check = "golines --dry-run {{ files }}"
-  fix = "golines -w {{ files }}"
+  check = new Config.CommandSpec {
+    command = "golines --dry-run {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "golines -w {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/go_sec.pkl
+++ b/pkl/builtins/go_sec.pkl
@@ -8,5 +8,8 @@ import "../Config.pkl"
 go_sec = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
-  check = "cd {{workspace}} && gosec ./..."
+  check = new Config.CommandSpec {
+    command = "cd {{workspace}} && gosec ./..."
+    effect = "write"
+  }
 }

--- a/pkl/builtins/go_vet.pkl
+++ b/pkl/builtins/go_vet.pkl
@@ -8,7 +8,10 @@ import "../Config.pkl"
 go_vet = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
-  check = "cd {{workspace}} && go vet ./..."
+  check = new Config.CommandSpec {
+    command = "cd {{workspace}} && go vet ./..."
+    effect = "write"
+  }
   tests {
     ["check good file"] {
       run = "check"

--- a/pkl/builtins/go_vuln_check.pkl
+++ b/pkl/builtins/go_vuln_check.pkl
@@ -8,5 +8,8 @@ import "../Config.pkl"
 go_vuln_check = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
-  check = "cd {{workspace}} && govulncheck ./..."
+  check = new Config.CommandSpec {
+    command = "cd {{workspace}} && govulncheck ./..."
+    effect = "write"
+  }
 }

--- a/pkl/builtins/golangci_lint.pkl
+++ b/pkl/builtins/golangci_lint.pkl
@@ -11,6 +11,12 @@ import "../Config.pkl"
 golangci_lint = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
-  check = "cd {{workspace}} && golangci-lint run --fix=false ./..."
-  fix = "cd {{workspace}} && golangci-lint run --fix ./..."
+  check = new Config.CommandSpec {
+    command = "cd {{workspace}} && golangci-lint run --fix=false ./..."
+    effect = "write"
+  }
+  fix = new Config.CommandSpec {
+    command = "cd {{workspace}} && golangci-lint run --fix ./..."
+    effect = "write"
+  }
 }

--- a/pkl/builtins/gomod_tidy.pkl
+++ b/pkl/builtins/gomod_tidy.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 gomod_tidy = new Config.Step {
   glob = "**/go.mod"
-  check_diff = "go mod tidy -diff"
-  fix = "go mod tidy"
+  check_diff = new Config.CommandSpec {
+    command = "go mod tidy -diff"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "go mod tidy"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/google_java_format.pkl
+++ b/pkl/builtins/google_java_format.pkl
@@ -11,9 +11,18 @@ import "./test/helpers.pkl"
 }
 google_java_format = new Config.Step {
   glob = "**/*.java"
-  check = "google-java-format --dry-run --set-exit-if-changed {{ files }}"
-  check_list_files = "google-java-format --dry-run {{ files }}"
-  fix = "google-java-format --replace {{ files }}"
+  check = new Config.CommandSpec {
+    command = "google-java-format --dry-run --set-exit-if-changed {{ files }}"
+    effect = "read"
+  }
+  check_list_files = new Config.CommandSpec {
+    command = "google-java-format --dry-run {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "google-java-format --replace {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "Test.java"

--- a/pkl/builtins/hadolint.pkl
+++ b/pkl/builtins/hadolint.pkl
@@ -11,7 +11,10 @@ import "./test/helpers.pkl"
 }
 hadolint = new Config.Step {
   glob = "**/Dockerfile*"
-  check = "hadolint {{ files }}"
+  check = new Config.CommandSpec {
+    command = "hadolint {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "Dockerfile" }
     ["check bad file"] = testMaker.checkFail("FROM debian\n", 1)

--- a/pkl/builtins/harper.pkl
+++ b/pkl/builtins/harper.pkl
@@ -8,7 +8,10 @@ import "./test/helpers.pkl"
 }
 harper = new Config.Step {
   types = List("text")
-  check = "harper-cli lint {{ files }}"
+  check = new Config.CommandSpec {
+    command = "harper-cli lint {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "foo.md"

--- a/pkl/builtins/harper_commit_message.pkl
+++ b/pkl/builtins/harper_commit_message.pkl
@@ -6,5 +6,8 @@ import "../Config.pkl"
   description = "Grammar checker for commit message"
 }
 harper_commit_message = new Config.Step {
-  check = "harper-cli lint {{commit_msg_file}}"
+  check = new Config.CommandSpec {
+    command = "harper-cli lint {{commit_msg_file}}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/hclfmt.pkl
+++ b/pkl/builtins/hclfmt.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 hclfmt = new Config.Step {
   glob = "**/*.hcl"
-  fix = "hclfmt -w {{ files }}"
+  fix = new Config.CommandSpec {
+    command = "hclfmt -w {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/hk_test.pkl
+++ b/pkl/builtins/hk_test.pkl
@@ -8,7 +8,10 @@ import "../Config.pkl"
 hk_test = new Config.Step {
   // See: src/config.rs `project_config_search_paths()`
   glob = List("hk.pkl", ".config/hk.pkl")
-  check = "hk test --quiet"
+  check = new Config.CommandSpec {
+    command = "hk test --quiet"
+    effect = "write"
+  }
   // No tests here. They would duplicate the existing `hk test` tests.
   // See: test/hk_test_*.bats
 }

--- a/pkl/builtins/isort.pkl
+++ b/pkl/builtins/isort.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 isort = new Config.Step {
   glob = "**/*.py"
-  check = "isort --check-only {{ files }}"
-  fix = "isort {{ files }}"
+  check = new Config.CommandSpec {
+    command = "isort --check-only {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "isort {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.py" }
     local const before = "import base64\nimport ast\n"

--- a/pkl/builtins/jq.pkl
+++ b/pkl/builtins/jq.pkl
@@ -8,20 +8,26 @@ import "./test/helpers.pkl"
 }
 jq = new Config.Step {
   glob = "**/*.json"
-  check_diff =
-    """
+  check_diff = new Config.CommandSpec {
+    command =
+      """
       failed=0
       for f in {{ files }}; do
-        jq . "$f" | diff -u "$f" - || failed=1
+      jq . "$f" | diff -u "$f" - || failed=1
       done
       exit $failed
-    """
-  fix =
-    """
+      """
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command =
+      """
       for f in {{ files }}; do
-        tmp=$(mktemp) && jq -S . "$f" > "$tmp" && mv "$tmp" "$f"
+      tmp=$(mktemp) && jq -S . "$f" > "$tmp" && mv "$tmp" "$f"
       done
-    """
+      """
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.json"

--- a/pkl/builtins/just_format.pkl
+++ b/pkl/builtins/just_format.pkl
@@ -9,5 +9,8 @@ just_format = new Config.Step {
   glob = List("**/justfile", "**/*.just")
   stdin = "{{ files_list | join(sep='\n') }}"
   // use xargs because `just --fmt` accepts only one file
-  fix = "xargs -d'\n' -I {} -- just --fmt --unstable --justfile {}"
+  fix = new Config.CommandSpec {
+    command = "xargs -d'\n' -I {} -- just --fmt --unstable --justfile {}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/kingfisher.pkl
+++ b/pkl/builtins/kingfisher.pkl
@@ -12,7 +12,10 @@ import "./test/helpers.pkl"
 kingfisher = new Config.Step {
   types = List("text")
   // Reference: https://github.com/mongodb/kingfisher/blob/v1.109.0/.pre-commit-hooks.yaml
-  check = "kingfisher scan {{ files }} --no-update-check --no-validate --quiet"
+  check = new Config.CommandSpec {
+    command = "kingfisher scan {{ files }} --no-update-check --no-validate --quiet"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "foo.txt" }
     // Findings exit with code 200 (205 when validation is enabled and a secret is live).

--- a/pkl/builtins/knip.pkl
+++ b/pkl/builtins/knip.pkl
@@ -13,8 +13,14 @@ knip = new Config.Step {
   workspace_indicator = "package.json"
   // https://knip.dev/explanations/entry-files
   types = List("javascript", "typescript")
-  check = "knip --no-progress --directory {{workspace}}"
-  fix = "knip --fix --no-progress --directory {{workspace}}"
+  check = new Config.CommandSpec {
+    command = "knip --no-progress --directory {{workspace}}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "knip --fix --no-progress --directory {{workspace}}"
+    effect = "write"
+  }
   tests {
     local const bad =
       """

--- a/pkl/builtins/knip_strict.pkl
+++ b/pkl/builtins/knip_strict.pkl
@@ -15,8 +15,14 @@ knip_strict = new Config.Step {
   types = List("javascript", "typescript")
   // Using `--strict` implies `--production`
   // https://knip.dev/features/production-mode#strict-mode
-  check = "knip --strict --no-progress --directory {{workspace}}"
-  fix = "knip --fix --strict --no-progress --directory {{workspace}}"
+  check = new Config.CommandSpec {
+    command = "knip --strict --no-progress --directory {{workspace}}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "knip --fix --strict --no-progress --directory {{workspace}}"
+    effect = "write"
+  }
   tests {
     local const bad =
       """

--- a/pkl/builtins/ktlint.pkl
+++ b/pkl/builtins/ktlint.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 ktlint = new Config.Step {
   glob = "**/*.kt"
-  check = "ktlint {{ files }}"
-  fix = "ktlint -F {{ files }}"
+  check = new Config.CommandSpec {
+    command = "ktlint {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "ktlint -F {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "Test.kt" }
     ["check bad file"] = testMaker.checkFail("const val FOO_1  =  \"foo1\"", 1)

--- a/pkl/builtins/luacheck.pkl
+++ b/pkl/builtins/luacheck.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 luacheck = new Config.Step {
   types = List("lua")
-  check = "luacheck {{ files }}"
+  check = new Config.CommandSpec {
+    command = "luacheck {{ files }}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/lychee.pkl
+++ b/pkl/builtins/lychee.pkl
@@ -8,5 +8,8 @@ import "../Config.pkl"
 lychee = new Config.Step {
   // https://github.com/lycheeverse/lychee/blob/db0f8a842f594e0a879563caf7d183266c02ca95/.pre-commit-hooks.yaml#L7
   types = List("text")
-  check = "lychee --no-progress {{ files }}"
+  check = new Config.CommandSpec {
+    command = "lychee --no-progress {{ files }}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/markdown_lint.pkl
+++ b/pkl/builtins/markdown_lint.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 markdown_lint = new Config.Step {
   glob = List("**/*.md", "**/*.markdown")
-  check = "markdownlint {{ files }}"
-  fix = "markdownlint --fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "markdownlint {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "markdownlint --fix {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.md" }
     local const before = "# Title\ncontent."

--- a/pkl/builtins/mdschema.pkl
+++ b/pkl/builtins/mdschema.pkl
@@ -12,7 +12,10 @@ import "./test/helpers.pkl"
 mdschema = new Config.Step {
   workspace_indicator = ".mdschema.yml"
   types = List("markdown")
-  check = "mdschema check {{ files }}"
+  check = new Config.CommandSpec {
+    command = "mdschema check {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "foo.md"

--- a/pkl/builtins/mise.pkl
+++ b/pkl/builtins/mise.pkl
@@ -27,8 +27,14 @@ mise = new Config.Step {
     )
   // `mise fmt` processes all configuration files itself and accepts no file arguments.
   batch = false
-  check = "mise fmt --check"
-  fix = "mise fmt"
+  check = new Config.CommandSpec {
+    command = "mise fmt --check"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "mise fmt"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "mise.toml" }
     ["check bad file"] = testMaker.checkFail("x  =  1", 1)

--- a/pkl/builtins/mix_compile.pkl
+++ b/pkl/builtins/mix_compile.pkl
@@ -8,5 +8,8 @@ import "../Config.pkl"
 mix_compile = new Config.Step {
   glob = "**/*.ex"
   exclude = List("deps/**/*")
-  check = "mix compile --warnings-as-errors --strict-errors {{files}}"
+  check = new Config.CommandSpec {
+    command = "mix compile --warnings-as-errors --strict-errors {{files}}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/mix_fmt.pkl
+++ b/pkl/builtins/mix_fmt.pkl
@@ -8,6 +8,12 @@ import "../Config.pkl"
 mix_fmt = new Config.Step {
   glob = List("**/*.ex", "**/*.exs")
   exclude = List("deps/**/*")
-  check = "mix format --check-formatted {{files}}"
-  fix = "mix format {{files}}"
+  check = new Config.CommandSpec {
+    command = "mix format --check-formatted {{files}}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "mix format {{files}}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/mix_test.pkl
+++ b/pkl/builtins/mix_test.pkl
@@ -8,5 +8,8 @@ import "../Config.pkl"
 mix_test = new Config.Step {
   glob = List("**/*.ex", "**/*.exs")
   exclude = List("deps/**/*")
-  check = "mix test --warnings-as-errors {{files}}"
+  check = new Config.CommandSpec {
+    command = "mix test --warnings-as-errors {{files}}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/mixed_line_ending.pkl
+++ b/pkl/builtins/mixed_line_ending.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 mixed_line_ending = new Config.Step {
   types = List("text")
-  check_diff = "hk util mixed-line-ending --diff {{files}}"
-  fix = "hk util mixed-line-ending --fix {{files}}"
+  check_diff = new Config.CommandSpec {
+    command = "hk util mixed-line-ending --diff {{files}}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "hk util mixed-line-ending --fix {{files}}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {}
     ["check bad file"] = testMaker.checkFail("line1\r\nline2\nline3\r\n", 1)

--- a/pkl/builtins/mypy.pkl
+++ b/pkl/builtins/mypy.pkl
@@ -11,7 +11,10 @@ import "./test/helpers.pkl"
 }
 mypy = new Config.Step {
   glob = List("**/*.py", "**/*.pyi")
-  check = "mypy {{ files }}"
+  check = new Config.CommandSpec {
+    command = "mypy {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.py" }
     ["check bad file"] = testMaker.checkFail("x: int = ''", 1)

--- a/pkl/builtins/newlines.pkl
+++ b/pkl/builtins/newlines.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 newlines = new Config.Step {
   types = List("text")
-  check_diff = "hk util end-of-file-fixer --diff {{files}}"
-  fix = "hk util end-of-file-fixer --fix {{files}}"
+  check_diff = new Config.CommandSpec {
+    command = "hk util end-of-file-fixer --diff {{files}}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "hk util end-of-file-fixer --fix {{files}}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {}
     ["check bad file"] = testMaker.checkFail("content", 1)

--- a/pkl/builtins/nil.pkl
+++ b/pkl/builtins/nil.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 nil = new Config.Step {
   glob = "**/*.nix"
-  check = "nil diagnostics --deny-warnings {{ files }}"
+  check = new Config.CommandSpec {
+    command = "nil diagnostics --deny-warnings {{ files }}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/nix_fmt.pkl
+++ b/pkl/builtins/nix_fmt.pkl
@@ -7,12 +7,18 @@ import "../Config.pkl"
 }
 nix_fmt = new Config.Step {
   glob = "**/*.nix"
-  check = new Config.Script {
-    windows = ""
-    other = "nixfmt --check {{ files }}"
+  check = new Config.CommandSpec {
+    command = new Config.Script {
+      windows = ""
+      other = "nixfmt --check {{ files }}"
+    }
+    effect = "read"
   }
-  fix = new Config.Script {
-    windows = ""
-    other = "nixfmt {{ files }}"
+  fix = new Config.CommandSpec {
+    command = new Config.Script {
+      windows = ""
+      other = "nixfmt {{ files }}"
+    }
+    effect = "write"
   }
 }

--- a/pkl/builtins/nixf_diagnose.pkl
+++ b/pkl/builtins/nixf_diagnose.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 nixf_diagnose = new Config.Step {
   glob = "**/*.nix"
-  check = "nixf-diagnose {{ files }}"
+  check = new Config.CommandSpec {
+    command = "nixf-diagnose {{ files }}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/nixpkgs_format.pkl
+++ b/pkl/builtins/nixpkgs_format.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 nixpkgs_format = new Config.Step {
   glob = "**/*.nix"
-  check = "nixpkgs-fmt --check {{ files }}"
-  fix = "nixpkgs-fmt {{ files }}"
+  check = new Config.CommandSpec {
+    command = "nixpkgs-fmt --check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "nixpkgs-fmt {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/no_commit_to_branch.pkl
+++ b/pkl/builtins/no_commit_to_branch.pkl
@@ -6,7 +6,10 @@ import "../Config.pkl"
   description = "Prevent direct commits to protected branches"
 }
 no_commit_to_branch = new Config.Step {
-  check = "hk util no-commit-to-branch"
+  check = new Config.CommandSpec {
+    command = "hk util no-commit-to-branch"
+    effect = "read"
+  }
   tests {
     ["passes on feature branch"] {
       run = "check"

--- a/pkl/builtins/ox_lint.pkl
+++ b/pkl/builtins/ox_lint.pkl
@@ -36,8 +36,14 @@ ox_lint = new Config.Step {
     )
   // Without `--deny-warnings`,
   // the exit code will be 0 even if there is code that violates the rules.
-  check = "oxlint --deny-warnings {{ files }}"
-  fix = "oxlint --deny-warnings --fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "oxlint --deny-warnings {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "oxlint --deny-warnings --fix {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "foo.ts" }
     // Reference: https://oxc.rs/docs/guide/usage/linter/rules/oxc/double-comparisons.html

--- a/pkl/builtins/oxfmt.pkl
+++ b/pkl/builtins/oxfmt.pkl
@@ -58,9 +58,18 @@ oxfmt = new Config.Step {
       "**/*.handlebars",
       "**/*.hbs",
     )
-  check = "oxfmt --check --no-error-on-unmatched-pattern {{ files }}"
-  check_list_files = "oxfmt --list-different --no-error-on-unmatched-pattern {{ files }}"
-  fix = "oxfmt --write --no-error-on-unmatched-pattern {{ files }}"
+  check = new Config.CommandSpec {
+    command = "oxfmt --check --no-error-on-unmatched-pattern {{ files }}"
+    effect = "read"
+  }
+  check_list_files = new Config.CommandSpec {
+    command = "oxfmt --list-different --no-error-on-unmatched-pattern {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "oxfmt --write --no-error-on-unmatched-pattern {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "foo.ts" }
     // Source: https://github.com/oxc-project/oxc/blob/apps_v1.63.0/apps/oxfmt/test/api/basic.test.ts

--- a/pkl/builtins/php_cs.pkl
+++ b/pkl/builtins/php_cs.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 php_cs = new Config.Step {
   glob = "**/*.php"
-  check = "phpcs {{ files }}"
-  fix = "phpcbf {{ files }}"
+  check = new Config.CommandSpec {
+    command = "phpcs {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "phpcbf {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/pinact.pkl
+++ b/pkl/builtins/pinact.pkl
@@ -10,8 +10,14 @@ const pinact = new Config.Step {
   glob = List(".github/workflows/*", "*/action.*")
   types = List("yaml")
   // `verify` flag to verify pairs of commit CHA and version are correct
-  check_diff = "pinact run --verify --check {{ files }}"
-  fix = "pinact run --verify {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "pinact run --verify --check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "pinact run --verify {{ files }}"
+    effect = "write"
+  }
   tests {
     local const bad =
       """

--- a/pkl/builtins/pinact_update.pkl
+++ b/pkl/builtins/pinact_update.pkl
@@ -9,7 +9,13 @@ const pinact_update = new Config.Step {
   glob = List(".github/workflows/*", "*/action.*")
   types = List("yaml")
   // `verify` flag to verify pairs of commit CHA and version are correct
-  check_diff = "pinact run --update --verify --check {{ files }}"
-  fix = "pinact run --update --verify {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "pinact run --update --verify --check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "pinact run --update --verify {{ files }}"
+    effect = "write"
+  }
   // Tests removed: they check against live GitHub Action versions, making them flaky
 }

--- a/pkl/builtins/pkl.pkl
+++ b/pkl/builtins/pkl.pkl
@@ -8,7 +8,10 @@ import "./test/helpers.pkl"
 }
 pkl = new Config.Step {
   types = List("pkl")
-  check = "pkl eval {{files}} >/dev/null"
+  check = new Config.CommandSpec {
+    command = "pkl eval {{files}} >/dev/null"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.pkl" }
     ["check bad file"] = testMaker.checkFail("x == 1", 1)

--- a/pkl/builtins/pkl_format.pkl
+++ b/pkl/builtins/pkl_format.pkl
@@ -8,22 +8,28 @@ import "./test/helpers.pkl"
 }
 pkl_format = new Config.Step {
   types = List("pkl")
-  check_list_files = "pkl format --diff-name-only {{ files }}"
+  check_list_files = new Config.CommandSpec {
+    command = "pkl format --diff-name-only {{ files }}"
+    effect = "read"
+  }
   // NB: pkl format exits 11 even if it fixes files
   //  (If you're using a version of pkl that includes https://github.com/apple/pkl/pull/1340
   //  you can override this command to just use `pkl format --write {{ files }}`
   //  and remove the `shell` definition)
   shell = "sh -c"
-  fix =
-    """
-        pkl format --write {{ files }}
-        code=$?
-        if [ $code -eq 11 ]; then
-            exit 0
-        else
-            exit $code
-        fi
-    """
+  fix = new Config.CommandSpec {
+    command =
+      """
+      pkl format --write {{ files }}
+      code=$?
+      if [ $code -eq 11 ]; then
+      exit 0
+      else
+      exit $code
+      fi
+      """
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.pkl" }
     ["check bad file"] = testMaker.checkFail("x = new {  }", 11)

--- a/pkl/builtins/prettier.pkl
+++ b/pkl/builtins/prettier.pkl
@@ -39,9 +39,18 @@ prettier = new Config.Step {
       "**/*.vue",
     )
   batch = true
-  check = new Config.Command { argv = List("prettier", "--check", "{{files}}") }
-  check_list_files = new Config.Command { argv = List("prettier", "--list-different", "{{files}}") }
-  fix = new Config.Command { argv = List("prettier", "--write", "{{files}}") }
+  check = new Config.CommandSpec {
+    command = new Config.Command { argv = List("prettier", "--check", "{{files}}") }
+    effect = "read"
+  }
+  check_list_files = new Config.CommandSpec {
+    command = new Config.Command { argv = List("prettier", "--list-different", "{{files}}") }
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = new Config.Command { argv = List("prettier", "--write", "{{files}}") }
+    effect = "write"
+  }
   tests {
     ["formats json"] {
       run = "fix"

--- a/pkl/builtins/pylint.pkl
+++ b/pkl/builtins/pylint.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 pylint = new Config.Step {
   glob = "**/*.py"
-  check = "pylint {{ files }}"
+  check = new Config.CommandSpec {
+    command = "pylint {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/python_check_ast.pkl
+++ b/pkl/builtins/python_check_ast.pkl
@@ -8,7 +8,10 @@ import "./test/helpers.pkl"
 }
 python_check_ast = new Config.Step {
   glob = "**/*.py"
-  check = "hk util python-check-ast {{files}}"
+  check = new Config.CommandSpec {
+    command = "hk util python-check-ast {{files}}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.py" }
     ["check bad file"] =

--- a/pkl/builtins/python_debug_statements.pkl
+++ b/pkl/builtins/python_debug_statements.pkl
@@ -8,7 +8,10 @@ import "./test/helpers.pkl"
 }
 python_debug_statements = new Config.Step {
   glob = "**/*.py"
-  check = "hk util python-debug-statements {{files}}"
+  check = new Config.CommandSpec {
+    command = "hk util python-debug-statements {{files}}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.py" }
     ["check pdb"] =

--- a/pkl/builtins/reek.pkl
+++ b/pkl/builtins/reek.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 reek = new Config.Step {
   types = List("ruby")
-  check = "reek {{ files }}"
+  check = new Config.CommandSpec {
+    command = "reek {{ files }}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/revive.pkl
+++ b/pkl/builtins/revive.pkl
@@ -8,5 +8,8 @@ import "../Config.pkl"
 revive = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
-  check = "cd {{workspace}} && revive ./..."
+  check = new Config.CommandSpec {
+    command = "cd {{workspace}} && revive ./..."
+    effect = "read"
+  }
 }

--- a/pkl/builtins/rubocop.pkl
+++ b/pkl/builtins/rubocop.pkl
@@ -71,9 +71,18 @@ rubocop = new Config.Step {
       ".git/**/*",
     )
   // `--force-exclusion`: Any files excluded by `Exclude` in RuboCop configuration files will be excluded, even if given explicitly as arguments.
-  check = "rubocop --force-exclusion {{ files }}"
-  check_list_files = "rubocop --force-exclusion --list-target-files {{ files }}"
-  fix = "rubocop --force-exclusion --autocorrect {{ files }}"
+  check = new Config.CommandSpec {
+    command = "rubocop --force-exclusion {{ files }}"
+    effect = "write"
+  }
+  check_list_files = new Config.CommandSpec {
+    command = "rubocop --force-exclusion --list-target-files {{ files }}"
+    effect = "write"
+  }
+  fix = new Config.CommandSpec {
+    command = "rubocop --force-exclusion --autocorrect {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.rb"

--- a/pkl/builtins/rubocop_server.pkl
+++ b/pkl/builtins/rubocop_server.pkl
@@ -1,4 +1,5 @@
 import "../Builtins.pkl"
+import "../Config.pkl"
 import "./rubocop.pkl"
 
 @Builtins.meta {
@@ -10,7 +11,16 @@ import "./rubocop.pkl"
 }
 rubocop_server = (rubocop.rubocop) {
   // `--server`: Use a long-lived RuboCop server process to speed up repeated invocations.
-  check = "rubocop --server --force-exclusion {{ files }}"
-  check_list_files = "rubocop --server --force-exclusion --list-target-files {{ files }}"
-  fix = "rubocop --server --force-exclusion --autocorrect {{ files }}"
+  check = new Config.CommandSpec {
+    command = "rubocop --server --force-exclusion {{ files }}"
+    effect = "write"
+  }
+  check_list_files = new Config.CommandSpec {
+    command = "rubocop --server --force-exclusion --list-target-files {{ files }}"
+    effect = "write"
+  }
+  fix = new Config.CommandSpec {
+    command = "rubocop --server --force-exclusion --autocorrect {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/ruff.pkl
+++ b/pkl/builtins/ruff.pkl
@@ -12,11 +12,19 @@ import "./test/helpers.pkl"
 }
 ruff = new Config.Step {
   types = List("python")
-  check = new Config.Command { argv = List("ruff", "check", "--force-exclude", "{{files}}") }
+  check = new Config.CommandSpec {
+    command = new Config.Command { argv = List("ruff", "check", "--force-exclude", "{{files}}") }
+    effect = "write"
+  }
   // `ruff check --diff` can exit 0 even if non-fixable issues exist, making it an
   // unreliable signal for whether to run `fix`. We use `check` instead.
   // check_diff = "ruff check --force-exclude --diff {{ files }}"
-  fix = new Config.Command { argv = List("ruff", "check", "--force-exclude", "--fix", "{{files}}") }
+  fix = new Config.CommandSpec {
+    command = new Config.Command {
+      argv = List("ruff", "check", "--force-exclude", "--fix", "{{files}}")
+    }
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.py"

--- a/pkl/builtins/ruff_format.pkl
+++ b/pkl/builtins/ruff_format.pkl
@@ -12,8 +12,14 @@ import "./test/helpers.pkl"
 }
 ruff_format = new Config.Step {
   types = List("python")
-  check_diff = "ruff format --quiet --force-exclude --diff {{ files }}"
-  fix = "ruff format --quiet --force-exclude {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "ruff format --quiet --force-exclude --diff {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "ruff format --quiet --force-exclude {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.py"

--- a/pkl/builtins/rumdl.pkl
+++ b/pkl/builtins/rumdl.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 rumdl = new Config.Step {
   glob = List("**/*.md", "**/*.markdown")
-  check_diff = "rumdl check --diff {{ files }}"
-  fix = "rumdl check --fix {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "rumdl check --diff {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "rumdl check --fix {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "file.md" }
     ["check bad file"] = testMaker.checkFail("# Hello\n\n\nParagraph\n", 1)

--- a/pkl/builtins/rumdl_format.pkl
+++ b/pkl/builtins/rumdl_format.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 rumdl_format = new Config.Step {
   glob = List("**/*.md", "**/*.markdown")
-  check_diff = "rumdl fmt --check --diff {{ files }}"
-  fix = "rumdl fmt {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "rumdl fmt --check --diff {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "rumdl fmt {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "file.md" }
     local const before = "# Hello\n\n\nParagraph\n"

--- a/pkl/builtins/rustfmt.pkl
+++ b/pkl/builtins/rustfmt.pkl
@@ -8,11 +8,22 @@ import "./test/helpers.pkl"
 }
 rustfmt = new Config.Step {
   glob = "**/*.rs"
-  check = new Config.Command { argv = List("rustfmt", "--check", "--edition", "2024", "{{files}}") }
-  check_list_files = new Config.Command {
-    argv = List("rustfmt", "--check", "--edition", "2024", "--files-with-diff", "{{files}}")
+  check = new Config.CommandSpec {
+    command = new Config.Command {
+      argv = List("rustfmt", "--check", "--edition", "2024", "{{files}}")
+    }
+    effect = "read"
   }
-  fix = new Config.Command { argv = List("rustfmt", "--edition", "2024", "{{files}}") }
+  check_list_files = new Config.CommandSpec {
+    command = new Config.Command {
+      argv = List("rustfmt", "--check", "--edition", "2024", "--files-with-diff", "{{files}}")
+    }
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = new Config.Command { argv = List("rustfmt", "--edition", "2024", "{{files}}") }
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.rs"

--- a/pkl/builtins/ryl.pkl
+++ b/pkl/builtins/ryl.pkl
@@ -19,9 +19,18 @@ import "./test/helpers.pkl"
 }
 ryl = new Config.Step {
   types = List("yaml")
-  check_diff = "ryl --diff {{ files }}"
-  check_list_files = "ryl --list-files {{ files }}"
-  fix = "ryl --fix {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "ryl --diff {{ files }}"
+    effect = "read"
+  }
+  check_list_files = new Config.CommandSpec {
+    command = "ryl --list-files {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "ryl --fix {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.yaml"

--- a/pkl/builtins/ryl_markdown.pkl
+++ b/pkl/builtins/ryl_markdown.pkl
@@ -19,9 +19,18 @@ import "./test/helpers.pkl"
 }
 ryl_markdown = new Config.Step {
   types = List("markdown")
-  check_diff = "ryl --diff --markdown {{ files }}"
-  check_list_files = "ryl --list-files --markdown {{ files }}"
-  fix = "ryl --fix --markdown {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "ryl --diff --markdown {{ files }}"
+    effect = "read"
+  }
+  check_list_files = new Config.CommandSpec {
+    command = "ryl --list-files --markdown {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "ryl --fix --markdown {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.md"

--- a/pkl/builtins/selene.pkl
+++ b/pkl/builtins/selene.pkl
@@ -8,7 +8,10 @@ import "./test/helpers.pkl"
 }
 selene = new Config.Step {
   types = List("lua")
-  check_diff = "selene {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "selene {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.lua"

--- a/pkl/builtins/shellcheck.pkl
+++ b/pkl/builtins/shellcheck.pkl
@@ -16,7 +16,10 @@ shellcheck = new Config.Step {
       new Config.FileSelector { glob = List("**/*.sh", "**/*.bash") },
       new Config.FileSelector { types = List("sh", "bash") },
     )
-  check = new Config.Command { argv = List("shellcheck", "{{files}}") }
+  check = new Config.CommandSpec {
+    command = new Config.Command { argv = List("shellcheck", "{{files}}") }
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.sh"

--- a/pkl/builtins/shellharden.pkl
+++ b/pkl/builtins/shellharden.pkl
@@ -15,8 +15,14 @@ shellharden = new Config.Step {
   batch = true
   // `check_diff` cannot be added.
   // `shellharden {{ files }}` shows a diff but exits with code 0 even when changes are suggested
-  check = "shellharden --check {{ files }}"
-  fix = "shellharden --replace {{ files }}"
+  check = new Config.CommandSpec {
+    command = "shellharden --check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "shellharden --replace {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.sh"

--- a/pkl/builtins/sherif.pkl
+++ b/pkl/builtins/sherif.pkl
@@ -14,14 +14,20 @@ sherif = new Config.Step {
   // accept file arguments, so there's no {{ files }} in the commands below.
   // https://github.com/QuiiBz/sherif
   glob = List("**/package.json", "**/pnpm-workspace.yaml")
-  check = "sherif"
+  check = new Config.CommandSpec {
+    command = "sherif"
+    effect = "read"
+  }
   // --no-install skips the package-manager install sherif otherwise runs
   // after autofixing. --select highest|lowest (for multiple-dependency-
   // versions autofix) is left to the user to configure if needed.
   // Note: fix may rewrite package.json files across the whole workspace
   // (e.g. multiple-dependency-versions), including files hk did not match
   // or lock for this run.
-  fix = "sherif --fix --no-install"
+  fix = new Config.CommandSpec {
+    command = "sherif --fix --no-install"
+    effect = "write"
+  }
   tests {
     // sherif refuses to run --fix whenever the CI env var is set to any
     // value ("Cannot fix issues inside a CI environment", exit 1). hk test

--- a/pkl/builtins/shfmt.pkl
+++ b/pkl/builtins/shfmt.pkl
@@ -18,16 +18,25 @@ shfmt = new Config.Step {
       },
       new Config.FileSelector { types = List("sh", "bash") },
     )
-  check_diff = "shfmt -d --apply-ignore {{ files }}"
-  check_list_files =
-    """
-    files=$(shfmt -l --apply-ignore {{ files }})
-    if [ -n "$files" ]; then
+  check_diff = new Config.CommandSpec {
+    command = "shfmt -d --apply-ignore {{ files }}"
+    effect = "read"
+  }
+  check_list_files = new Config.CommandSpec {
+    command =
+      """
+      files=$(shfmt -l --apply-ignore {{ files }})
+      if [ -n "$files" ]; then
       echo "$files"
       exit 1
-    fi
-    """
-  fix = "shfmt -w --apply-ignore {{ files }}"
+      fi
+      """
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "shfmt -w --apply-ignore {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.sh" }
     local const before =

--- a/pkl/builtins/sorbet.pkl
+++ b/pkl/builtins/sorbet.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 sorbet = new Config.Step {
   types = List("ruby")
-  check = "srb tc {{ files }}"
+  check = new Config.CommandSpec {
+    command = "srb tc {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/sort_package_json.pkl
+++ b/pkl/builtins/sort_package_json.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 sort_package_json = new Config.Step {
   glob = "**/package.json"
-  check = "sort-package-json --check {{ files }}"
-  fix = "sort-package-json {{ files }}"
+  check = new Config.CommandSpec {
+    command = "sort-package-json --check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "sort-package-json {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/sql_fluff.pkl
+++ b/pkl/builtins/sql_fluff.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 sql_fluff = new Config.Step {
   glob = "**/*.sql"
-  check = "sqlfluff lint {{ files }}"
-  fix = "sqlfluff fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "sqlfluff lint {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "sqlfluff fix {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/standard_js.pkl
+++ b/pkl/builtins/standard_js.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 standard_js = new Config.Step {
   glob = List("**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx")
-  check = "standard {{ files }}"
-  fix = "standard --fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "standard {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "standard --fix {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/standard_rb.pkl
+++ b/pkl/builtins/standard_rb.pkl
@@ -10,6 +10,12 @@ import "../Config.pkl"
 }
 standard_rb = new Config.Step {
   types = List("ruby")
-  check = "standardrb {{ files }}"
-  fix = "standardrb --fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "standardrb {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "standardrb --fix {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/staticcheck.pkl
+++ b/pkl/builtins/staticcheck.pkl
@@ -8,5 +8,8 @@ import "../Config.pkl"
 staticcheck = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
-  check = "cd {{workspace}} && staticcheck ./..."
+  check = new Config.CommandSpec {
+    command = "cd {{workspace}} && staticcheck ./..."
+    effect = "write"
+  }
 }

--- a/pkl/builtins/stylelint.pkl
+++ b/pkl/builtins/stylelint.pkl
@@ -11,8 +11,14 @@ import "./test/helpers.pkl"
 }
 stylelint = new Config.Step {
   glob = List("**/*.css", "**/*.scss", "**/*.sass", "**/*.less")
-  check = "stylelint {{ files }}"
-  fix = "stylelint --fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "stylelint {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "stylelint --fix {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.css"

--- a/pkl/builtins/stylua.pkl
+++ b/pkl/builtins/stylua.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 stylua = new Config.Step {
   types = List("lua")
-  check_diff = "stylua --check {{ files }}"
-  fix = "stylua {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "stylua --check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "stylua {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.lua"

--- a/pkl/builtins/swiftlint.pkl
+++ b/pkl/builtins/swiftlint.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 swiftlint = new Config.Step {
   glob = "**/*.swift"
-  check = "swiftlint lint {{ files }}"
-  fix = "swiftlint --fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "swiftlint lint {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "swiftlint --fix {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/taplo.pkl
+++ b/pkl/builtins/taplo.pkl
@@ -12,7 +12,10 @@ taplo = new Config.Step {
     // prevent logs to stderr with the list of checked files
     ["RUST_LOG"] = "warn"
   }
-  check = "taplo lint {{ files }}"
+  check = new Config.CommandSpec {
+    command = "taplo lint {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.toml" }
     ["check bad file"] = testMaker.checkFail("[table]\nkey = 0\nkey = 1\n", 1)

--- a/pkl/builtins/taplo_format.pkl
+++ b/pkl/builtins/taplo_format.pkl
@@ -12,8 +12,14 @@ taplo_format = new Config.Step {
     // prevent logs to stderr with the list of checked files
     ["RUST_LOG"] = "warn"
   }
-  check_diff = "taplo format --check --diff {{ files }}"
-  fix = "taplo format {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "taplo format --check --diff {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "taplo format {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.toml" }
     ["check bad file"] = testMaker.checkFail("[table]\nkey  =  \"value\"\n", 1)

--- a/pkl/builtins/terraform.pkl
+++ b/pkl/builtins/terraform.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 terraform = new Config.Step {
   glob = List("**/*.tf", "**/*.tfvars", "**/*.tftest.hcl")
-  check_list_files = "terraform fmt -check {{ files }}"
-  fix = "terraform fmt {{ files }}"
+  check_list_files = new Config.CommandSpec {
+    command = "terraform fmt -check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "terraform fmt {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/textlint.pkl
+++ b/pkl/builtins/textlint.pkl
@@ -20,8 +20,14 @@ textlint = new Config.Step {
   // https://textlint.org/docs/plugin/
   glob = List("**/*.md", "**/*.markdown", "**/*.txt")
   batch = true
-  check = "textlint {{ files }}"
-  fix = "textlint --fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "textlint {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "textlint --fix {{ files }}"
+    effect = "write"
+  }
   tests {
     // textlint has no built-in rules; ship a tiny fixable rule and reference it
     // from .textlintrc.js by absolute path so the test does not depend on any

--- a/pkl/builtins/tf_lint.pkl
+++ b/pkl/builtins/tf_lint.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 tf_lint = new Config.Step {
   glob = "**/*.tf"
-  check = "tflint"
-  fix = "tflint --fix"
+  check = new Config.CommandSpec {
+    command = "tflint"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "tflint --fix"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/tofu.pkl
+++ b/pkl/builtins/tofu.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 tofu = new Config.Step {
   glob = List("**/*.tf", "**/*.tfvars", "**/*.tftest.hcl")
-  check_list_files = "tofu fmt -check {{ files }}"
-  fix = "tofu fmt {{ files }}"
+  check_list_files = new Config.CommandSpec {
+    command = "tofu fmt -check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "tofu fmt {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/tombi.pkl
+++ b/pkl/builtins/tombi.pkl
@@ -8,7 +8,10 @@ import "./test/helpers.pkl"
 }
 tombi = new Config.Step {
   glob = "**/*.toml"
-  check = "tombi lint --quiet {{ files }}"
+  check = new Config.CommandSpec {
+    command = "tombi lint --quiet {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "file.toml"

--- a/pkl/builtins/tombi_format.pkl
+++ b/pkl/builtins/tombi_format.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 tombi_format = new Config.Step {
   glob = "**/*.toml"
-  check_diff = "tombi format --quiet --check --diff {{ files }}"
-  fix = "tombi format --quiet {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "tombi format --quiet --check --diff {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "tombi format --quiet {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.toml"

--- a/pkl/builtins/trailing_whitespace.pkl
+++ b/pkl/builtins/trailing_whitespace.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 trailing_whitespace = new Config.Step {
   types = List("text")
-  check_diff = "hk util trailing-whitespace --diff {{files}}"
-  fix = "hk util trailing-whitespace --fix {{files}}"
+  check_diff = new Config.CommandSpec {
+    command = "hk util trailing-whitespace --diff {{files}}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "hk util trailing-whitespace --fix {{files}}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {}
     ["check bad file"] = testMaker.checkFail("trailing  \n", 1)

--- a/pkl/builtins/tsc.pkl
+++ b/pkl/builtins/tsc.pkl
@@ -12,7 +12,10 @@ import "./test/helpers.pkl"
 tsc = new Config.Step {
   workspace_indicator = "tsconfig.json"
   glob = List("**/*.ts", "**/*.tsx")
-  check = "tsc --noEmit -p {{workspace_indicator}}"
+  check = new Config.CommandSpec {
+    command = "tsc --noEmit -p {{workspace_indicator}}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "src/test.ts"

--- a/pkl/builtins/tsserver.pkl
+++ b/pkl/builtins/tsserver.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 tsserver = new Config.Step {
   glob = List("**/*.ts", "**/*.tsx")
-  check = "tsc-files --noEmit {{ files }}"
+  check = new Config.CommandSpec {
+    command = "tsc-files --noEmit {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/ty.pkl
+++ b/pkl/builtins/ty.pkl
@@ -8,7 +8,10 @@ import "./test/helpers.pkl"
 }
 ty = new Config.Step {
   glob = List("**/*.py", "**/*.pyi")
-  check = "ty check {{ files }}"
+  check = new Config.CommandSpec {
+    command = "ty check {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.py" }
     ["check bad file"] = testMaker.checkFail("x: int = ''", 1)

--- a/pkl/builtins/typos.pkl
+++ b/pkl/builtins/typos.pkl
@@ -8,14 +8,20 @@ import "./test/helpers.pkl"
 }
 typos = new Config.Step {
   types = List("text")
-  check_diff =
-    """
-    output=$(typos --force-exclude --diff {{files}})
-    [ -z "$output" ] && exit 0
-    printf "%s" "$output"
-    exit 1
-    """
-  fix = "typos --force-exclude --write-changes {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command =
+      """
+      output=$(typos --force-exclude --diff {{files}})
+      [ -z "$output" ] && exit 0
+      printf "%s" "$output"
+      exit 1
+      """
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "typos --force-exclude --write-changes {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.txt"

--- a/pkl/builtins/vacuum.pkl
+++ b/pkl/builtins/vacuum.pkl
@@ -15,6 +15,12 @@ vacuum = new Config.Step {
       "**/*swagger*.yml",
       "**/*swagger*.json",
     )
-  check = "vacuum lint {{files}}"
-  fix = "vacuum lint --fix {{files}}"
+  check = new Config.CommandSpec {
+    command = "vacuum lint {{files}}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "vacuum lint --fix {{files}}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/vale.pkl
+++ b/pkl/builtins/vale.pkl
@@ -9,7 +9,10 @@ import "./test/helpers.pkl"
 vale = new Config.Step {
   types = List("text")
   // `vale sync` command downloads and installs external configuration sources.
-  check = "vale sync && vale {{ files }}"
+  check = new Config.CommandSpec {
+    command = "vale sync && vale {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.rs"

--- a/pkl/builtins/vp_check.pkl
+++ b/pkl/builtins/vp_check.pkl
@@ -58,8 +58,14 @@ vp_check = new Config.Step {
       // TOML
       "**/*.toml",
     )
-  check = "vp check {{ files }}"
-  fix = "vp check --fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "vp check {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "vp check --fix {{ files }}"
+    effect = "write"
+  }
   workspace_indicator = "package.json"
   tests {
     local const testMaker = new helpers.TestMaker {

--- a/pkl/builtins/vp_fmt.pkl
+++ b/pkl/builtins/vp_fmt.pkl
@@ -56,9 +56,18 @@ vp_fmt = new Config.Step {
       "**/*.handlebars",
       "**/*.hbs",
     )
-  check = "vp fmt --check {{ files }}"
-  check_list_files = "vp fmt --list-different {{ files }}"
-  fix = "vp fmt {{ files }}"
+  check = new Config.CommandSpec {
+    command = "vp fmt --check {{ files }}"
+    effect = "read"
+  }
+  check_list_files = new Config.CommandSpec {
+    command = "vp fmt --list-different {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "vp fmt {{ files }}"
+    effect = "write"
+  }
   workspace_indicator = "package.json"
   tests {
     local const testMaker = new helpers.TestMaker {

--- a/pkl/builtins/vp_lint.pkl
+++ b/pkl/builtins/vp_lint.pkl
@@ -35,8 +35,14 @@ vp_lint = new Config.Step {
     )
   // Without `--deny-warnings`,
   // the exit code will be 0 even if there is code that violates the rules.
-  check = "vp lint --deny-warnings {{ files }}"
-  fix = "vp lint --deny-warnings --fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "vp lint --deny-warnings {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "vp lint --deny-warnings --fix {{ files }}"
+    effect = "write"
+  }
   workspace_indicator = "package.json"
   tests {
     local const testMaker = new helpers.TestMaker {

--- a/pkl/builtins/xmllint.pkl
+++ b/pkl/builtins/xmllint.pkl
@@ -7,5 +7,8 @@ import "../Config.pkl"
 }
 xmllint = new Config.Step {
   glob = "**/*.xml"
-  check = "xmllint --noout {{ files }}"
+  check = new Config.CommandSpec {
+    command = "xmllint --noout {{ files }}"
+    effect = "read"
+  }
 }

--- a/pkl/builtins/xo.pkl
+++ b/pkl/builtins/xo.pkl
@@ -7,6 +7,12 @@ import "../Config.pkl"
 }
 xo = new Config.Step {
   glob = List("**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx")
-  check = "xo {{ files }}"
-  fix = "xo --fix {{ files }}"
+  check = new Config.CommandSpec {
+    command = "xo {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "xo --fix {{ files }}"
+    effect = "write"
+  }
 }

--- a/pkl/builtins/yamlfmt.pkl
+++ b/pkl/builtins/yamlfmt.pkl
@@ -8,8 +8,14 @@ import "./test/helpers.pkl"
 }
 yamlfmt = new Config.Step {
   glob = List("**/*.yml", "**/*.yaml")
-  check_diff = "yamlfmt -lint {{ files }}"
-  fix = "yamlfmt {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "yamlfmt -lint {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "yamlfmt {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.yaml"

--- a/pkl/builtins/yamllint.pkl
+++ b/pkl/builtins/yamllint.pkl
@@ -8,7 +8,10 @@ import "./test/helpers.pkl"
 }
 yamllint = new Config.Step {
   glob = List("**/*.yml", "**/*.yaml")
-  check = "yamllint --strict {{ files }}"
+  check = new Config.CommandSpec {
+    command = "yamllint --strict {{ files }}"
+    effect = "read"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.yaml" }
     ["check good file"] = testMaker.checkPass("---\nx: 1\n")

--- a/pkl/builtins/yq.pkl
+++ b/pkl/builtins/yq.pkl
@@ -8,15 +8,21 @@ import "./test/helpers.pkl"
 }
 yq = new Config.Step {
   glob = List("**/*.yaml", "**/*.yml")
-  check_diff =
-    """
-    failed=0
-    for f in {{ files }}; do
+  check_diff = new Config.CommandSpec {
+    command =
+      """
+      failed=0
+      for f in {{ files }}; do
       yq -P "$f" | diff -u "$f" - || failed=1
-    done
-    exit $failed
-    """
-  fix = "yq -iP {{ files }}"
+      done
+      exit $failed
+      """
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "yq -iP {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.yaml" }
     ["check bad file"] = testMaker.checkFail("foo:  bar", 1)

--- a/pkl/builtins/zizmor.pkl
+++ b/pkl/builtins/zizmor.pkl
@@ -18,8 +18,14 @@ zizmor = new Config.Step {
       "**/action.yml",
       "**/action.yaml",
     )
-  check_diff = "zizmor --no-progress {{ files }}"
-  fix = "zizmor --no-progress --fix {{ files }}"
+  check_diff = new Config.CommandSpec {
+    command = "zizmor --no-progress {{ files }}"
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = "zizmor --no-progress --fix {{ files }}"
+    effect = "write"
+  }
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = ".github/workflows/action.yaml"

--- a/scripts/gen_builtins.py
+++ b/scripts/gen_builtins.py
@@ -8,10 +8,13 @@ import subprocess
 import sys
 import tempfile
 
+COMMAND_FIELDS = ("check", "check_list_files", "check_diff", "fix")
+
 HEADER = """\
 // THIS FILE IS GENERATED: Run 'mise run pkl:gen' to generate.
 
 import* "builtins/*.pkl" as Builtins
+import "Config.pkl" as Config
 
 /// Indicator for detecting if a builtin is relevant to a project
 class ProjectIndicator {
@@ -61,6 +64,31 @@ DEPRECATED_ALIASES = [
 ]
 
 
+def validate_effect_coverage():
+    result = subprocess.run(
+        ["pkl", "eval", "pkl/Builtins.pkl", "--format", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    builtins = json.loads(result.stdout)
+    missing = []
+    for name, step in builtins.items():
+        if not isinstance(step, dict):
+            continue
+        for field in COMMAND_FIELDS:
+            command = step.get(field)
+            if command is not None and (
+                not isinstance(command, dict)
+                or command.get("effect") not in {"read", "write", "destructive"}
+            ):
+                missing.append(f"{name}.{field}")
+    if missing:
+        raise RuntimeError(
+            "builtin commands missing effects:\n  " + "\n  ".join(sorted(missing))
+        )
+
+
 def main():
     skip = {alias for alias, _, _, _ in DEPRECATED_ALIASES}
 
@@ -80,10 +108,11 @@ def main():
             f.write(f'  since = "{since}"\n')
             f.write(f'  message = "{message}"\n')
             f.write("}\n")
-            f.write(f'{alias} = Builtins["builtins/{canonical}.pkl"].{canonical}\n')
+            f.write(f"{alias} = {canonical}\n")
 
     # pkl format (exits 11 after formatting, ignore that)
     subprocess.run(["pkl", "format", "--write", "pkl/Builtins.pkl"])
+    validate_effect_coverage()
 
     # Generate builtins metadata JSON for build script
     reflect_script = os.path.join(os.getcwd(), "scripts", "reflect.pkl")
@@ -99,9 +128,18 @@ def main():
         # Use pkl reflection to extract metadata
         try:
             result = subprocess.run(
-                ["pkl", "eval", filepath, "--format", "json", "-x",
-                 f'import("{reflect_uri}").render(module)'],
-                capture_output=True, text=True, timeout=30,
+                [
+                    "pkl",
+                    "eval",
+                    filepath,
+                    "--format",
+                    "json",
+                    "-x",
+                    f'import("{reflect_uri}").render(module)',
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             if result.returncode != 0:
                 continue
@@ -127,18 +165,22 @@ def main():
                         if isinstance(indicators, list):
                             project_indicators = indicators
 
-                entries.append({
-                    "name": name,
-                    "category": category,
-                    "description": description,
-                    "project_indicators": project_indicators,
-                })
+                entries.append(
+                    {
+                        "name": name,
+                        "category": category,
+                        "description": description,
+                        "project_indicators": project_indicators,
+                    }
+                )
                 break  # Only first property (the builtin definition)
         except Exception:
             continue
 
     # Write atomically
-    fd, tmpfile = tempfile.mkstemp(dir="pkl", prefix="builtins_meta.json.", suffix=".tmp")
+    fd, tmpfile = tempfile.mkstemp(
+        dir="pkl", prefix="builtins_meta.json.", suffix=".tmp"
+    )
     try:
         with os.fdopen(fd, "w", newline="\n") as f:
             json.dump(entries, f, indent=None)

--- a/test/builtin_effects.bats
+++ b/test/builtin_effects.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+write_config() {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["trailing_whitespace"] = Builtins.trailing_whitespace
+            ["vale"] = Builtins.vale
+        }
+    }
+}
+EOF
+    touch clean.txt
+    git add .
+    git commit -m init
+}
+
+@test "builtin plans expose read, write, and fix effects" {
+    write_config
+
+    run bash -c "hk check --all --plan --json 2>/dev/null"
+    assert_success
+    run jq -r '.steps[] | [.name, .metadata.effect] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'trailing_whitespace\tread\nvale\twrite'
+
+    run bash -c "hk check --fix --all --plan --json 2>/dev/null"
+    assert_success
+    run jq -r '.steps[] | select(.name == "trailing_whitespace") | .metadata.effect' <<<"$output"
+    assert_success
+    assert_output "write"
+}
+
+@test "safe mode executes a builtin read command" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["trailing_whitespace"] = Builtins.trailing_whitespace
+        }
+    }
+}
+EOF
+    touch clean.txt
+    git add .
+    git commit -m init
+
+    run hk check --all --safe
+    assert_success
+}
+
+@test "overriding a builtin command drops its inherited effect" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["overridden"] = (Builtins.trailing_whitespace) {
+                check_diff = "touch should-not-run"
+            }
+        }
+    }
+}
+EOF
+    touch clean.txt
+    git add .
+    git commit -m init
+
+    run hk check --all --safe
+    assert_failure
+    assert_output --partial "overridden.check_diff: effect is unknown"
+    assert_file_not_exists should-not-run
+}


### PR DESCRIPTION
## Summary

- classify every command exposed by the current builtin catalog: 236 command fields across 144 command-bearing modules
- wrap builtin commands at the generated `Builtins.pkl` boundary so overrides replace both the command and its safety claim
- classify fixers as writes and checks that populate caches, compile, or synchronize data as writes; other checks are reads
- fail builtin generation if any exposed `check`, `check_list_files`, `check_diff`, or `fix` command lacks an effect

## Stack

Depends on #1166 (`feat(step): add command effect safety`). This is layer 4 of the agent-native hk stack.

## Test evidence

- `python3 -m py_compile scripts/gen_builtins.py`
- `mise exec ruff@0.15.20 -- ruff check scripts/gen_builtins.py`
- `mise exec ruff@0.15.20 -- ruff format --check scripts/gen_builtins.py`
- `mise run pkl:gen` (includes 100% effect-coverage validation)
- `mise run build`
- `mise run test:bats test/builtin_effects.bats`
- `mise run test:bats test/builtins_tests.bats` was attempted locally; catalog loading and effect wrapping succeeded, while 27 tool executions failed because this host lacks configured Node, Ruby, or Java runtimes and one network-dependent zizmor check timed out. CI has the project toolchain and remains authoritative for the complete catalog.

## Rollout notes

Builtin consumers receive explicit effects automatically. A user override such as replacing `Builtins.trailing_whitespace.check_diff` with a string becomes unknown rather than inheriting the builtin's read claim. No builtin is marked destructive because current builtin commands only inspect or update recreatable/project state.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large mechanical change across 100+ builtin modules; misclassified `read` vs `write` could block or allow the wrong commands under safe mode, though generation enforces complete coverage.
> 
> **Overview**
> **Builtin commands now declare safety effects** so hk can reason about read-only vs mutating steps (e.g. `--safe`, plan JSON).
> 
> Across the builtin catalog, `check`, `check_list_files`, `check_diff`, and `fix` are no longer bare strings or `Command` objects—they use `Config.CommandSpec` with `effect = "read"` for typical linters/format checks and `effect = "write"` for fixers and checks that compile, sync, or write caches (cargo, tsc, vale, rubocop, etc.). No builtins are marked `destructive`.
> 
> `scripts/gen_builtins.py` runs **`validate_effect_coverage()`** after generating `Builtins.pkl`, evaluating the catalog as JSON and erroring if any exposed command field lacks a valid effect. Deprecated builtin aliases now re-export the canonical builtin directly instead of re-importing the module path.
> 
> **`test/builtin_effects.bats`** asserts plan output includes per-step effects, safe mode runs a read builtin, and overriding a builtin command without `CommandSpec` surfaces an unknown effect instead of inheriting the builtin’s read claim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c77afc6e3737d1761e3a7b2c8330e9241a288e0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->