### PR TITLE
fix(step): support argv prefixes for structured commands

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,7 +138,10 @@ The first `argv` entry is the executable, which hk resolves using `PATH`. Each r
 
 Structured commands preserve argument boundaries, so filenames containing spaces or shell metacharacters are passed literally. Shell syntax is not interpreted: entries such as `"*"`, `"$HOME"`, `"|"`, and `">"` remain literal arguments. Use a string command if shell interpretation is required.
 
-Structured commands cannot be combined with the step's `shell` or `prefix` options. Other step behavior, including `dir`, `env`, and automatic batching for large file lists, continues to apply.
+Structured commands cannot be combined with the step's `shell` option or a string
+`prefix`. Use an argv-list prefix such as `List("mise", "x", "--")` when the
+structured command should run through a launcher. Other step behavior, including
+`dir`, `env`, and automatic batching for large file lists, continues to apply.
 
 ### Focus checks on failing files
 
@@ -201,7 +204,7 @@ Groups may define a small set of step settings that child steps inherit when the
 | Group option          | Inherited step option | Type                                 |
 | --------------------- | --------------------- | ------------------------------------ |
 | `dir`                 | `dir`                 | `String?`                            |
-| `prefix`              | `prefix`              | `String?`                            |
+| `prefix`              | `prefix`              | `(String \| List<String>)?`          |
 | `workspace_indicator` | `workspace_indicator` | `String?`                            |
 | `shell`               | `shell`               | `(String \| Script)?`                |
 | `stage`               | `stage`               | `(String \| List<String>)?`          |
