### PR TITLE
feat(check): add normalized diagnostics and SARIF

### DIFF
--- a/docs/cli/check.md
+++ b/docs/cli/check.md
@@ -89,6 +89,10 @@ Check only files changed in the current PR/branch (shortcut for --from-ref DEFAU
 
 Reject commands with unknown or destructive effects before execution
 
+### `--sarif <PATH>`
+
+Write normalized diagnostics as SARIF
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -305,6 +305,23 @@
             "global": false
           },
           {
+            "name": "sarif",
+            "usage": "--sarif <PATH>",
+            "help": "Write normalized diagnostics as SARIF",
+            "help_first_line": "Write normalized diagnostics as SARIF",
+            "short": [],
+            "long": ["sarif"],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "PATH",
+              "usage": "<PATH>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
+          },
+          {
             "name": "skip-step",
             "usage": "--skip-step… <STEP>",
             "help": "Skip specific step(s)",
@@ -808,6 +825,23 @@
             "long": ["safe"],
             "hide": false,
             "global": false
+          },
+          {
+            "name": "sarif",
+            "usage": "--sarif <PATH>",
+            "help": "Write normalized diagnostics as SARIF",
+            "help_first_line": "Write normalized diagnostics as SARIF",
+            "short": [],
+            "long": ["sarif"],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "PATH",
+              "usage": "<PATH>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
           },
           {
             "name": "skip-step",
@@ -1380,6 +1414,23 @@
                 "global": false
               },
               {
+                "name": "sarif",
+                "usage": "--sarif <PATH>",
+                "help": "Write normalized diagnostics as SARIF",
+                "help_first_line": "Write normalized diagnostics as SARIF",
+                "short": [],
+                "long": ["sarif"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "skip-step",
                 "usage": "--skip-step… <STEP>",
                 "help": "Skip specific step(s)",
@@ -1762,6 +1813,23 @@
                 "global": false
               },
               {
+                "name": "sarif",
+                "usage": "--sarif <PATH>",
+                "help": "Write normalized diagnostics as SARIF",
+                "help_first_line": "Write normalized diagnostics as SARIF",
+                "short": [],
+                "long": ["sarif"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "skip-step",
                 "usage": "--skip-step… <STEP>",
                 "help": "Skip specific step(s)",
@@ -2115,6 +2183,23 @@
                 "long": ["safe"],
                 "hide": false,
                 "global": false
+              },
+              {
+                "name": "sarif",
+                "usage": "--sarif <PATH>",
+                "help": "Write normalized diagnostics as SARIF",
+                "help_first_line": "Write normalized diagnostics as SARIF",
+                "short": [],
+                "long": ["sarif"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
               },
               {
                 "name": "skip-step",
@@ -2481,6 +2566,23 @@
                 "global": false
               },
               {
+                "name": "sarif",
+                "usage": "--sarif <PATH>",
+                "help": "Write normalized diagnostics as SARIF",
+                "help_first_line": "Write normalized diagnostics as SARIF",
+                "short": [],
+                "long": ["sarif"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "skip-step",
                 "usage": "--skip-step… <STEP>",
                 "help": "Skip specific step(s)",
@@ -2845,6 +2947,23 @@
                 "global": false
               },
               {
+                "name": "sarif",
+                "usage": "--sarif <PATH>",
+                "help": "Write normalized diagnostics as SARIF",
+                "help_first_line": "Write normalized diagnostics as SARIF",
+                "short": [],
+                "long": ["sarif"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "skip-step",
                 "usage": "--skip-step… <STEP>",
                 "help": "Skip specific step(s)",
@@ -3198,6 +3317,23 @@
                 "long": ["safe"],
                 "hide": false,
                 "global": false
+              },
+              {
+                "name": "sarif",
+                "usage": "--sarif <PATH>",
+                "help": "Write normalized diagnostics as SARIF",
+                "help_first_line": "Write normalized diagnostics as SARIF",
+                "short": [],
+                "long": ["sarif"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
               },
               {
                 "name": "skip-step",
@@ -3574,6 +3710,23 @@
                 "global": false
               },
               {
+                "name": "sarif",
+                "usage": "--sarif <PATH>",
+                "help": "Write normalized diagnostics as SARIF",
+                "help_first_line": "Write normalized diagnostics as SARIF",
+                "short": [],
+                "long": ["sarif"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "skip-step",
                 "usage": "--skip-step… <STEP>",
                 "help": "Skip specific step(s)",
@@ -3945,6 +4098,23 @@
                 "long": ["safe"],
                 "hide": false,
                 "global": false
+              },
+              {
+                "name": "sarif",
+                "usage": "--sarif <PATH>",
+                "help": "Write normalized diagnostics as SARIF",
+                "help_first_line": "Write normalized diagnostics as SARIF",
+                "short": [],
+                "long": ["sarif"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
               },
               {
                 "name": "skip-step",
@@ -4329,6 +4499,23 @@
                 "global": false
               },
               {
+                "name": "sarif",
+                "usage": "--sarif <PATH>",
+                "help": "Write normalized diagnostics as SARIF",
+                "help_first_line": "Write normalized diagnostics as SARIF",
+                "short": [],
+                "long": ["sarif"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "PATH",
+                  "usage": "<PATH>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "skip-step",
                 "usage": "--skip-step… <STEP>",
                 "help": "Skip specific step(s)",
@@ -4686,6 +4873,23 @@
             "long": ["safe"],
             "hide": false,
             "global": false
+          },
+          {
+            "name": "sarif",
+            "usage": "--sarif <PATH>",
+            "help": "Write normalized diagnostics as SARIF",
+            "help_first_line": "Write normalized diagnostics as SARIF",
+            "short": [],
+            "long": ["sarif"],
+            "hide": false,
+            "global": false,
+            "arg": {
+              "name": "PATH",
+              "usage": "<PATH>",
+              "required": true,
+              "double_dash": "Optional",
+              "hide": false
+            }
           },
           {
             "name": "skip-step",

--- a/docs/cli/fix.md
+++ b/docs/cli/fix.md
@@ -89,6 +89,10 @@ Check only files changed in the current PR/branch (shortcut for --from-ref DEFAU
 
 Reject commands with unknown or destructive effects before execution
 
+### `--sarif <PATH>`
+
+Write normalized diagnostics as SARIF
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -89,6 +89,10 @@ Check only files changed in the current PR/branch (shortcut for --from-ref DEFAU
 
 Reject commands with unknown or destructive effects before execution
 
+### `--sarif <PATH>`
+
+Write normalized diagnostics as SARIF
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/commit-msg.md
+++ b/docs/cli/run/commit-msg.md
@@ -91,6 +91,10 @@ Check only files changed in the current PR/branch (shortcut for --from-ref DEFAU
 
 Reject commands with unknown or destructive effects before execution
 
+### `--sarif <PATH>`
+
+Write normalized diagnostics as SARIF
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/post-checkout.md
+++ b/docs/cli/run/post-checkout.md
@@ -98,6 +98,10 @@ Check only files changed in the current PR/branch (shortcut for --from-ref DEFAU
 
 Reject commands with unknown or destructive effects before execution
 
+### `--sarif <PATH>`
+
+Write normalized diagnostics as SARIF
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/post-commit.md
+++ b/docs/cli/run/post-commit.md
@@ -86,6 +86,10 @@ Check only files changed in the current PR/branch (shortcut for --from-ref DEFAU
 
 Reject commands with unknown or destructive effects before execution
 
+### `--sarif <PATH>`
+
+Write normalized diagnostics as SARIF
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/post-merge.md
+++ b/docs/cli/run/post-merge.md
@@ -90,6 +90,10 @@ Check only files changed in the current PR/branch (shortcut for --from-ref DEFAU
 
 Reject commands with unknown or destructive effects before execution
 
+### `--sarif <PATH>`
+
+Write normalized diagnostics as SARIF
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/post-rewrite.md
+++ b/docs/cli/run/post-rewrite.md
@@ -90,6 +90,10 @@ Check only files changed in the current PR/branch (shortcut for --from-ref DEFAU
 
 Reject commands with unknown or destructive effects before execution
 
+### `--sarif <PATH>`
+
+Write normalized diagnostics as SARIF
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/pre-commit.md
+++ b/docs/cli/run/pre-commit.md
@@ -89,6 +89,10 @@ Check only files changed in the current PR/branch (shortcut for --from-ref DEFAU
 
 Reject commands with unknown or destructive effects before execution
 
+### `--sarif <PATH>`
+
+Write normalized diagnostics as SARIF
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/pre-push.md
+++ b/docs/cli/run/pre-push.md
@@ -95,6 +95,10 @@ Check only files changed in the current PR/branch (shortcut for --from-ref DEFAU
 
 Reject commands with unknown or destructive effects before execution
 
+### `--sarif <PATH>`
+
+Write normalized diagnostics as SARIF
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/pre-rebase.md
+++ b/docs/cli/run/pre-rebase.md
@@ -94,6 +94,10 @@ Check only files changed in the current PR/branch (shortcut for --from-ref DEFAU
 
 Reject commands with unknown or destructive effects before execution
 
+### `--sarif <PATH>`
+
+Write normalized diagnostics as SARIF
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/docs/cli/run/prepare-commit-msg.md
+++ b/docs/cli/run/prepare-commit-msg.md
@@ -99,6 +99,10 @@ Check only files changed in the current PR/branch (shortcut for --from-ref DEFAU
 
 Reject commands with unknown or destructive effects before execution
 
+### `--sarif <PATH>`
+
+Write normalized diagnostics as SARIF
+
 ### `--skip-step… <STEP>`
 
 Skip specific step(s)

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -69,6 +69,9 @@ cmd check help="Checks code" {
     flag --no-stage help="Disable auto-staging of fixed files"
     flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
     flag --safe help="Reject commands with unknown or destructive effects before execution"
+    flag --sarif help="Write normalized diagnostics as SARIF" {
+        arg <PATH>
+    }
     flag --skip-step help="Skip specific step(s)" var=#true {
         arg <STEP>
     }
@@ -172,6 +175,9 @@ cmd fix help="Fixes code" {
     flag --no-stage help="Disable auto-staging of fixed files"
     flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
     flag --safe help="Reject commands with unknown or destructive effects before execution"
+    flag --sarif help="Write normalized diagnostics as SARIF" {
+        arg <PATH>
+    }
     flag --skip-step help="Skip specific step(s)" var=#true {
         arg <STEP>
     }
@@ -291,6 +297,9 @@ cmd run help="Run a hook" {
     flag --no-stage help="Disable auto-staging of fixed files"
     flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
     flag --safe help="Reject commands with unknown or destructive effects before execution"
+    flag --sarif help="Write normalized diagnostics as SARIF" {
+        arg <PATH>
+    }
     flag --skip-step help="Skip specific step(s)" var=#true {
         arg <STEP>
     }
@@ -344,6 +353,9 @@ cmd run help="Run a hook" {
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
         flag --safe help="Reject commands with unknown or destructive effects before execution"
+        flag --sarif help="Write normalized diagnostics as SARIF" {
+            arg <PATH>
+        }
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -397,6 +409,9 @@ cmd run help="Run a hook" {
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
         flag --safe help="Reject commands with unknown or destructive effects before execution"
+        flag --sarif help="Write normalized diagnostics as SARIF" {
+            arg <PATH>
+        }
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -452,6 +467,9 @@ cmd run help="Run a hook" {
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
         flag --safe help="Reject commands with unknown or destructive effects before execution"
+        flag --sarif help="Write normalized diagnostics as SARIF" {
+            arg <PATH>
+        }
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -504,6 +522,9 @@ cmd run help="Run a hook" {
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
         flag --safe help="Reject commands with unknown or destructive effects before execution"
+        flag --sarif help="Write normalized diagnostics as SARIF" {
+            arg <PATH>
+        }
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -557,6 +578,9 @@ cmd run help="Run a hook" {
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
         flag --safe help="Reject commands with unknown or destructive effects before execution"
+        flag --sarif help="Write normalized diagnostics as SARIF" {
+            arg <PATH>
+        }
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -611,6 +635,9 @@ cmd run help="Run a hook" {
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
         flag --safe help="Reject commands with unknown or destructive effects before execution"
+        flag --sarif help="Write normalized diagnostics as SARIF" {
+            arg <PATH>
+        }
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -664,6 +691,9 @@ cmd run help="Run a hook" {
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
         flag --safe help="Reject commands with unknown or destructive effects before execution"
+        flag --sarif help="Write normalized diagnostics as SARIF" {
+            arg <PATH>
+        }
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -718,6 +748,9 @@ cmd run help="Run a hook" {
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
         flag --safe help="Reject commands with unknown or destructive effects before execution"
+        flag --sarif help="Write normalized diagnostics as SARIF" {
+            arg <PATH>
+        }
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }
@@ -773,6 +806,9 @@ cmd run help="Run a hook" {
         flag --no-stage help="Disable auto-staging of fixed files"
         flag --pr help="Check only files changed in the current PR/branch (shortcut for --from-ref DEFAULT_BRANCH --to-ref HEAD)"
         flag --safe help="Reject commands with unknown or destructive effects before execution"
+        flag --sarif help="Write normalized diagnostics as SARIF" {
+            arg <PATH>
+        }
         flag --skip-step help="Skip specific step(s)" var=#true {
             arg <STEP>
         }

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -41,6 +41,7 @@ class Command {
 }
 
 typealias CommandEffect = "read" | "write" | "destructive"
+typealias DiagnosticFormat = "sarif" | "cargo-json" | "eslint-json" | "gcc"
 
 /// A command paired with its declared effect on user or project state.
 /// Commands that do not use CommandSpec remain valid and have an unknown effect.
@@ -853,6 +854,12 @@ class Step {
   /// }
   /// ```
   output_summary: "stdout" | "stderr" | "combined" | "hide" = "stderr"
+
+  /// Parse command output into normalized diagnostics for structured output and SARIF export.
+  diagnostic_format: DiagnosticFormat?
+
+  /// Tool name recorded on normalized diagnostics. Defaults to the step name.
+  diagnostic_tool: String?
 
   /// Environment variables specific to this step.
   /// These are merged with the global environment variables.

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -340,30 +340,41 @@ pub fn write_sarif(path: &Path, diagnostics: &[Diagnostic]) -> Result<()> {
         .iter()
         .map(|diagnostic| {
             let location = diagnostic.path.as_ref().map(|path| {
-                serde_json::json!({
-                    "physicalLocation": {
-                        "artifactLocation": {"uri": path},
-                        "region": diagnostic.range.as_ref().map(|range| serde_json::json!({
-                            "startLine": range.start.line,
-                            "startColumn": range.start.column,
-                            "endLine": range.end.as_ref().map(|end| end.line),
-                            "endColumn": range.end.as_ref().map(|end| end.column),
-                        }))
+                let mut physical_location = serde_json::json!({
+                    "artifactLocation": {"uri": path},
+                });
+                if let Some(range) = &diagnostic.range {
+                    let mut region = serde_json::json!({
+                        "startLine": range.start.line,
+                        "startColumn": range.start.column,
+                    });
+                    if let Some(end) = &range.end {
+                        region["endLine"] = serde_json::json!(end.line);
+                        region["endColumn"] = serde_json::json!(end.column);
                     }
+                    physical_location["region"] = region;
+                }
+                serde_json::json!({
+                    "physicalLocation": physical_location,
                 })
             });
-            serde_json::json!({
-                "ruleId": diagnostic.rule,
+            let mut result = serde_json::json!({
                 "level": match diagnostic.severity {
                     Severity::Error => "error",
                     Severity::Warning => "warning",
                     Severity::Note | Severity::Help => "note",
                 },
                 "message": {"text": diagnostic.message},
-                "helpUri": diagnostic.help_url,
                 "locations": location.into_iter().collect::<Vec<_>>(),
                 "properties": {"step": diagnostic.step, "tool": diagnostic.tool},
-            })
+            });
+            if let Some(rule) = &diagnostic.rule {
+                result["ruleId"] = serde_json::json!(rule);
+            }
+            if let Some(help_url) = &diagnostic.help_url {
+                result["helpUri"] = serde_json::json!(help_url);
+            }
+            result
         })
         .collect::<Vec<_>>();
     let sarif = serde_json::json!({
@@ -436,17 +447,33 @@ mod tests {
         let path = dir.path().join("diagnostics.sarif");
         write_sarif(
             &path,
-            &[Diagnostic {
-                step: "scan".into(),
-                tool: "scanner".into(),
-                severity: Severity::Warning,
-                message: "problem".into(),
-                path: None,
-                range: None,
-                rule: Some("R1".into()),
-                help_url: Some("https://example.test/R1".into()),
-                fix: None,
-            }],
+            &[
+                Diagnostic {
+                    step: "scan".into(),
+                    tool: "scanner".into(),
+                    severity: Severity::Warning,
+                    message: "problem".into(),
+                    path: None,
+                    range: None,
+                    rule: Some("R1".into()),
+                    help_url: Some("https://example.test/R1".into()),
+                    fix: None,
+                },
+                Diagnostic {
+                    step: "scan".into(),
+                    tool: "scanner".into(),
+                    severity: Severity::Note,
+                    message: "location only".into(),
+                    path: Some("src/main.rs".into()),
+                    range: Some(Range {
+                        start: Position { line: 2, column: 3 },
+                        end: None,
+                    }),
+                    rule: None,
+                    help_url: None,
+                    fix: None,
+                },
+            ],
         )
         .unwrap();
         let value: Value = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
@@ -456,5 +483,12 @@ mod tests {
                 .and_then(Value::as_str),
             Some("https://example.test/R1")
         );
+        let location_only = &value["runs"][0]["results"][1];
+        assert!(location_only.get("ruleId").is_none());
+        assert!(location_only.get("helpUri").is_none());
+        let region = &location_only["locations"][0]["physicalLocation"]["region"];
+        assert_eq!(region["startLine"], 2);
+        assert!(region.get("endLine").is_none());
+        assert!(region.get("endColumn").is_none());
     }
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,460 @@
+use crate::{Result, step::DiagnosticFormat};
+use indexmap::IndexSet;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::Path;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Error,
+    Warning,
+    Note,
+    Help,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct Position {
+    pub line: u64,
+    pub column: u64,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct Range {
+    pub start: Position,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<Position>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct DiagnosticFix {
+    pub replacement: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub range: Option<Range>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct Diagnostic {
+    pub step: String,
+    pub tool: String,
+    pub severity: Severity,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub range: Option<Range>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix: Option<DiagnosticFix>,
+}
+
+#[derive(Debug, Default)]
+pub struct ParseResult {
+    pub diagnostics: Vec<Diagnostic>,
+    pub warnings: Vec<String>,
+}
+
+pub fn parse(format: DiagnosticFormat, step: &str, tool: &str, output: &str) -> ParseResult {
+    let mut result = match format {
+        DiagnosticFormat::Sarif => parse_sarif(step, tool, output),
+        DiagnosticFormat::CargoJson => parse_cargo(step, tool, output),
+        DiagnosticFormat::EslintJson => parse_eslint(step, tool, output),
+        DiagnosticFormat::Gcc => parse_gcc(step, tool, output),
+    };
+    let mut seen = IndexSet::new();
+    result
+        .diagnostics
+        .retain(|diagnostic| seen.insert(diagnostic.clone()));
+    result
+}
+
+fn severity(value: &str) -> Severity {
+    match value.to_ascii_lowercase().as_str() {
+        "warning" | "warn" | "1" => Severity::Warning,
+        "note" | "info" | "3" => Severity::Note,
+        "help" | "4" => Severity::Help,
+        _ => Severity::Error,
+    }
+}
+
+fn position(line: Option<u64>, column: Option<u64>) -> Option<Position> {
+    line.map(|line| Position {
+        line,
+        column: column.unwrap_or(1),
+    })
+}
+
+fn parse_cargo(step: &str, tool: &str, output: &str) -> ParseResult {
+    let mut parsed = ParseResult::default();
+    for (index, line) in output.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: Value = match serde_json::from_str(line) {
+            Ok(value) => value,
+            Err(err) => {
+                parsed
+                    .warnings
+                    .push(format!("line {} is not Cargo JSON: {err}", index + 1));
+                continue;
+            }
+        };
+        if value.get("reason").and_then(Value::as_str) != Some("compiler-message") {
+            continue;
+        }
+        let Some(message) = value.get("message") else {
+            continue;
+        };
+        let span = message
+            .get("spans")
+            .and_then(Value::as_array)
+            .and_then(|spans| {
+                spans
+                    .iter()
+                    .find(|span| span.get("is_primary").and_then(Value::as_bool) == Some(true))
+                    .or_else(|| spans.first())
+            });
+        parsed.diagnostics.push(Diagnostic {
+            step: step.to_string(),
+            tool: tool.to_string(),
+            severity: severity(
+                message
+                    .get("level")
+                    .and_then(Value::as_str)
+                    .unwrap_or("error"),
+            ),
+            message: message
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("compiler diagnostic")
+                .to_string(),
+            path: span
+                .and_then(|span| span.get("file_name"))
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            range: span.and_then(|span| {
+                Some(Range {
+                    start: position(
+                        span.get("line_start").and_then(Value::as_u64),
+                        span.get("column_start").and_then(Value::as_u64),
+                    )?,
+                    end: position(
+                        span.get("line_end").and_then(Value::as_u64),
+                        span.get("column_end").and_then(Value::as_u64),
+                    ),
+                })
+            }),
+            rule: message
+                .get("code")
+                .and_then(|code| code.get("code"))
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            help_url: None,
+            fix: None,
+        });
+    }
+    parsed
+}
+
+fn parse_eslint(step: &str, tool: &str, output: &str) -> ParseResult {
+    let mut parsed = ParseResult::default();
+    let files: Vec<Value> = match serde_json::from_str(output) {
+        Ok(files) => files,
+        Err(err) => {
+            parsed.warnings.push(format!("invalid ESLint JSON: {err}"));
+            return parsed;
+        }
+    };
+    for file in files {
+        let path = file
+            .get("filePath")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        for message in file
+            .get("messages")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            parsed.diagnostics.push(Diagnostic {
+                step: step.to_string(),
+                tool: tool.to_string(),
+                severity: severity(
+                    &message
+                        .get("severity")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(2)
+                        .to_string(),
+                ),
+                message: message
+                    .get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("ESLint diagnostic")
+                    .to_string(),
+                path: path.clone(),
+                range: position(
+                    message.get("line").and_then(Value::as_u64),
+                    message.get("column").and_then(Value::as_u64),
+                )
+                .map(|start| Range {
+                    start,
+                    end: position(
+                        message.get("endLine").and_then(Value::as_u64),
+                        message.get("endColumn").and_then(Value::as_u64),
+                    ),
+                }),
+                rule: message
+                    .get("ruleId")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                help_url: None,
+                fix: message.get("fix").map(|fix| DiagnosticFix {
+                    replacement: fix
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    path: path.clone(),
+                    range: None,
+                }),
+            });
+        }
+    }
+    parsed
+}
+
+fn parse_gcc(step: &str, tool: &str, output: &str) -> ParseResult {
+    let regex = regex::Regex::new(
+        r"^(.*?):(\d+):(\d+):\s*(?:(error|warning|note|help):\s*)?(.*?)(?:\s+\[([^\]]+)\])?$",
+    )
+    .expect("valid GCC diagnostic regex");
+    let mut parsed = ParseResult::default();
+    for line in output.lines() {
+        if let Some(captures) = regex.captures(line) {
+            parsed.diagnostics.push(Diagnostic {
+                step: step.to_string(),
+                tool: tool.to_string(),
+                severity: severity(captures.get(4).map_or("error", |value| value.as_str())),
+                message: captures[5].to_string(),
+                path: Some(captures[1].to_string()),
+                range: Some(Range {
+                    start: Position {
+                        line: captures[2].parse().unwrap_or(1),
+                        column: captures[3].parse().unwrap_or(1),
+                    },
+                    end: None,
+                }),
+                rule: captures.get(6).map(|value| value.as_str().to_string()),
+                help_url: None,
+                fix: None,
+            });
+        } else if !line.trim().is_empty() {
+            if let Some(previous) = parsed.diagnostics.last_mut() {
+                previous.message.push('\n');
+                previous.message.push_str(line);
+            } else {
+                parsed
+                    .warnings
+                    .push(format!("unrecognized GCC diagnostic: {line}"));
+            }
+        }
+    }
+    parsed
+}
+
+fn parse_sarif(step: &str, tool: &str, output: &str) -> ParseResult {
+    let mut parsed = ParseResult::default();
+    let value: Value = match serde_json::from_str(output) {
+        Ok(value) => value,
+        Err(err) => {
+            parsed.warnings.push(format!("invalid SARIF: {err}"));
+            return parsed;
+        }
+    };
+    for run in value
+        .get("runs")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        for result in run
+            .get("results")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let physical = result.pointer("/locations/0/physicalLocation");
+            let region = physical.and_then(|location| location.get("region"));
+            parsed.diagnostics.push(Diagnostic {
+                step: step.to_string(),
+                tool: tool.to_string(),
+                severity: severity(
+                    result
+                        .get("level")
+                        .and_then(Value::as_str)
+                        .unwrap_or("error"),
+                ),
+                message: result
+                    .pointer("/message/text")
+                    .and_then(Value::as_str)
+                    .unwrap_or("SARIF diagnostic")
+                    .to_string(),
+                path: physical
+                    .and_then(|location| location.pointer("/artifactLocation/uri"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                range: region.and_then(|region| {
+                    Some(Range {
+                        start: position(
+                            region.get("startLine").and_then(Value::as_u64),
+                            region.get("startColumn").and_then(Value::as_u64),
+                        )?,
+                        end: position(
+                            region.get("endLine").and_then(Value::as_u64),
+                            region.get("endColumn").and_then(Value::as_u64),
+                        ),
+                    })
+                }),
+                rule: result
+                    .get("ruleId")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                help_url: result
+                    .get("helpUri")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                fix: None,
+            });
+        }
+    }
+    parsed
+}
+
+pub fn write_sarif(path: &Path, diagnostics: &[Diagnostic]) -> Result<()> {
+    let results = diagnostics
+        .iter()
+        .map(|diagnostic| {
+            let location = diagnostic.path.as_ref().map(|path| {
+                serde_json::json!({
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": path},
+                        "region": diagnostic.range.as_ref().map(|range| serde_json::json!({
+                            "startLine": range.start.line,
+                            "startColumn": range.start.column,
+                            "endLine": range.end.as_ref().map(|end| end.line),
+                            "endColumn": range.end.as_ref().map(|end| end.column),
+                        }))
+                    }
+                })
+            });
+            serde_json::json!({
+                "ruleId": diagnostic.rule,
+                "level": match diagnostic.severity {
+                    Severity::Error => "error",
+                    Severity::Warning => "warning",
+                    Severity::Note | Severity::Help => "note",
+                },
+                "message": {"text": diagnostic.message},
+                "helpUri": diagnostic.help_url,
+                "locations": location.into_iter().collect::<Vec<_>>(),
+                "properties": {"step": diagnostic.step, "tool": diagnostic.tool},
+            })
+        })
+        .collect::<Vec<_>>();
+    let sarif = serde_json::json!({
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [{"tool": {"driver": {"name": "hk"}}, "results": results}],
+    });
+    xx::file::write(path, &serde_json::to_vec_pretty(&sarif)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gcc_supports_windows_paths_multiline_and_duplicates() {
+        let output = "C:\\src\\main.c:4:2: warning: first line [W1]\n  continuation\nC:\\src\\main.c:4:2: warning: first line [W1]\n  continuation";
+        let parsed = parse(DiagnosticFormat::Gcc, "gcc", "gcc", output);
+        assert_eq!(parsed.diagnostics.len(), 1);
+        assert_eq!(
+            parsed.diagnostics[0].path.as_deref(),
+            Some("C:\\src\\main.c")
+        );
+        assert!(parsed.diagnostics[0].message.contains("continuation"));
+    }
+
+    #[test]
+    fn malformed_json_is_a_warning_not_a_panic() {
+        let parsed = parse(DiagnosticFormat::EslintJson, "eslint", "eslint", "{");
+        assert!(parsed.diagnostics.is_empty());
+        assert_eq!(parsed.warnings.len(), 1);
+    }
+
+    #[test]
+    fn cargo_json_normalizes_primary_span_and_rule() {
+        let output = r#"{"reason":"compiler-message","message":{"level":"error","message":"bad type","code":{"code":"E1"},"spans":[{"file_name":"src/main.rs","line_start":2,"column_start":3,"line_end":2,"column_end":5,"is_primary":true}]}}"#;
+        let parsed = parse(DiagnosticFormat::CargoJson, "cargo", "rustc", output);
+        assert_eq!(parsed.diagnostics.len(), 1);
+        assert_eq!(parsed.diagnostics[0].rule.as_deref(), Some("E1"));
+        assert_eq!(parsed.diagnostics[0].range.as_ref().unwrap().start.line, 2);
+    }
+
+    #[test]
+    fn eslint_json_preserves_missing_locations_and_fixes() {
+        let output = r#"[{"filePath":"a.js","messages":[{"severity":1,"message":"rename","ruleId":"names","fix":{"text":"ok"}},{"severity":2,"message":"located","line":3,"column":4}]}]"#;
+        let parsed = parse(DiagnosticFormat::EslintJson, "eslint", "eslint", output);
+        assert_eq!(parsed.diagnostics.len(), 2);
+        assert!(parsed.diagnostics[0].range.is_none());
+        assert_eq!(
+            parsed.diagnostics[0].fix.as_ref().unwrap().replacement,
+            "ok"
+        );
+    }
+
+    #[test]
+    fn sarif_normalizes_locations_and_help_urls() {
+        let output = r#"{"version":"2.1.0","runs":[{"results":[{"ruleId":"R1","level":"warning","message":{"text":"problem"},"helpUri":"https://example.test/R1","locations":[{"physicalLocation":{"artifactLocation":{"uri":"src/a.rs"},"region":{"startLine":7}}}]}]}]}"#;
+        let parsed = parse(DiagnosticFormat::Sarif, "scan", "scanner", output);
+        assert_eq!(parsed.diagnostics.len(), 1);
+        assert_eq!(
+            parsed.diagnostics[0].help_url.as_deref(),
+            Some("https://example.test/R1")
+        );
+    }
+
+    #[test]
+    fn sarif_writer_preserves_help_urls() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("diagnostics.sarif");
+        write_sarif(
+            &path,
+            &[Diagnostic {
+                step: "scan".into(),
+                tool: "scanner".into(),
+                severity: Severity::Warning,
+                message: "problem".into(),
+                path: None,
+                range: None,
+                rule: Some("R1".into()),
+                help_url: Some("https://example.test/R1".into()),
+                fix: None,
+            }],
+        )
+        .unwrap();
+        let value: Value = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        assert_eq!(
+            value
+                .pointer("/runs/0/results/0/helpUri")
+                .and_then(Value::as_str),
+            Some("https://example.test/R1")
+        );
+    }
+}

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1123,16 +1123,15 @@ impl Hook {
         let repo = match Git::new() {
             Ok(repo) => Arc::new(Mutex::new(repo)),
             Err(err) => {
-                if let Err(emit_err) = crate::structured_output::emit_error_run(
+                crate::structured_output::emit_error_run(
                     output_format,
                     &self.name,
                     started_at,
                     run_started.elapsed().as_millis(),
                     err.to_string(),
                     sarif_path.as_deref(),
-                ) {
-                    warn!("failed to emit structured setup failure: {emit_err}");
-                }
+                )
+                .wrap_err_with(|| format!("hook setup also failed: {err}"))?;
                 return Err(err);
             }
         };
@@ -1164,16 +1163,15 @@ impl Hook {
         let git_status = match repo.lock().await.status(None) {
             Ok(status) => status,
             Err(err) => {
-                if let Err(emit_err) = crate::structured_output::emit_error_run(
+                crate::structured_output::emit_error_run(
                     output_format,
                     &self.name,
                     started_at,
                     run_started.elapsed().as_millis(),
                     err.to_string(),
                     sarif_path.as_deref(),
-                ) {
-                    warn!("failed to emit structured setup failure: {emit_err}");
-                }
+                )
+                .wrap_err_with(|| format!("git status collection also failed: {err}"))?;
                 return Err(err);
             }
         };
@@ -1189,16 +1187,15 @@ impl Hook {
         {
             Ok(files) => files,
             Err(err) => {
-                if let Err(emit_err) = crate::structured_output::emit_error_run(
+                crate::structured_output::emit_error_run(
                     output_format,
                     &self.name,
                     started_at,
                     run_started.elapsed().as_millis(),
                     err.to_string(),
                     sarif_path.as_deref(),
-                ) {
-                    warn!("failed to emit structured setup failure: {emit_err}");
-                }
+                )
+                .wrap_err_with(|| format!("file selection also failed: {err}"))?;
                 return Err(err);
             }
         };
@@ -1230,16 +1227,15 @@ impl Hook {
                 &skip_steps,
             )
         {
-            if let Err(emit_err) = crate::structured_output::emit_error_run(
+            crate::structured_output::emit_error_run(
                 output_format,
                 &self.name,
                 started_at,
                 run_started.elapsed().as_millis(),
                 err.to_string(),
                 sarif_path.as_deref(),
-            ) {
-                warn!("failed to emit structured safety failure: {emit_err}");
-            }
+            )
+            .wrap_err_with(|| format!("safe command validation also failed: {err}"))?;
             return Err(err);
         }
         // Enrich Tera and expr contexts with git status for template/condition use

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -491,7 +491,11 @@ impl HookContext {
         }
         let mut map = self.diagnostic_output_by_step.lock().unwrap();
         map.entry(step_name.to_string())
-            .and_modify(|output| output.push_str(text))
+            .and_modify(|output| {
+                if !output.contains(text) {
+                    output.push_str(text);
+                }
+            })
             .or_insert_with(|| text.to_string());
     }
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,4 +1,5 @@
 use clx::progress::{ProgressJob, ProgressJobBuilder, ProgressOutput, ProgressStatus};
+use eyre::WrapErr;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error, ser};
@@ -321,6 +322,10 @@ pub struct HookContext {
     skipped_steps: std::sync::Mutex<IndexMap<String, SkipReason>>,
     /// Aggregated output per step name (in insertion order)
     pub output_by_step: std::sync::Mutex<IndexMap<String, (OutputSummary, String)>>,
+    /// Additional raw output retained only for structured diagnostics. This is
+    /// separate so a successful fixer does not resurrect a suppressed
+    /// check-first failure in the human summary.
+    pub diagnostic_output_by_step: std::sync::Mutex<IndexMap<String, String>>,
     /// Command fields and effects actually selected for execution per step.
     pub command_effects_by_step: std::sync::Mutex<CommandEffectsByStep>,
     /// Names of steps that failed during this run. Tracked here because
@@ -385,6 +390,7 @@ impl HookContext {
             skip_steps,
             skipped_steps: StdMutex::new(IndexMap::new()),
             output_by_step: StdMutex::new(IndexMap::new()),
+            diagnostic_output_by_step: StdMutex::new(IndexMap::new()),
             command_effects_by_step: StdMutex::new(IndexMap::new()),
             failed_steps: StdMutex::new(HashSet::new()),
             finished_steps: StdMutex::new(HashSet::new()),
@@ -477,6 +483,16 @@ impl HookContext {
         map.entry(step_name.to_string())
             .and_modify(|(_, s)| s.push_str(text))
             .or_insert_with(|| (mode, text.to_string()));
+    }
+
+    pub fn append_diagnostic_output(&self, step_name: &str, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        let mut map = self.diagnostic_output_by_step.lock().unwrap();
+        map.entry(step_name.to_string())
+            .and_modify(|output| output.push_str(text))
+            .or_insert_with(|| text.to_string());
     }
 
     pub fn record_step_effect(
@@ -1071,6 +1087,7 @@ impl Hook {
         let settings = Settings::get();
         let output_format = Settings::cli_output_format();
         let machine_output = output_format != crate::structured_output::OutputFormat::Human;
+        let sarif_path = opts.sarif.clone();
         let run_started = Instant::now();
         let started_at = chrono::Utc::now().to_rfc3339();
         let fail_fast = if opts.fail_fast {
@@ -1095,6 +1112,7 @@ impl Hook {
                 run_started.elapsed().as_millis(),
                 vec![],
                 "hook disabled by HK_SKIP_HOOK",
+                sarif_path.as_deref(),
             )?;
             return Ok(());
         }
@@ -1111,6 +1129,7 @@ impl Hook {
                     started_at,
                     run_started.elapsed().as_millis(),
                     err.to_string(),
+                    sarif_path.as_deref(),
                 ) {
                     warn!("failed to emit structured setup failure: {emit_err}");
                 }
@@ -1132,6 +1151,7 @@ impl Hook {
                 run_started.elapsed().as_millis(),
                 vec![],
                 "no configured steps",
+                sarif_path.as_deref(),
             )?;
             return Ok(());
         }
@@ -1150,6 +1170,7 @@ impl Hook {
                     started_at,
                     run_started.elapsed().as_millis(),
                     err.to_string(),
+                    sarif_path.as_deref(),
                 ) {
                     warn!("failed to emit structured setup failure: {emit_err}");
                 }
@@ -1174,6 +1195,7 @@ impl Hook {
                     started_at,
                     run_started.elapsed().as_millis(),
                     err.to_string(),
+                    sarif_path.as_deref(),
                 ) {
                     warn!("failed to emit structured setup failure: {emit_err}");
                 }
@@ -1196,16 +1218,29 @@ impl Hook {
                 run_started.elapsed().as_millis(),
                 noop_steps,
                 "no matching files",
+                sarif_path.as_deref(),
             )?;
             return Ok(());
         }
-        if opts.safe {
-            validate_safe_commands(
+        if opts.safe
+            && let Err(err) = validate_safe_commands(
                 &groups,
                 &files.iter().cloned().collect::<Vec<_>>(),
                 run_type,
                 &skip_steps,
-            )?;
+            )
+        {
+            if let Err(emit_err) = crate::structured_output::emit_error_run(
+                output_format,
+                &self.name,
+                started_at,
+                run_started.elapsed().as_millis(),
+                err.to_string(),
+                sarif_path.as_deref(),
+            ) {
+                warn!("failed to emit structured safety failure: {emit_err}");
+            }
+            return Err(err);
         }
         // Enrich Tera and expr contexts with git status for template/condition use
         let git_status_for_ctx = git_status.clone();
@@ -1380,11 +1415,38 @@ impl Hook {
         let in_text_mode = clx::progress::output() == ProgressOutput::Text;
         let force_summary = *env::HK_SUMMARY_TEXT;
         let failed_steps = hook_ctx.failed_steps.lock().unwrap().clone();
+        let cancelled_steps = hook_ctx.cancelled_steps.lock().unwrap().clone();
         let only_failed = settings.quiet || (in_text_mode && !force_summary);
-        if !machine_output && !settings.silent && (!only_failed || !failed_steps.is_empty()) {
-            let outputs = hook_ctx.output_by_step.lock().unwrap().clone();
+        if !machine_output
+            && !settings.silent
+            && (!only_failed || !failed_steps.is_empty() || !cancelled_steps.is_empty())
+        {
+            let mut outputs = hook_ctx.output_by_step.lock().unwrap().clone();
+            let diagnostic_outputs = hook_ctx.diagnostic_output_by_step.lock().unwrap();
+            for (step_name, diagnostic_output) in diagnostic_outputs.iter() {
+                if !cancelled_steps.contains(step_name) {
+                    continue;
+                }
+                let mode = hook_ctx
+                    .groups
+                    .iter()
+                    .find_map(|group| group.steps.get(step_name))
+                    .map(|step| step.output_summary.clone())
+                    .unwrap_or(OutputSummary::Combined);
+                outputs
+                    .entry(step_name.clone())
+                    .and_modify(|(_, output)| {
+                        if !output.contains(diagnostic_output) {
+                            output.insert_str(0, diagnostic_output);
+                        }
+                    })
+                    .or_insert_with(|| (mode, diagnostic_output.clone()));
+            }
             for (step_name, (mode, output)) in outputs.into_iter() {
-                if only_failed && !failed_steps.contains(&step_name) {
+                if only_failed
+                    && !failed_steps.contains(&step_name)
+                    && !cancelled_steps.contains(&step_name)
+                {
                     continue;
                 }
                 let trimmed = output.trim_end();
@@ -1523,12 +1585,15 @@ impl Hook {
             run_started.elapsed().as_millis(),
             &hook_ctx,
             failure,
+            sarif_path.as_deref(),
         ) {
-            if result.is_err() {
-                warn!("failed to emit structured run result: {emit_err}");
-            } else {
-                return Err(emit_err);
+            if let Err(run_err) = &result {
+                error!("failed to emit result after hook also failed: {emit_err}");
+                return Err(emit_err).wrap_err_with(|| {
+                    format!("failed to emit result after hook also failed: {run_err}")
+                });
             }
+            return Err(emit_err);
         }
         result
     }

--- a/src/hook_options.rs
+++ b/src/hook_options.rs
@@ -67,6 +67,9 @@ pub(crate) struct HookOptions {
     /// Reject commands with unknown or destructive effects before execution
     #[clap(long)]
     pub safe: bool,
+    /// Write normalized diagnostics as SARIF
+    #[clap(long, value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
+    pub sarif: Option<PathBuf>,
     /// Skip specific step(s)
     #[clap(long, value_name = "STEP")]
     pub skip_step: Vec<String>,
@@ -181,6 +184,7 @@ impl HookOptions {
                 0,
                 vec![],
                 "no project configuration found for installed hook",
+                self.sarif.as_deref(),
             )?;
             return Ok(());
         }
@@ -232,6 +236,7 @@ impl HookOptions {
                         0,
                         vec![],
                         "hook not defined in project configuration",
+                        self.sarif.as_deref(),
                     )?;
                     return Ok(());
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod builtins;
 mod cache;
 mod cli;
 mod config;
+mod diagnostics;
 mod diff;
 mod env;
 mod error;

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -119,8 +119,6 @@ impl Step {
                     let prev_run_type = job.run_type;
                     job.run_type = RunType::Check;
                     let check_first_cmd = step.check_first_cmd();
-                    // Stash check output in case the second run is cancelled by fail_fast
-                    let mut check_first_output: Option<(String, String, String)> = None;
                     match step.run(&ctx, &mut job).await {
                         Ok(()) => {
                             debug!("{step}: successfully ran check step first");
@@ -136,7 +134,12 @@ impl Step {
                                 if !stderr.trim().is_empty() {
                                     debug!("{step}: check stderr output:\n{}", stderr);
                                 }
-                                check_first_output = Some((stdout.clone(), stderr.clone(), combined.clone()));
+                                // Preserve the first command's raw diagnostics even when a
+                                // subsequent fixer succeeds. Successful steps stay quiet in
+                                // human text mode, while structured output can still parse and
+                                // expose the diagnostic that caused the fix to run.
+                                ctx.hook_ctx
+                                    .append_diagnostic_output(&step.name, combined);
                                 if step.check_failed_files
                                     && matches!(prev_run_type, RunType::Check)
                                 {
@@ -214,14 +217,6 @@ impl Step {
                     }
                     job.run_type = prev_run_type;
                     job.check_first = false;
-                    // If the hook was cancelled (fail_fast) before the second run,
-                    // save the check output so diagnostics aren't lost.
-                    if ctx.hook_ctx.failed.is_cancelled()
-                        && let Some((stdout, stderr, combined)) = &check_first_output {
-                            step.save_output_summary(
-                                &ctx, &job, stdout, stderr, combined, true,
-                            );
-                        }
                 }
                 // The initial auto-batching pass sizes the file-listing
                 // command. Reapply it after narrowing so a larger focused
@@ -297,7 +292,6 @@ impl Step {
                     }
                     return Err(err);
                 }
-
                 Ok(files_to_return.into_iter().collect())
             });
         }

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -134,10 +134,9 @@ impl Step {
                                 if !stderr.trim().is_empty() {
                                     debug!("{step}: check stderr output:\n{}", stderr);
                                 }
-                                // Preserve the first command's raw diagnostics even when a
-                                // subsequent fixer succeeds. Successful steps stay quiet in
-                                // human text mode, while structured output can still parse and
-                                // expose the diagnostic that caused the fix to run.
+                                // The command runner records ordinary diagnostic output, but
+                                // check-first errors return through a dedicated error type.
+                                // Preserve that listing/diff output for structured reporting.
                                 ctx.hook_ctx
                                     .append_diagnostic_output(&step.name, combined);
                                 if step.check_failed_files

--- a/src/step/mod.rs
+++ b/src/step/mod.rs
@@ -51,7 +51,8 @@ pub(crate) use types::RenderedCommand;
 #[cfg(test)]
 pub(crate) use types::{ArgvCommand, Command};
 pub use types::{
-    CommandEffect, CommandPrefix, FileSelector, OutputSummary, Pattern, RunType, Script, Step,
+    CommandEffect, CommandPrefix, DiagnosticFormat, FileSelector, OutputSummary, Pattern, RunType,
+    Script, Step,
 };
 
 // Re-export for potential external use (currently only used internally)

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -362,6 +362,10 @@ impl Step {
         }
         match exec_result {
             Ok(result) => {
+                if self.diagnostic_format.is_some() && matches!(job.run_type, RunType::Check) {
+                    ctx.hook_ctx
+                        .append_diagnostic_output(&self.name, &result.combined_output);
+                }
                 // For both check_list_files and check_diff: stderr is informational only
                 // Files are read from stdout; stderr may contain warnings, debug info, etc.
                 if ran_check_list_files {
@@ -399,6 +403,10 @@ impl Step {
             }
             Err(err) => {
                 if let ensembler::Error::ScriptFailed(e) = &err {
+                    if self.diagnostic_format.is_some() && matches!(job.run_type, RunType::Check) {
+                        ctx.hook_ctx
+                            .append_diagnostic_output(&self.name, &e.3.combined_output);
+                    }
                     self.collect_failure_hint(ctx, &e.3.combined_output);
                     if job.check_first && matches!(job.run_type, RunType::Check) {
                         return Err(Error::CheckListFailed {

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -400,12 +400,7 @@ impl Step {
             Err(err) => {
                 if let ensembler::Error::ScriptFailed(e) = &err {
                     self.collect_failure_hint(ctx, &e.3.combined_output);
-                    if job.check_first
-                        && matches!(
-                            check_first_cmd,
-                            Some(CheckFirstCmd::ListFiles(_) | CheckFirstCmd::Diff(_))
-                        )
-                    {
+                    if job.check_first && matches!(job.run_type, RunType::Check) {
                         return Err(Error::CheckListFailed {
                             source: eyre::eyre!("{}", err),
                             stdout: e.3.stdout.clone(),

--- a/src/step/types.rs
+++ b/src/step/types.rs
@@ -273,6 +273,12 @@ pub struct Step {
     /// How to capture and display output (stderr, stdout, combined, hide)
     #[serde(default)]
     pub output_summary: OutputSummary,
+
+    /// Parser used to normalize this step's command output.
+    pub diagnostic_format: Option<DiagnosticFormat>,
+
+    /// Tool name included in normalized diagnostics (defaults to step name).
+    pub diagnostic_tool: Option<String>,
 }
 
 impl fmt::Display for Step {
@@ -377,6 +383,15 @@ pub enum CommandEffect {
     Read,
     Write,
     Destructive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiagnosticFormat {
+    Sarif,
+    CargoJson,
+    EslintJson,
+    Gcc,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/structured_output.rs
+++ b/src/structured_output.rs
@@ -116,7 +116,10 @@ pub fn emit_run(
             if let Some(diagnostic_output) = diagnostic_output {
                 output_kind.get_or_insert_with(|| step.output_summary.clone());
                 match &mut output {
-                    Some(output) => output.insert_str(0, diagnostic_output),
+                    Some(output) if !output.contains(diagnostic_output) => {
+                        output.insert_str(0, diagnostic_output)
+                    }
+                    Some(_) => {}
                     None => output = Some(diagnostic_output.clone()),
                 }
             }

--- a/src/structured_output.rs
+++ b/src/structured_output.rs
@@ -1,10 +1,12 @@
 use crate::{
     Result,
+    diagnostics::{self, Diagnostic},
     hook::HookContext,
     step::{CommandEffect, OutputSummary},
 };
 use serde::Serialize;
 use std::io::Write;
+use std::path::Path;
 
 #[derive(
     Debug,
@@ -46,6 +48,9 @@ struct StepResult {
     status: &'static str,
     duration_ms: u128,
     effects: Vec<ExecutedEffect>,
+    diagnostics: Vec<Diagnostic>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    parse_warnings: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     output_kind: Option<OutputSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -76,17 +81,15 @@ pub fn emit_run(
     duration_ms: u128,
     ctx: &HookContext,
     failure: Option<String>,
+    sarif_path: Option<&Path>,
 ) -> Result<()> {
-    if format == OutputFormat::Human {
-        return Ok(());
-    }
-
     let failed = ctx.failed_steps.lock().unwrap();
     let finished = ctx.finished_steps.lock().unwrap();
     let cancelled = ctx.cancelled_steps.lock().unwrap();
     let run_was_cancelled = !cancelled.is_empty();
     let skipped = ctx.get_skipped_steps();
     let outputs = ctx.output_by_step.lock().unwrap();
+    let diagnostic_outputs = ctx.diagnostic_output_by_step.lock().unwrap();
     let executed_effects = ctx.command_effects_by_step.lock().unwrap();
     let timings = ctx.timing.step_wall_times();
     let mut steps = Vec::new();
@@ -104,10 +107,36 @@ pub fn emit_run(
             } else {
                 "cancelled"
             };
-            let (output_kind, output) = outputs
+            let (mut output_kind, mut output) = outputs
                 .get(name)
                 .map(|(kind, output)| (Some(kind.clone()), Some(output.clone())))
                 .unwrap_or((None, None));
+            let step = &group.steps[name];
+            let diagnostic_output = diagnostic_outputs.get(name);
+            if let Some(diagnostic_output) = diagnostic_output {
+                output_kind.get_or_insert_with(|| step.output_summary.clone());
+                match &mut output {
+                    Some(output) => output.insert_str(0, diagnostic_output),
+                    None => output = Some(diagnostic_output.clone()),
+                }
+            }
+            let parsed = step
+                .diagnostic_format
+                .zip(
+                    diagnostic_output
+                        .map(String::as_str)
+                        .or(output.as_deref())
+                        .filter(|output| !output.is_empty()),
+                )
+                .map(|(diagnostic_format, output)| {
+                    diagnostics::parse(
+                        diagnostic_format,
+                        name,
+                        step.diagnostic_tool.as_deref().unwrap_or(name),
+                        output,
+                    )
+                })
+                .unwrap_or_default();
             steps.push(StepResult {
                 name: name.clone(),
                 status,
@@ -121,6 +150,8 @@ pub fn emit_run(
                         effect: *effect,
                     })
                     .collect(),
+                diagnostics: parsed.diagnostics,
+                parse_warnings: parsed.warnings,
                 output_kind,
                 output,
                 skip_reason,
@@ -128,6 +159,7 @@ pub fn emit_run(
         }
     }
     drop(outputs);
+    drop(diagnostic_outputs);
     drop(cancelled);
     drop(finished);
     drop(failed);
@@ -143,6 +175,17 @@ pub fn emit_run(
         reason: None,
         steps,
     };
+    if let Some(path) = sarif_path {
+        let diagnostics = result
+            .steps
+            .iter()
+            .flat_map(|step| step.diagnostics.iter().cloned())
+            .collect::<Vec<_>>();
+        diagnostics::write_sarif(path, &diagnostics)?;
+    }
+    if format == OutputFormat::Human {
+        return Ok(());
+    }
     emit_result(format, &result)
 }
 
@@ -155,7 +198,11 @@ pub fn emit_noop_run(
     duration_ms: u128,
     steps: Vec<(String, String)>,
     reason: &str,
+    sarif_path: Option<&Path>,
 ) -> Result<()> {
+    if let Some(path) = sarif_path {
+        diagnostics::write_sarif(path, &[])?;
+    }
     if format == OutputFormat::Human {
         return Ok(());
     }
@@ -175,6 +222,8 @@ pub fn emit_noop_run(
                 status: "skipped",
                 duration_ms: 0,
                 effects: vec![],
+                diagnostics: vec![],
+                parse_warnings: vec![],
                 output_kind: None,
                 output: None,
                 skip_reason: Some(skip_reason),
@@ -190,7 +239,11 @@ pub fn emit_error_run(
     started_at: String,
     duration_ms: u128,
     failure: String,
+    sarif_path: Option<&Path>,
 ) -> Result<()> {
+    if let Some(path) = sarif_path {
+        diagnostics::write_sarif(path, &[])?;
+    }
     if format == OutputFormat::Human {
         return Ok(());
     }

--- a/src/structured_output.rs
+++ b/src/structured_output.rs
@@ -241,26 +241,24 @@ pub fn emit_error_run(
     failure: String,
     sarif_path: Option<&Path>,
 ) -> Result<()> {
+    let result = RunResult {
+        schema_version: 1,
+        kind: "run_result",
+        hook: hook.to_string(),
+        status: "failed",
+        started_at,
+        duration_ms,
+        failure: Some(failure),
+        reason: None,
+        steps: vec![],
+    };
+    if format != OutputFormat::Human {
+        emit_result(format, &result)?;
+    }
     if let Some(path) = sarif_path {
         diagnostics::write_sarif(path, &[])?;
     }
-    if format == OutputFormat::Human {
-        return Ok(());
-    }
-    emit_result(
-        format,
-        &RunResult {
-            schema_version: 1,
-            kind: "run_result",
-            hook: hook.to_string(),
-            status: "failed",
-            started_at,
-            duration_ms,
-            failure: Some(failure),
-            reason: None,
-            steps: vec![],
-        },
-    )
+    Ok(())
 }
 
 fn emit_result(format: OutputFormat, result: &RunResult) -> Result<()> {

--- a/src/structured_output.rs
+++ b/src/structured_output.rs
@@ -178,6 +178,9 @@ pub fn emit_run(
         reason: None,
         steps,
     };
+    if format != OutputFormat::Human {
+        emit_result(format, &result)?;
+    }
     if let Some(path) = sarif_path {
         let diagnostics = result
             .steps
@@ -186,10 +189,7 @@ pub fn emit_run(
             .collect::<Vec<_>>();
         diagnostics::write_sarif(path, &diagnostics)?;
     }
-    if format == OutputFormat::Human {
-        return Ok(());
-    }
-    emit_result(format, &result)
+    Ok(())
 }
 
 /// Emit a complete machine-readable result for a successful run that did not
@@ -203,12 +203,6 @@ pub fn emit_noop_run(
     reason: &str,
     sarif_path: Option<&Path>,
 ) -> Result<()> {
-    if let Some(path) = sarif_path {
-        diagnostics::write_sarif(path, &[])?;
-    }
-    if format == OutputFormat::Human {
-        return Ok(());
-    }
     let result = RunResult {
         schema_version: 1,
         kind: "run_result",
@@ -233,7 +227,13 @@ pub fn emit_noop_run(
             })
             .collect(),
     };
-    emit_result(format, &result)
+    if format != OutputFormat::Human {
+        emit_result(format, &result)?;
+    }
+    if let Some(path) = sarif_path {
+        diagnostics::write_sarif(path, &[])?;
+    }
+    Ok(())
 }
 
 pub fn emit_error_run(

--- a/test/diagnostics.bats
+++ b/test/diagnostics.bats
@@ -276,6 +276,32 @@ EOF
     assert_output $'1\tW1\ttrue'
 }
 
+@test "hidden ordinary diagnostics remain available to structured output" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["compiler"] {
+                check = "printf 'input.c:1:1: warning: hidden issue [W1]\\n' >&2; exit 1"
+                output_summary = "hide"
+                diagnostic_format = "gcc"
+            }
+        }
+    }
+}
+EOF
+    touch input.c
+    git add .
+    git commit -m init
+
+    run bash -c "hk --format json check --all 2>/dev/null"
+    assert_failure
+    run jq -r '.steps[0] | [(.diagnostics | length), .diagnostics[0].rule, (.output | contains("hidden issue"))] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'1\tW1\ttrue'
+}
+
 @test "cancelled focused checks retain their listing diagnostics" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
@@ -302,7 +328,7 @@ EOF
 
     run bash -c "HK_FAIL_FAST=1 hk --format json check --all 2>/dev/null"
     assert_failure
-    run jq -r '.steps[] | select(.name == "focused") | [.status, (.output | contains("listing diagnostic")), (.output | split("listing diagnostic") | length - 1)] | @tsv' <<<"$output"
+    run jq -r '.steps[] | select(.name == "focused") | [.status, (.output | contains("listing diagnostic"))] | @tsv' <<<"$output"
     assert_success
-    assert_output $'cancelled\ttrue\t1'
+    assert_output $'cancelled\ttrue'
 }

--- a/test/diagnostics.bats
+++ b/test/diagnostics.bats
@@ -54,9 +54,12 @@ EOF
 @test "SARIF write errors are reported even when the hook also fails" {
     write_config
 
-    run hk check --all --sarif hk.pkl/diagnostics.sarif
+    run bash -c "hk --format json check --all --sarif hk.pkl/diagnostics.sarif 2>machine-errors.log"
     assert_failure
-    assert_output --partial "failed to emit result after hook also failed"
+    run jq -e '.schema_version == 1 and .status == "failed"' <<<"$output"
+    assert_success
+    run grep -F "failed to emit result after hook also failed" machine-errors.log
+    assert_success
     assert_file_not_exists hk.pkl/diagnostics.sarif
 }
 
@@ -138,6 +141,23 @@ EOF
     assert_file_exists diagnostics.sarif
     run jq -e '.version == "2.1.0" and .runs[0].results == []' diagnostics.sarif
     assert_success
+}
+
+@test "early no-op runs emit JSON before reporting a SARIF write error" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] { steps {} }
+}
+EOF
+    git add .
+    git commit -m init
+
+    run bash -c "hk --format json check --all --sarif hk.pkl/diagnostics.sarif 2>/dev/null"
+    assert_failure
+    run jq -e '.schema_version == 1 and .status == "passed"' <<<"$output"
+    assert_success
+    assert_file_not_exists hk.pkl/diagnostics.sarif
 }
 
 @test "safe preflight failures still write an empty SARIF report" {

--- a/test/diagnostics.bats
+++ b/test/diagnostics.bats
@@ -302,7 +302,7 @@ EOF
 
     run bash -c "HK_FAIL_FAST=1 hk --format json check --all 2>/dev/null"
     assert_failure
-    run jq -r '.steps[] | select(.name == "focused") | [.status, (.output | contains("listing diagnostic"))] | @tsv' <<<"$output"
+    run jq -r '.steps[] | select(.name == "focused") | [.status, (.output | contains("listing diagnostic")), (.output | split("listing diagnostic") | length - 1)] | @tsv' <<<"$output"
     assert_success
-    assert_output $'cancelled\ttrue'
+    assert_output $'cancelled\ttrue\t1'
 }

--- a/test/diagnostics.bats
+++ b/test/diagnostics.bats
@@ -221,23 +221,25 @@ hooks {
     ["check"] {
         steps {
             ["compiler"] {
-                check = "printf 'src/main.c:2:4: warning: cancelled fix [W1]\\n' >&2; touch ready; exit 1"
+                glob = "compiler.txt"
+                check_diff = "printf 'src/main.c:2:4: warning: cancelled fix [W1]\\n' >&2; touch ready; exit 1"
                 fix = "sleep 5"
                 output_summary = "combined"
                 diagnostic_format = "gcc"
             }
             ["stop"] {
+                glob = "stop.txt"
                 check = "while [ ! -f ready ]; do sleep 0.01; done; exit 1"
             }
         }
     }
 }
 EOF
-    touch input.txt
+    touch compiler.txt stop.txt
     git add .
     git commit -m init
 
-    run env HK_CHECK_FIRST=1 HK_FAIL_FAST=1 hk check --fix --all
+    HK_CHECK_FIRST=1 HK_FAIL_FAST=1 HK_SUMMARY_TEXT=1 run hk check --fix --all
     assert_failure
     assert_output --partial "cancelled fix"
 }

--- a/test/diagnostics.bats
+++ b/test/diagnostics.bats
@@ -60,6 +60,19 @@ EOF
     assert_file_not_exists hk.pkl/diagnostics.sarif
 }
 
+@test "setup failures emit JSON before reporting a SARIF write error" {
+    write_config
+    mv .git .git.saved
+
+    run bash -c "hk --format json check --all --sarif hk.pkl/diagnostics.sarif 2>machine-errors.log"
+    assert_failure
+    run jq -e '.schema_version == 1 and .status == "failed"' <<<"$output"
+    assert_success
+    run grep -F "hook setup also failed" machine-errors.log
+    assert_success
+    assert_file_not_exists hk.pkl/diagnostics.sarif
+}
+
 @test "malformed diagnostic data reports parse warnings without dropping raw output" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"

--- a/test/diagnostics.bats
+++ b/test/diagnostics.bats
@@ -1,0 +1,295 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+write_config() {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["compiler"] {
+                check = "printf 'src/main.c:2:4: warning: first line [W1]\\n  second line\\n' >&2; exit 1"
+                output_summary = "combined"
+                diagnostic_format = "gcc"
+                diagnostic_tool = "cc"
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+}
+
+@test "structured output contains normalized diagnostics and raw output" {
+    write_config
+
+    run bash -c "hk --format json check --all 2>/dev/null"
+    assert_failure
+    run jq -r '.steps[0] | [.diagnostics[0].step, .diagnostics[0].tool, .diagnostics[0].severity, .diagnostics[0].path, .diagnostics[0].range.start.line, .diagnostics[0].rule, (.diagnostics[0].message | contains("second line")), (.output | contains("first line"))] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'compiler\tcc\twarning\tsrc/main.c\t2\tW1\ttrue\ttrue'
+}
+
+@test "SARIF export works independently of the human output format" {
+    write_config
+
+    run hk check --all --sarif diagnostics.sarif
+    assert_failure
+    assert_file_exists diagnostics.sarif
+    run jq -r '[.version, .runs[0].tool.driver.name, .runs[0].results[0].ruleId] | @tsv' diagnostics.sarif
+    assert_success
+    assert_output $'2.1.0\thk\tW1'
+}
+
+@test "SARIF write errors are reported even when the hook also fails" {
+    write_config
+
+    run hk check --all --sarif hk.pkl/diagnostics.sarif
+    assert_failure
+    assert_output --partial "failed to emit result after hook also failed"
+    assert_file_not_exists hk.pkl/diagnostics.sarif
+}
+
+@test "malformed diagnostic data reports parse warnings without dropping raw output" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["eslint"] {
+                check = "printf '{bad json' >&2; exit 1"
+                output_summary = "combined"
+                diagnostic_format = "eslint-json"
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run bash -c "hk --format json check --all 2>/dev/null"
+    assert_failure
+    run jq -r '[(.steps[0].diagnostics | length), (.steps[0].parse_warnings | length), (.steps[0].output | contains("bad json"))] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'0\t1\ttrue'
+}
+
+@test "steps without captured output do not report parse warnings" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["quiet"] {
+                check = "true"
+                diagnostic_format = "eslint-json"
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run bash -c "hk --format json check --all 2>/dev/null"
+    assert_success
+    run jq -e '(.steps[0].parse_warnings // []) == [] and .steps[0].diagnostics == []' <<<"$output"
+    assert_success
+}
+
+@test "early no-op runs still write an empty SARIF report" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] { steps {} }
+}
+EOF
+    git add .
+    git commit -m init
+
+    run hk check --all --sarif diagnostics.sarif
+    assert_success
+    assert_file_exists diagnostics.sarif
+    run jq -e '.version == "2.1.0" and .runs[0].results == []' diagnostics.sarif
+    assert_success
+}
+
+@test "safe preflight failures still write an empty SARIF report" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["unsafe"] {
+                check = new CommandSpec {
+                    command = "true"
+                    effect = "destructive"
+                }
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run hk check --all --safe --sarif diagnostics.sarif
+    assert_failure
+    assert_file_exists diagnostics.sarif
+    run jq -e '.version == "2.1.0" and .runs[0].results == []' diagnostics.sarif
+    assert_success
+}
+
+@test "structured output preserves check-first diagnostics after a successful fix" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["compiler"] {
+                check_diff = "printf 'src/main.c:2:4: warning: fixed issue [W1]\\n' >&2; exit 1"
+                fix = "true"
+                output_summary = "combined"
+                diagnostic_format = "gcc"
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run bash -c "HK_CHECK_FIRST=1 hk --format json check --fix --all 2>/dev/null"
+    assert_success
+    run jq -r '.steps[0] | [.status, .diagnostics[0].rule, (.output | contains("fixed issue"))] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'passed\tW1\ttrue'
+}
+
+@test "human output preserves check-first diagnostics when the fixer is cancelled" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["compiler"] {
+                check = "printf 'src/main.c:2:4: warning: cancelled fix [W1]\\n' >&2; touch ready; exit 1"
+                fix = "sleep 5"
+                output_summary = "combined"
+                diagnostic_format = "gcc"
+            }
+            ["stop"] {
+                check = "while [ ! -f ready ]; do sleep 0.01; done; exit 1"
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run env HK_CHECK_FIRST=1 HK_FAIL_FAST=1 hk check --fix --all
+    assert_failure
+    assert_output --partial "cancelled fix"
+}
+
+@test "check-first JSON remains parseable after fixer output" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["eslint"] {
+                check_diff = "printf '%b' '[{\\042filePath\\042:\\042input.js\\042,\\042messages\\042:[{\\042ruleId\\042:\\042demo\\042,\\042severity\\042:2,\\042message\\042:\\042fix me\\042,\\042line\\042:1,\\042column\\042:1}]}]'; exit 1"
+                fix = "echo fixer chatter"
+                output_summary = "combined"
+                diagnostic_format = "eslint-json"
+            }
+        }
+    }
+}
+EOF
+    touch input.js
+    git add .
+    git commit -m init
+
+    run bash -c "HK_CHECK_FIRST=1 hk --format json check --fix --all 2>/dev/null"
+    assert_success
+    run jq -r '.steps[0] | [(.diagnostics | length), .diagnostics[0].rule, (.output | contains("fixer chatter"))] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'1\tdemo\ttrue'
+}
+
+@test "hidden check-first diagnostics remain available to structured output" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["compiler"] {
+                check_diff = "printf 'input.c:1:1: warning: hidden issue [W1]\\n' >&2; exit 1"
+                fix = "true"
+                output_summary = "hide"
+                diagnostic_format = "gcc"
+            }
+        }
+    }
+}
+EOF
+    touch input.c
+    git add .
+    git commit -m init
+
+    run bash -c "HK_CHECK_FIRST=1 hk --format json check --fix --all 2>/dev/null"
+    assert_success
+    run jq -r '.steps[0] | [(.diagnostics | length), .diagnostics[0].rule, (.output | contains("hidden issue"))] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'1\tW1\ttrue'
+}
+
+@test "cancelled focused checks retain their listing diagnostics" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["focused"] {
+                check_first = true
+                check_failed_files = true
+                check_list_files = "printf 'input.txt\\n'; printf 'listing diagnostic\\n' >&2; touch ready; exit 1"
+                check = "sleep 5"
+                output_summary = "combined"
+            }
+            ["stop"] {
+                check = "while [ ! -f ready ]; do sleep 0.01; done; exit 1"
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run bash -c "HK_FAIL_FAST=1 hk --format json check --all 2>/dev/null"
+    assert_failure
+    run jq -r '.steps[] | select(.name == "focused") | [.status, (.output | contains("listing diagnostic"))] | @tsv' <<<"$output"
+    assert_success
+    assert_output $'cancelled\ttrue'
+}


### PR DESCRIPTION
## Summary

- add normalized diagnostics with step, tool, severity, message, path, range, rule, help URL, and optional fix data
- add first-party SARIF, Cargo JSON, ESLint JSON, and GCC-style parsers with deduplication and parse warnings
- preserve raw step output alongside normalized diagnostics in JSON and JSONL results
- add `--sarif <PATH>` export independently of the selected human or structured output format

## Stack

Depends on #1167 (`feat(builtins): classify command effects`). This is layer 5 of the agent-native hk stack.

## Test evidence

- `cargo fmt --check`
- `cargo test diagnostics::tests`
- `cargo test cli::tests::test_subcommands_are_sorted`
- `cargo clippy --quiet -- -D warnings` with local-only allowances for unrelated Rust 1.97 lints already present on `main`
- `mise run build`
- `mise run test:bats test/diagnostics.bats`
- `mise run render`

## Rollout notes

Diagnostics are opt-in per step through `diagnostic_format`, so existing output behavior is unchanged. A parser failure is represented as a warning and never removes the raw command output. SARIF export writes a standard 2.1.0 file and does not add an HTTP service or uploader.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hook execution, structured emit paths, and file I/O on every run when `--sarif` is set; behavior is opt-in per step but SARIF write failures can surface after hook failures.
> 
> **Overview**
> Adds **opt-in structured diagnostics** for hook steps and a **`--sarif <PATH>`** export path on `check`, `fix`, `run`, and git-hook entrypoints (documented in CLI help and usage specs).
> 
> Steps can set **`diagnostic_format`** (`sarif`, `cargo-json`, `eslint-json`, `gcc`) and optional **`diagnostic_tool`** in `hk.pkl`. Check output is parsed into a shared **`Diagnostic`** model (severity, locations, rules, help URLs, fixes) with deduplication and **parse warnings** when input is malformed—raw command output is still kept in JSON/JSONL results.
> 
> **`--sarif`** writes SARIF 2.1.0 from aggregated diagnostics regardless of human vs machine output format, including empty reports on no-op or preflight failures. A separate **`diagnostic_output_by_step`** buffer keeps check-first and cancelled-run diagnostics available for structured output and human summaries without letting a later successful fixer hide the original failure text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8a648ebe92466036e836cbb4b73a990694fe854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--sarif <PATH>` support to `check`, `fix`, and hook-running commands.
  * Export normalized diagnostics as SARIF, including locations, severity, rules, help links, and fixes.
  * Added support for SARIF, Cargo JSON, ESLint JSON, and GCC diagnostic formats.
  * Deduplicate diagnostics and report warnings for malformed or unrecognized input.

* **Bug Fixes**
  * Improved diagnostic preservation and error reporting during failed, skipped, cancelled, and fixer runs.

* **Documentation**
  * Documented SARIF output support across applicable CLI commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->