### PR TITLE
chore: release v1.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [1.56.0](https://github.com/jdx/hk/compare/v1.55.0..v1.56.0) - 2026-08-19
+
+### 🚀 Features
+
+- **(builtins)** support pinact v3 and v4 by [@risu729](https://github.com/risu729) in [#1195](https://github.com/jdx/hk/pull/1195)
+- **(pkl)** persist packages for offline evaluation by [@jdx](https://github.com/jdx) in [#1199](https://github.com/jdx/hk/pull/1199)
+
+### 🐛 Bug Fixes
+
+- **(builtins)** preserve file argument boundaries by [@jdx](https://github.com/jdx) in [#1194](https://github.com/jdx/hk/pull/1194)
+- **(config)** allow steps to include binary files by [@jdx](https://github.com/jdx) in [#1190](https://github.com/jdx/hk/pull/1190)
+- **(hook)** preserve worktree root for scoped steps by [@jdx](https://github.com/jdx) in [#1200](https://github.com/jdx/hk/pull/1200)
+- **(pre-push)** peel annotated tags before diffing by [@jdx](https://github.com/jdx) in [#1197](https://github.com/jdx/hk/pull/1197)
+- **(step)** preserve condition compatibility with expr v2 by [@jdx](https://github.com/jdx) in [#1212](https://github.com/jdx/hk/pull/1212)
+
+### 🔍 Other Changes
+
+- **(pkl)** upgrade formatter to 0.32.1 by [@jdx](https://github.com/jdx) in [#1203](https://github.com/jdx/hk/pull/1203)
+- Add `HK_OUTPUT_FILE` env var to control the output file location by [@signadou](https://github.com/signadou) in [#1204](https://github.com/jdx/hk/pull/1204)
+
+### 📦️ Dependency Updates
+
+- update anthropics/claude-code-action action to v1.0.185 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1191](https://github.com/jdx/hk/pull/1191)
+- update dependency vitest to v4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1186](https://github.com/jdx/hk/pull/1186)
+- update dependency vite to v8 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1185](https://github.com/jdx/hk/pull/1185)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1202](https://github.com/jdx/hk/pull/1202)
+- update anthropics/claude-code-action action to v1.0.190 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1205](https://github.com/jdx/hk/pull/1205)
+- update dependency @testing-library/jest-dom to v7.0.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1206](https://github.com/jdx/hk/pull/1206)
+- update rust crate shell-quote to 0.8 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1207](https://github.com/jdx/hk/pull/1207)
+- update jdx/renovate-config digest to 75abd12 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1208](https://github.com/jdx/hk/pull/1208)
+- update anthropics/claude-code-action action to v1.0.191 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1209](https://github.com/jdx/hk/pull/1209)
+
+### New Contributors
+
+- @signadou made their first contribution in [#1204](https://github.com/jdx/hk/pull/1204)
+
 ## [1.55.0](https://github.com/jdx/hk/compare/v1.54.1..v1.55.0) - 2026-08-11
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,7 +979,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.55.0"
+version = "1.56.0"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "hk"
 repository = "https://github.com/jdx/hk"
 resolver = "3"
 rust-version = "1.88.0"
-version = "1.55.0"
+version = "1.56.0"
 
 [[bin]]
 name = "generate-docs"

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 140+ pre-configured linters and formatters through the `Builtins` mo
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -6064,7 +6064,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.55.0",
+  "version": "1.56.0",
   "usage": "Usage: hk [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "A tool for managing git hooks",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.55.0
+**Version**: 1.56.0
 
 - **Usage**: `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined
@@ -299,8 +299,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -333,7 +333,7 @@ Add steps to your hkrc. hk merges them into every project's hooks — steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -426,7 +426,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,8 +105,8 @@ Separately from global *hooks*, you can also create a global *config* file that 
 `hk init` generates an `hk.pkl` file in the root of the repository. Here's an example `hk.pkl` with eslint and prettier linters:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -43,7 +43,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,9 +3,9 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,9 +3,9 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,9 +3,9 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,9 +4,9 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -6,8 +6,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -6,8 +6,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -13,8 +13,8 @@ Groups can set common step attributes such as `dir`, `workspace_indicator`, `pre
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {
@@ -114,7 +114,7 @@ its own `hk.pkl` next to its code. The root config lists the subproject director
 
 ```pkl
 // hk.pkl (repo root)
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
 
 subprojects = List("frontend", "backend", "packages/*")
 
@@ -126,8 +126,8 @@ hooks {
 
 ```pkl
 // frontend/hk.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 hooks {
   ["check"] {

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -7,8 +7,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,6 +1,6 @@
-amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.56.0/hk@1.56.0#/Config.pkl"
 amends "pkl/Config.pkl"
 
 import "pkl/Builtins.pkl"

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name hk
 bin hk
-version "1.55.0"
+version "1.56.0"
 about "A tool for managing git hooks"
 usage "Usage: hk [OPTIONS] <COMMAND>"
 flag --cd help="Run as if hk was started in this directory" global=#true {


### PR DESCRIPTION
### 🚀 Features

- **(builtins)** support pinact v3 and v4 by [@risu729](https://github.com/risu729) in [#1195](https://github.com/jdx/hk/pull/1195)
- **(pkl)** persist packages for offline evaluation by [@jdx](https://github.com/jdx) in [#1199](https://github.com/jdx/hk/pull/1199)

### 🐛 Bug Fixes

- **(builtins)** preserve file argument boundaries by [@jdx](https://github.com/jdx) in [#1194](https://github.com/jdx/hk/pull/1194)
- **(config)** allow steps to include binary files by [@jdx](https://github.com/jdx) in [#1190](https://github.com/jdx/hk/pull/1190)
- **(hook)** preserve worktree root for scoped steps by [@jdx](https://github.com/jdx) in [#1200](https://github.com/jdx/hk/pull/1200)
- **(pre-push)** peel annotated tags before diffing by [@jdx](https://github.com/jdx) in [#1197](https://github.com/jdx/hk/pull/1197)
- **(step)** preserve condition compatibility with expr v2 by [@jdx](https://github.com/jdx) in [#1212](https://github.com/jdx/hk/pull/1212)

### 🔍 Other Changes

- **(pkl)** upgrade formatter to 0.32.1 by [@jdx](https://github.com/jdx) in [#1203](https://github.com/jdx/hk/pull/1203)
- Add `HK_OUTPUT_FILE` env var to control the output file location by [@signadou](https://github.com/signadou) in [#1204](https://github.com/jdx/hk/pull/1204)

### 📦️ Dependency Updates

- update anthropics/claude-code-action action to v1.0.185 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1191](https://github.com/jdx/hk/pull/1191)
- update dependency vitest to v4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1186](https://github.com/jdx/hk/pull/1186)
- update dependency vite to v8 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1185](https://github.com/jdx/hk/pull/1185)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1202](https://github.com/jdx/hk/pull/1202)
- update anthropics/claude-code-action action to v1.0.190 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1205](https://github.com/jdx/hk/pull/1205)
- update dependency @testing-library/jest-dom to v7.0.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1206](https://github.com/jdx/hk/pull/1206)
- update rust crate shell-quote to 0.8 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1207](https://github.com/jdx/hk/pull/1207)
- update jdx/renovate-config digest to 75abd12 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1208](https://github.com/jdx/hk/pull/1208)
- update anthropics/claude-code-action action to v1.0.191 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1209](https://github.com/jdx/hk/pull/1209)

### New Contributors

- @signadou made their first contribution in [#1204](https://github.com/jdx/hk/pull/1204)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and documentation bump with no application source changes in the diff; typical low-risk release packaging.
> 
> **Overview**
> **Release v1.56.0** — bumps the crate and CLI metadata from `1.55.0` to `1.56.0` and adds the **1.56.0** section to `CHANGELOG.md`.
> 
> Every published `hk@…` / `v1.55.0` Pkl package URI in docs, examples, and sample `hk.pkl` files is retargeted to **v1.56.0**. Generated usage docs (`hk.usage.kdl`, `docs/cli/commands.json`, `docs/cli/index.md`) pick up the new version string; `Cargo.lock` reflects the workspace version only.
> 
> The changelog documents what ships in this tag: **pinact v3/v4**, offline Pkl package persistence, hook/pre-push/step/config/builtins fixes, Pkl formatter 0.32.1, **`HK_OUTPUT_FILE`**, and assorted dependency updates — those behaviors are not introduced in this diff, only recorded and versioned here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b70bacfc3954ef17d31c81a1dd0b7c3b748d09c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->