### PR TITLE
fix(docs): keep search modal above site navigation

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -285,6 +285,7 @@ pre.language-sh::before {
 .VPLocalSearchBox {
   --vp-local-search-highlight-bg: rgba(76, 201, 240, 0.2);
   --vp-local-search-highlight-text: var(--hk-blue-primary);
+  z-index: 1100 !important;
 }
 
 /* Custom scrollbar */


### PR DESCRIPTION
## Summary

- render the VitePress local-search overlay above the custom navigation and announcement banner
- keep the search input and results fully visible while the modal is open

## Root cause

VitePress assigns the local-search modal `z-index: 100`, while hk's navigation and announcement banner use `1000` and `1001`. Those fixed site layers covered the top of the search modal, hiding its input and clipping the results pane.

## Validation

- `mise exec -- aube run docs:build` (from `docs/`)
- `mise exec -- aube run eslint` (from `docs/`)
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit eba8e7921d36588abf08218eed93ee3c4f19a81d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local search visibility by ensuring the search modal appears above navigation and other page elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->