### PR TITLE
chore(ci): use github-hosted runner for pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,7 +64,9 @@ jobs:
       pages: write # to deploy to Pages
       id-token: write # to verify the deployment originates from an appropriate source
     needs: build
-    runs-on: namespace-profile-endev-linux-amd64
+    # Keep deployment independent of the external build runner. A queued deploy
+    # holds the workflow's Pages concurrency group and blocks newer releases.
+    runs-on: ubuntu-latest
     name: Deploy
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary

- run the GitHub Pages deployment job on `ubuntu-latest`
- keep the documentation build on the existing Namespace runner

## Why

The docs build completed successfully, but the deployment job remained queued without a runner. Because the workflow uses a shared Pages concurrency group, that queued deployment blocked newer documentation releases and left the live site stale.

Using a GitHub-hosted runner for the lightweight deployment step removes the external runner dependency from the critical publishing path.

## Validation

- `mise exec shellcheck@0.11.0 -- actionlint .github/workflows/docs.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only runner change for a lightweight deploy step; no application, auth, or data-handling logic is modified.
> 
> **Overview**
> Moves the GitHub Pages **deploy** job onto `ubuntu-latest` so publishing no longer depends on the Namespace runner.
> 
> The docs **build** job still runs on `namespace-profile-endev-linux-amd64`. This avoids a queued deploy holding the shared `pages` concurrency group and blocking newer documentation releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d4267ab86e43a30ff596af42dbe44b151a18d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation deployments now use a standard hosted build environment.
  * Improved deployment independence and coordination for hosted documentation updates.
  * No changes were made to the public API or documented functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->