### PR TITLE
test(init): decouple agent docs assertion from releases

### DIFF
--- a/src/cli/init/generator.rs
+++ b/src/cli/init/generator.rs
@@ -144,8 +144,11 @@ mod tests {
 
     #[test]
     fn test_agent_docs_link_follows_imports() {
-        let expected = "import \"package://github.com/jdx/hk/releases/download/v1.34.0/hk@1.34.0#/Builtins.pkl\"\n// Using a coding agent? See https://hk.jdx.dev/agents";
-        assert!(generate_pkl(&[], &[], "1.34.0").contains(expected));
-        assert!(generate_default_template("1.34.0").contains(expected));
+        let version = "test-version";
+        let expected = format!(
+            "import \"package://github.com/jdx/hk/releases/download/v{version}/hk@{version}#/Builtins.pkl\"\n// Using a coding agent? See https://hk.jdx.dev/agents"
+        );
+        assert!(generate_pkl(&[], &[], version).contains(&expected));
+        assert!(generate_default_template(version).contains(&expected));
     }
 }


### PR DESCRIPTION
## Summary

- build the expected generated import from the same synthetic version passed to the generators
- prevent release automation from rewriting only the assertion's hard-coded package URL

## Root cause

The v1.55.0 release update changed the expected import URL in `test_agent_docs_link_follows_imports`, while the generators were still called with `1.34.0`. This made the assertion fail on Linux, macOS, and Windows.

## Validation

- `cargo test test_agent_docs_link_follows_imports`
- `cargo fmt --all -- --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in init generator assertions; no runtime or generator behavior changes.
> 
> **Overview**
> **`test_agent_docs_link_follows_imports`** no longer hard-codes a package import URL (e.g. `v1.34.0`) that could be rewritten independently of the version passed into **`generate_pkl`** and **`generate_default_template`**.
> 
> The test now uses a synthetic **`test-version`**, builds the expected import line with **`format!`**, and asserts both generators include that string plus the agents docs comment—so release bumps can’t desync the expectation from the generator inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c3870ccdf895d91a286d3683dfc40e0b40c7671. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage reliability by deriving expected documentation links from the configured test version instead of hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->