### PR TITLE
fix(config): allow steps to include binary files

### DIFF
--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -417,6 +417,9 @@ class Step {
   /// ```
   match_any: List<FileSelector>?
 
+  /// Whether to include binary files (default: false)
+  allow_binary: Boolean = false
+
   /// Whether to include symbolic links (default: false)
   allow_symlinks: Boolean = false
 

--- a/test/binary_file_cache.bats
+++ b/test/binary_file_cache.bats
@@ -42,6 +42,31 @@ EOF
     refute_output --partial "binary.dat"
 }
 
+@test "allow_binary includes binary files" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+
+hooks {
+    ["check"] {
+        steps {
+            ["test"] {
+                types = List("binary")
+                allow_binary = true
+                check = "echo {{files}}"
+            }
+        }
+    }
+}
+EOF
+
+    printf '\x00\x01\x02\x03' > binary.dat
+    git add binary.dat
+
+    run hk check
+    assert_success
+    assert_output --partial "binary.dat"
+}
+
 @test "binary file detection caches results" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"


### PR DESCRIPTION
## Summary

- expose the existing `allow_binary` step option in `Config.pkl`
- add regression coverage showing binary type selectors receive NUL-containing files when opted in

## Root cause

The Rust step model and file filter already supported `allow_binary`, but the Pkl `Step` schema did not declare it. Binary files were therefore filtered by default with no valid configuration path to include them.

Fixes the behavior reported in https://github.com/jdx/hk/discussions/1189.

## Validation

- `mise run test:bats test/binary_file_cache.bats`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema exposure and test-only change; runtime filtering behavior already existed and the default remains false.
> 
> **Overview**
> Exposes the existing **`allow_binary`** step option in `Config.pkl` so configs can opt into processing binary files (default remains `false`).
> 
> The Rust step model and file filter already honored this flag; without the Pkl field there was no valid way to set it. Adds a bats regression test covering `types = List("binary")` with `allow_binary = true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aac8c45857c530be0539cd4d1b66f211eaa86e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that enabling binary-file checks includes binary files in the check output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->