@@ -226,6 +229,19 @@ local frontend = new Group {
 ```
 
 In this example, `prettier` inherits `dir = "packages/frontend"` and `prefix = "mise x --"`. `eslint` keeps its explicit `dir = "different/path"` and still inherits `prefix = "mise x --"`.
+
+String prefixes are shell syntax and can only be used with string commands. For a
+structured command, use a list so each prefix argument retains its boundary:
+
+```pkl
+["ruff"] = (Builtins.ruff) {
+    prefix = List("mise", "x", "--")
+}
+```
+
+An argv prefix is rendered and prepended to the structured command without invoking
+a shell. It cannot be combined with a string command, and it cannot contain
+`{{files}}` or `{{workspace_files}}`.
 
 ## Git status in conditions and templates
 

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -34,7 +34,8 @@ class Script {
 ///
 /// The first entry is the executable. Exact `{{files}}` and
 /// `{{workspace_files}}` entries expand to one argument per file.
-/// Structured commands cannot be combined with a step's `shell` or `prefix`.
+/// Structured commands cannot be combined with a step's `shell` or a string
+/// `prefix`.
 class Command {
   argv: List<String>
 }
@@ -589,7 +590,8 @@ class Step {
   /// ```
   workspace_indicator: String?
 
-  /// If set, run the linter scripts with this prefix, e.g.: "mise exec --" or "npm run".
+  /// If set, run commands with this prefix. Use a string for shell commands or
+  /// a list of explicit arguments for structured commands.
   ///
   /// ```pkl
   /// local linters = new Mapping<String, Step> {
@@ -598,7 +600,7 @@ class Step {
   ///     }
   /// }
   /// ```
-  prefix: String?
+  prefix: (String | List<String>)?
 
   /// If set, run the linter scripts in this directory.
   ///
@@ -987,7 +989,7 @@ class Group {
   /// Command prefix inherited by child steps that do not set `prefix`.
   ///
   /// This is copied to each child step as a default; child step values override it completely.
-  prefix: String?
+  prefix: (String | List<String>)?
 
   /// Workspace indicator inherited by child steps that do not set `workspace_indicator`.
   ///

--- a/src/step/batching.rs
+++ b/src/step/batching.rs
@@ -117,7 +117,7 @@ impl Step {
         }
         let tctx = temp.tctx(base_tctx);
         run_cmd
-            .render(&tctx, self.prefix.as_deref())
+            .render(&tctx, self.prefix.as_ref())
             .ok()
             .map(|command| RenderedCommandSize {
                 aggregate: command.execution_size(),
@@ -328,6 +328,36 @@ mod tests {
 
         assert!(err.to_string().contains("101-byte argument"));
         assert!(err.to_string().contains("100-byte platform limit"));
+    }
+
+    #[test]
+    fn structured_argv_auto_batch_accounts_for_prefix() {
+        let step = Step {
+            name: "test".to_string(),
+            check: Some(Command::Argv(super::super::types::ArgvCommand {
+                argv: vec!["tool".to_string(), "{{files}}".to_string()],
+            })),
+            prefix: Some(super::super::types::CommandPrefix::Argv(vec![
+                "launcher".to_string(),
+                "1234567890".to_string(),
+            ])),
+            ..Default::default()
+        };
+        let files = (0..6).map(|i| PathBuf::from(format!("f{i}"))).collect();
+        let job = StepJob::new(Arc::new(step.clone()), files, RunType::Check);
+        let tctx = tera::Context::default();
+
+        let jobs = step
+            .auto_batch_jobs_with_limit(vec![job], &tctx, Some(40))
+            .unwrap();
+
+        assert!(jobs.len() > 1);
+        assert!(jobs.iter().all(|job| {
+            step.render_run_command_size(job, &job.files, &tctx)
+                .unwrap()
+                .aggregate
+                <= 40
+        }));
     }
 
     #[cfg(target_os = "linux")]

--- a/src/step/mod.rs
+++ b/src/step/mod.rs
@@ -48,7 +48,9 @@ mod types;
 pub use expr_env::{EXPR_CTX, EXPR_ENV};
 pub use shell::ShellType;
 pub(crate) use types::RenderedCommand;
-pub use types::{FileSelector, OutputSummary, Pattern, RunType, Script, Step};
+#[cfg(test)]
+pub(crate) use types::{ArgvCommand, Command};
+pub use types::{CommandPrefix, FileSelector, OutputSummary, Pattern, RunType, Script, Step};
 
 // Re-export for potential external use (currently only used internally)
 #[allow(unused_imports)]

--- a/src/step/output.rs
+++ b/src/step/output.rs
@@ -146,7 +146,7 @@ impl Step {
         if let Some(fix_cmd) = self
             .run_cmd(RunType::Fix)
             .filter(|command| !command.is_empty())
-            && let Ok(rendered) = fix_cmd.render(&suggest_ctx, self.prefix.as_deref())
+            && let Ok(rendered) = fix_cmd.render(&suggest_ctx, self.prefix.as_ref())
         {
             let rendered = rendered.display(self.shell_type());
             let should_use_hk_fix =

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -24,7 +24,9 @@ use std::process::Stdio;
 
 use super::expr_env::EXPR_ENV;
 use super::shell::ShellType;
-use super::types::{CheckFirstCmd, Command, Pattern, RenderedCommand, RunType, Step};
+use super::types::{
+    CheckFirstCmd, Command, CommandPrefix, Pattern, RenderedCommand, RunType, Step,
+};
 use crate::error::Error;
 
 /// Cap on the per-job progress message in printable characters. The
@@ -161,11 +163,11 @@ impl Step {
         // progress message; this keeps the command shape and one
         // concrete example path visible without unbounded expansion.
         let run_for_display = run_cmd
-            .render(&tctx.for_display(), self.prefix.as_deref())
+            .render(&tctx.for_display(), self.prefix.as_ref())
             .map(|command| command.display(self.shell_type()))
             .unwrap_or_else(|_| run_cmd.to_string());
         let rendered_command = run_cmd
-            .render(&tctx, self.prefix.as_deref())
+            .render(&tctx, self.prefix.as_ref())
             .wrap_err_with(|| format!("{self}: failed to render command template"))?;
         let run = rendered_command.display(self.shell_type());
         let display_pattern = |pattern: &Pattern| match pattern {
@@ -400,13 +402,20 @@ impl Step {
             self.check_diff.as_ref(),
             self.fix.as_ref(),
         ];
-        if commands.iter().flatten().any(|command| command.is_argv()) {
+        let has_argv = commands.iter().flatten().any(|command| command.is_argv());
+        let has_shell = commands.iter().flatten().any(|command| !command.is_argv());
+        if has_argv {
             if self.shell.is_some() {
                 eyre::bail!("Step '{name}' can't combine structured argv commands with `shell`.");
             }
-            if self.prefix.is_some() {
-                eyre::bail!("Step '{name}' can't combine structured argv commands with `prefix`.");
+            if matches!(self.prefix, Some(CommandPrefix::Shell(_))) {
+                eyre::bail!(
+                    "Step '{name}' can't combine structured argv commands with a shell `prefix`."
+                );
             }
+        }
+        if has_shell && matches!(self.prefix, Some(CommandPrefix::Argv(_))) {
+            eyre::bail!("Step '{name}' can't combine shell commands with an argv `prefix`.");
         }
         self.name = name.to_string();
         if self.interactive {
@@ -520,6 +529,7 @@ impl Step {
 mod tests {
     use super::*;
     use crate::step::Script;
+    use crate::step::types::ArgvCommand;
 
     #[test]
     fn truncate_progress_message_passes_short_input() {
@@ -608,5 +618,33 @@ mod tests {
 
         assert!(!step.has_command_for(RunType::Check));
         assert!(!step.has_command_for(RunType::Fix));
+    }
+
+    #[test]
+    fn init_rejects_shell_prefix_for_structured_command() {
+        let mut step = Step {
+            check: Some(Command::Argv(ArgvCommand {
+                argv: vec!["tool".to_string()],
+            })),
+            prefix: Some(CommandPrefix::Shell("mise x --".to_string())),
+            ..Default::default()
+        };
+
+        let err = step.init("test").unwrap_err();
+
+        assert!(err.to_string().contains("shell `prefix`"));
+    }
+
+    #[test]
+    fn init_rejects_argv_prefix_for_shell_command() {
+        let mut step = Step {
+            check: Some("tool".parse().unwrap()),
+            prefix: Some(CommandPrefix::Argv(vec!["mise".to_string()])),
+            ..Default::default()
+        };
+
+        let err = step.init("test").unwrap_err();
+
+        assert!(err.to_string().contains("argv `prefix`"));
     }
 }

--- a/src/step/types.rs
+++ b/src/step/types.rs
@@ -213,7 +213,7 @@ pub struct Step {
     pub workspace_indicator: Option<String>,
 
     /// Prefix to prepend to all commands
-    pub prefix: Option<String>,
+    pub prefix: Option<CommandPrefix>,
 
     /// Working directory for commands (relative to repo root)
     pub dir: Option<String>,
@@ -362,6 +362,14 @@ pub struct ArgvCommand {
     pub argv: Vec<String>,
 }
 
+/// A command prefix that preserves the execution mode of the command it wraps.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CommandPrefix {
+    Shell(String),
+    Argv(Vec<String>),
+}
+
 /// A step command that either runs through a shell or executes an argv directly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -391,34 +399,41 @@ impl Command {
     pub(crate) fn render(
         &self,
         tctx: &tera::Context,
-        prefix: Option<&str>,
+        prefix: Option<&CommandPrefix>,
     ) -> Result<RenderedCommand> {
         match self {
             Self::Shell(script) => {
                 let script = script.to_string();
-                let script = if let Some(prefix) = prefix {
-                    format!("{prefix} {script}")
-                } else {
-                    script
+                let script = match prefix {
+                    Some(CommandPrefix::Shell(prefix)) => format!("{prefix} {script}"),
+                    Some(CommandPrefix::Argv(_)) => {
+                        eyre::bail!("shell commands cannot use an argv `prefix`");
+                    }
+                    None => script,
                 };
                 Ok(RenderedCommand::Shell(tera::render(&script, tctx)?))
             }
             Self::Argv(command) => {
-                if prefix.is_some() {
-                    eyre::bail!("structured argv commands cannot use `prefix`");
+                let prefix: &[String] = match prefix {
+                    Some(CommandPrefix::Argv(prefix)) => prefix.as_slice(),
+                    Some(CommandPrefix::Shell(_)) => {
+                        eyre::bail!("structured argv commands cannot use a shell `prefix`");
+                    }
+                    None => &[],
+                };
+                let mut rendered = Vec::with_capacity(prefix.len() + command.argv.len());
+                for arg in prefix {
+                    if file_list_placeholder(arg).is_some() {
+                        eyre::bail!("argv `prefix` cannot contain file-list placeholders");
+                    }
+                    rendered.push(tera::render(arg, tctx)?);
                 }
-                let mut rendered = Vec::new();
+                if !prefix.is_empty() && rendered[0].trim().is_empty() {
+                    eyre::bail!("argv `prefix` must contain an executable");
+                }
+                let command_start = rendered.len();
                 for (index, arg) in command.argv.iter().enumerate() {
-                    let placeholder = arg
-                        .chars()
-                        .filter(|c| !c.is_whitespace())
-                        .collect::<String>();
-                    let list = match placeholder.as_str() {
-                        "{{files}}" => Some("files_list"),
-                        "{{workspace_files}}" => Some("workspace_files_list"),
-                        _ => None,
-                    };
-                    if let Some(list) = list {
+                    if let Some(list) = file_list_placeholder(arg) {
                         if index == 0 {
                             eyre::bail!("the executable cannot be a file-list placeholder");
                         }
@@ -432,12 +447,28 @@ impl Command {
                         rendered.push(tera::render(arg, tctx)?);
                     }
                 }
-                if rendered.is_empty() || rendered[0].trim().is_empty() {
+                if command.argv.is_empty()
+                    || rendered
+                        .get(command_start)
+                        .is_none_or(|executable| executable.trim().is_empty())
+                {
                     eyre::bail!("structured argv command must contain an executable");
                 }
                 Ok(RenderedCommand::Argv(rendered))
             }
         }
+    }
+}
+
+fn file_list_placeholder(arg: &str) -> Option<&'static str> {
+    let placeholder = arg
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>();
+    match placeholder.as_str() {
+        "{{files}}" => Some("files_list"),
+        "{{workspace_files}}" => Some("workspace_files_list"),
+        _ => None,
     }
 }
 
@@ -565,12 +596,66 @@ mod tests {
         let command = Command::Argv(ArgvCommand {
             argv: vec!["tool".to_string()],
         });
+        let prefix = CommandPrefix::Shell("env FOO=bar".to_string());
 
         let err = command
-            .render(&tera::Context::default(), Some("env FOO=bar"))
+            .render(&tera::Context::default(), Some(&prefix))
             .unwrap_err();
 
-        assert!(err.to_string().contains("cannot use `prefix`"));
+        assert!(err.to_string().contains("cannot use a shell `prefix`"));
+    }
+
+    #[test]
+    fn structured_argv_prepends_rendered_prefix_arguments() {
+        let command = Command::Argv(ArgvCommand {
+            argv: vec!["tool".to_string(), "{{files}}".to_string()],
+        });
+        let prefix = CommandPrefix::Argv(vec![
+            "{{launcher}}".to_string(),
+            "prefix value".to_string(),
+            "$HOME".to_string(),
+        ]);
+        let mut tctx = tera::Context::default();
+        tctx.insert("launcher", "mise");
+        tctx.insert("files_list", &vec!["a b.txt", "semi;colon.txt"]);
+
+        assert_eq!(
+            command.render(&tctx, Some(&prefix)).unwrap(),
+            RenderedCommand::Argv(vec![
+                "mise".to_string(),
+                "prefix value".to_string(),
+                "$HOME".to_string(),
+                "tool".to_string(),
+                "a b.txt".to_string(),
+                "semi;colon.txt".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn shell_command_rejects_argv_prefix() {
+        let command: Command = "echo ok".parse().unwrap();
+        let prefix = CommandPrefix::Argv(vec!["mise".to_string(), "x".to_string()]);
+
+        let err = command
+            .render(&tera::Context::default(), Some(&prefix))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("cannot use an argv `prefix`"));
+    }
+
+    #[test]
+    fn argv_prefix_rejects_file_list_placeholders() {
+        let command = Command::Argv(ArgvCommand {
+            argv: vec!["tool".to_string()],
+        });
+        let prefix = CommandPrefix::Argv(vec!["mise".to_string(), "{{files}}".to_string()]);
+
+        let err = command
+            .render(&tera::Context::default(), Some(&prefix))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("file-list placeholders"));
     }
 
     #[test]

--- a/src/step_group.rs
+++ b/src/step_group.rs
@@ -7,7 +7,7 @@ use serde_with::{DisplayFromStr, PickFirst, serde_as};
 use crate::{
     Result,
     hook::{HookContext, StepOrGroup},
-    step::{Pattern, RunType, Script, Step},
+    step::{CommandPrefix, Pattern, RunType, Script, Step},
     step_context::StepContext,
     step_depends::StepDepends,
 };
@@ -25,7 +25,7 @@ pub struct StepGroup {
     pub _type: Option<String>,
     pub name: Option<String>,
     pub workspace_indicator: Option<String>,
-    pub prefix: Option<String>,
+    pub prefix: Option<CommandPrefix>,
     pub dir: Option<String>,
     #[serde_as(as = "Option<PickFirst<(_, DisplayFromStr)>>")]
     pub shell: Option<Script>,
@@ -274,6 +274,7 @@ impl StepGroup {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::step::{ArgvCommand, Command};
 
     #[test]
     fn init_inherits_group_fields_without_merging_child_overrides() {
@@ -289,7 +290,7 @@ mod tests {
         let mut override_step = Step::default();
         override_step.check = Some("echo override".parse().unwrap());
         override_step.dir = Some("different/path".to_string());
-        override_step.prefix = Some("npm exec --".to_string());
+        override_step.prefix = Some(CommandPrefix::Shell("npm exec --".to_string()));
         override_step.workspace_indicator = Some("eslint.config.js".to_string());
         override_step.shell = Some(child_shell.clone());
         override_step.stage = Some(vec!["eslint-output/**".to_string()]);
@@ -297,7 +298,7 @@ mod tests {
 
         let mut group = StepGroup {
             dir: Some("packages/frontend".to_string()),
-            prefix: Some("mise x --".to_string()),
+            prefix: Some(CommandPrefix::Shell("mise x --".to_string())),
             workspace_indicator: Some("package.json".to_string()),
             shell: Some(group_shell.clone()),
             stage: Some(vec!["dist/**".to_string()]),
@@ -313,7 +314,10 @@ mod tests {
 
         let prettier = group.steps.get("prettier").unwrap();
         assert_eq!(prettier.dir.as_deref(), Some("packages/frontend"));
-        assert_eq!(prettier.prefix.as_deref(), Some("mise x --"));
+        assert_eq!(
+            prettier.prefix.as_ref(),
+            Some(&CommandPrefix::Shell("mise x --".to_string()))
+        );
         assert_eq!(
             prettier.workspace_indicator.as_deref(),
             Some("package.json")
@@ -327,7 +331,10 @@ mod tests {
 
         let eslint = group.steps.get("eslint").unwrap();
         assert_eq!(eslint.dir.as_deref(), Some("different/path"));
-        assert_eq!(eslint.prefix.as_deref(), Some("npm exec --"));
+        assert_eq!(
+            eslint.prefix.as_ref(),
+            Some(&CommandPrefix::Shell("npm exec --".to_string()))
+        );
         assert_eq!(
             eslint.workspace_indicator.as_deref(),
             Some("eslint.config.js")
@@ -338,5 +345,26 @@ mod tests {
             Some(&["eslint-output/**".to_string()][..])
         );
         assert_eq!(eslint.exclude.as_ref(), Some(&child_exclude));
+    }
+
+    #[test]
+    fn init_inherits_argv_prefix_for_structured_command() {
+        let step = Step {
+            check: Some(Command::Argv(ArgvCommand {
+                argv: vec!["ruff".to_string(), "check".to_string()],
+            })),
+            ..Default::default()
+        };
+        let prefix =
+            CommandPrefix::Argv(vec!["mise".to_string(), "x".to_string(), "--".to_string()]);
+        let mut group = StepGroup {
+            prefix: Some(prefix.clone()),
+            steps: IndexMap::from([("ruff".to_string(), step)]),
+            ..Default::default()
+        };
+
+        group.init("python").unwrap();
+
+        assert_eq!(group.steps["ruff"].prefix.as_ref(), Some(&prefix));
     }
 }

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -235,7 +235,7 @@ pub async fn run_test_named(step: &Step, name: &str, test: &StepTest) -> Result<
     let Some(run_cmd) = step.run_cmd(run_type).filter(|command| !command.is_empty()) else {
         eyre::bail!("{}: no command for test", step.name);
     };
-    let run = run_cmd.render(&tctx, step.prefix.as_deref())?;
+    let run = run_cmd.render(&tctx, step.prefix.as_ref())?;
 
     // Run pre-command (before)
     let mut before_stdout = String::new();

--- a/test/structured_argv.bats
+++ b/test/structured_argv.bats
@@ -9,6 +9,45 @@ teardown() {
     _common_teardown
 }
 
+@test "structured argv supports a literal argv prefix" {
+    cat <<'EOF' > capture-prefix
+#!/bin/sh
+printf '%s\n' "$@" > argv.log
+EOF
+    chmod +x capture-prefix
+    touch 'a b.txt' 'semi;colon.txt'
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["capture"] {
+                glob = "*.txt"
+                prefix = List("{{root}}/capture-prefix", "prefix value", "\$HOME", "*")
+                check = new Command {
+                    argv = List("tool", "--flag", "{{files}}")
+                }
+            }
+        }
+    }
+}
+EOF
+
+    run hk check --all
+    assert_success
+
+    run cat argv.log
+    assert_success
+    assert_line --index 0 'prefix value'
+    assert_line --index 1 '$HOME'
+    assert_line --index 2 '*'
+    assert_line --index 3 'tool'
+    assert_line --index 4 '--flag'
+    assert_line 'a b.txt'
+    assert_line 'semi;colon.txt'
+    assert_equal "${#lines[@]}" 7
+}
+
 @test "structured argv preserves literal arguments and file boundaries" {
     cat <<'EOF' > capture-args
 #!/bin/sh
@@ -42,4 +81,23 @@ EOF
     assert_line 'a b.txt'
     assert_line 'semi;colon.txt'
     assert_equal "${#lines[@]}" 4
+}
+
+@test "structured argv prefix composes with a builtin" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["ruff"] = (Builtins.ruff) {
+                prefix = List("mise", "x", "--")
+            }
+        }
+    }
+}
+EOF
+
+    run hk validate
+    assert_success
 }


### PR DESCRIPTION
## Summary

- accept either a shell string or an argv list for `prefix`
- prepend rendered argv prefixes without invoking a shell or losing argument boundaries
- preserve string-prefix behavior for shell commands and reject cross-mode combinations
- support inherited argv prefixes on step groups
- document and test composition with structured builtins such as `Builtins.ruff`

## Root cause

PR #1067 migrated several builtins to structured argv while structured commands rejected every `prefix`. Configurations that inherited a builtin and supplied a string prefix therefore stopped loading even though the same configuration worked before the builtin migration.

This restores that capability with an explicit argv representation:

```pkl
["ruff"] = (Builtins.ruff) {
  prefix = List("mise", "x", "--")
}
```

The existing string form remains shell syntax and is still valid only for shell commands. Argv prefixes reject file-list placeholders so the original structured command retains ownership of file expansion.

Closes discussion #1174.

## Validation

- `mise run test:cargo` — 219 tests passed
- `mise run test:bats test/structured_argv.bats`
- `mise run test:bats test/group_inheritance.bats`
- `mise run test:bats test/stdin.bats`
- `mise x shellcheck@0.11.0 hk@1.54.1 -- hk check --all`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every step command is rendered and executed, but behavior is narrowly scoped to prefix handling with validation and broad test coverage; existing string prefixes on shell steps remain compatible.
> 
> **Overview**
> **`prefix` can be a shell string or an explicit argv list**, so structured `Command` steps (including argv builtins like `Builtins.ruff`) can run through launchers such as `List("mise", "x", "--")` without losing argument boundaries.
> 
> Rendering **prepends Tera-rendered argv prefix arguments** ahead of the structured command and executes them directly—no shell. **String prefixes are unchanged** for shell commands (concatenated into the script). **Cross-mode combinations are rejected** (shell command + argv prefix, structured command + string prefix, or `shell` + argv).
> 
> **Argv prefixes cannot use `{{files}}` / `{{workspace_files}}`**; file expansion stays on the main command. **Auto-batching** sizes rendered commands including the prefix. **Groups** can inherit argv prefixes to child steps. Docs and integration tests cover literal metacharacters and builtin composition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3006a270ce5ced06d9d879a3a3e214b201d76ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for argument-list prefixes on structured commands.
  - Prefixes now preserve spaces, shell metacharacters, and literal environment-variable text.
  - Prefixes can be inherited by grouped steps.

- **Bug Fixes**
  - Added validation for incompatible shell and structured command prefixes.
  - Improved command-size batching to account for prefix arguments.
  - Added validation preventing unsupported file-list placeholders in prefixes.

- **Documentation**
  - Clarified prefix compatibility, inheritance, restrictions, and usage examples for structured commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->