### PR TITLE
fix(check): exclude deleted paths from ref checks

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1723,6 +1723,9 @@ fn collect_existing_paths_from_diff(diff: Diff<'_>) -> Result<Vec<PathBuf>> {
     let mut files = BTreeSet::new();
     diff.foreach(
         &mut |diff_delta, _| {
+            if diff_delta.status() == git2::Delta::Deleted {
+                return true;
+            }
             if let Some(path) = diff_delta.new_file().path() {
                 let path_buf = PathBuf::from(path);
                 if path_buf.exists() {

--- a/test/git.bats
+++ b/test/git.bats
@@ -128,6 +128,47 @@ EOF
     assert_output --partial "print-files – main.txt"
 }
 
+@test "files_between_refs excludes deleted paths for case-only renames" {
+    _disable_test_cache
+
+    mkdir -p src
+    echo "content" > src/example.txt
+    git add src/example.txt
+    git commit -m "add example"
+    BASE_COMMIT=$(git rev-parse HEAD)
+
+    git mv src/example.txt src/Example.txt
+    git commit -m "rename example"
+    TARGET_COMMIT=$(git rev-parse HEAD)
+
+    # On case-sensitive filesystems, emulate the case-insensitive exists() check
+    # by recreating the deleted spelling as an untracked path. On case-insensitive
+    # filesystems this writes through the old spelling to the tracked target path.
+    echo "worktree content" > src/example.txt
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["print-files"] {
+                check = "echo '{{files}}'"
+            }
+        }
+    }
+}
+EOF
+
+    for use_libgit2 in 1 0; do
+        HK_LIBGIT2="$use_libgit2" run hk check \
+            --from-ref="$BASE_COMMIT" \
+            --to-ref="$TARGET_COMMIT"
+        assert_success
+        assert_output --partial "print-files – src/Example.txt"
+        refute_output --partial "src/example.txt"
+    done
+}
+
 @test "files_between_refs falls back to two-dot diff without merge base using libgit2" {
     echo "main content" > main.txt
     git add main.txt


### PR DESCRIPTION
## Summary

- exclude deleted libgit2 deltas from ref-scoped file selection
- keep the existing worktree-existence guard for live paths
- add portable coverage for case-only renames under both libgit2 and shell-Git backends

## Root cause

The libgit2 backend used `Path::exists()` to distinguish live paths from deleted deltas. On a case-insensitive filesystem, the old spelling of a case-only rename still resolves to the new path, so both spellings were passed to every selected step. The shell-Git backend already excludes deleted paths with `--diff-filter=ACMRTUXB`.

This fixes the shared selection layer discussed in https://github.com/jdx/hk/discussions/1176, so linters and formatters no longer receive the stale deleted spelling either.

## Validation

- `mise run test:bats test/git.bats`
- `hk check --all` (slow profile skipped)

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to ref-scoped file enumeration with a focused regression test; no auth or data-path impact.
> 
> **Overview**
> **Ref-scoped checks** (`--from-ref` / `--to-ref`) no longer pass **deleted** diff paths into hook steps when using the **libgit2** backend. `collect_existing_paths_from_diff` now skips `Delta::Deleted` entries before the worktree `exists()` guard, aligning with shell Git’s `--diff-filter=ACMRTUXB` behavior.
> 
> This fixes **case-only renames on case-insensitive filesystems**, where the old spelling still `exists()` and was incorrectly included alongside the new path.
> 
> Adds a **bats** test that runs `hk check` across both `HK_LIBGIT2=1` and `0` and asserts only `src/Example.txt` is selected, not `src/example.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e756861184508d1ea8357ad8a2beffe9a49a446b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file change detection so deleted file paths are excluded.
  * Corrected case-only rename handling to retain only the renamed file’s current path.

* **Tests**
  * Added regression coverage for case-only renames across supported Git implementations and filesystem types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->