### PR TITLE
feat(builtins): support pinact v3 and v4

### DIFF
--- a/pkl/builtins/pinact.pkl
+++ b/pkl/builtins/pinact.pkl
@@ -9,15 +9,17 @@ import "./test/helpers.pkl"
 const pinact = new Config.Step {
   glob = List(".github/workflows/*", "*/action.*")
   types = List("yaml")
-  // `verify` flag to verify pairs of commit CHA and version are correct
+  // `verify-comment` verifies pairs of commit SHA and version comments are correct
   check_diff = new Config.CommandSpec {
     command = new Config.Command {
-      argv = List("pinact", "run", "--verify", "--check", "{{files}}")
+      argv = List("pinact", "run", "--verify-comment", "--check", "{{files}}")
     }
     effect = "read"
   }
   fix = new Config.CommandSpec {
-    command = new Config.Command { argv = List("pinact", "run", "--verify", "{{files}}") }
+    command = new Config.Command {
+      argv = List("pinact", "run", "--verify-comment", "{{files}}")
+    }
     effect = "write"
   }
   tests {

--- a/pkl/builtins/pinact.pkl
+++ b/pkl/builtins/pinact.pkl
@@ -53,8 +53,8 @@ const pinact = new Config.Step {
     }
     ["check bad file"] = testMaker.checkFail(bad, 1)
     ["check good file"] = testMaker.checkPass(good)
-    ["fix bad file violations remain"] =
-      testMaker.fixFail(
+    ["fix bad file and mismatched version comment"] =
+      testMaker.fixPass(
         """
         name: pinact test
         on:
@@ -76,10 +76,9 @@ const pinact = new Config.Step {
             runs-on: ubuntu-latest
             steps:
               - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-              - uses: jdx/mise-action@d16887ba50704baed7de72bd1e82e04391e4457a # v3.5.1
+              - uses: jdx/mise-action@d16887ba50704baed7de72bd1e82e04391e4457a # v3.5.0
 
         """,
-        1,
       )
     ["fix bad file all violations are fixed"] = testMaker.fixPass(bad, good)
     ["fix good file"] = testMaker.fixPass(good, good)

--- a/pkl/builtins/pinact_update.pkl
+++ b/pkl/builtins/pinact_update.pkl
@@ -11,14 +11,15 @@ const pinact_update = new Config.Step {
   // `verify-comment` verifies pairs of commit SHA and version comments are correct
   check_diff = new Config.CommandSpec {
     command = new Config.Command {
-      argv = List(
-        "pinact",
-        "run",
-        "--update",
-        "--verify-comment",
-        "--check",
-        "{{files}}",
-      )
+      argv =
+        List(
+          "pinact",
+          "run",
+          "--update",
+          "--verify-comment",
+          "--check",
+          "{{files}}",
+        )
     }
     effect = "read"
   }

--- a/pkl/builtins/pinact_update.pkl
+++ b/pkl/builtins/pinact_update.pkl
@@ -8,16 +8,23 @@ import "../Config.pkl"
 const pinact_update = new Config.Step {
   glob = List(".github/workflows/*", "*/action.*")
   types = List("yaml")
-  // `verify` flag to verify pairs of commit CHA and version are correct
+  // `verify-comment` verifies pairs of commit SHA and version comments are correct
   check_diff = new Config.CommandSpec {
     command = new Config.Command {
-      argv = List("pinact", "run", "--update", "--verify", "--check", "{{files}}")
+      argv = List(
+        "pinact",
+        "run",
+        "--update",
+        "--verify-comment",
+        "--check",
+        "{{files}}",
+      )
     }
     effect = "read"
   }
   fix = new Config.CommandSpec {
     command = new Config.Command {
-      argv = List("pinact", "run", "--update", "--verify", "{{files}}")
+      argv = List("pinact", "run", "--update", "--verify-comment", "{{files}}")
     }
     effect = "write"
   }

--- a/pkl/builtins/pinact_update_v3.pkl
+++ b/pkl/builtins/pinact_update_v3.pkl
@@ -1,0 +1,23 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+import "./pinact_update.pkl"
+
+@Builtins.meta {
+  category = "Infrastructure"
+  description = "Update GitHub Actions to latest versions using pinact v3"
+}
+const pinact_update_v3 = (pinact_update.pinact_update) {
+  // pinact v3 calls this flag `verify`; v4 renamed it to `verify-comment`.
+  check_diff = new Config.CommandSpec {
+    command = new Config.Command {
+      argv = List("pinact", "run", "--update", "--verify", "--check", "{{files}}")
+    }
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = new Config.Command {
+      argv = List("pinact", "run", "--update", "--verify", "{{files}}")
+    }
+    effect = "write"
+  }
+}

--- a/pkl/builtins/pinact_v3.pkl
+++ b/pkl/builtins/pinact_v3.pkl
@@ -1,0 +1,57 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+import "./pinact.pkl"
+import "./test/helpers.pkl"
+
+@Builtins.meta {
+  category = "Infrastructure"
+  description = "Pin GitHub Actions to commit SHA for security using pinact v3"
+}
+const pinact_v3 = (pinact.pinact) {
+  // pinact v3 calls this flag `verify`; v4 renamed it to `verify-comment`.
+  check_diff = new Config.CommandSpec {
+    command = new Config.Command {
+      argv = List("pinact", "run", "--verify", "--check", "{{files}}")
+    }
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = new Config.Command { argv = List("pinact", "run", "--verify", "{{files}}") }
+    effect = "write"
+  }
+  tests {
+    local const testMaker = new helpers.TestMaker {
+      before = "pinact init" // create the pinact configuration file
+      filename = ".github/workflows/test.yml"
+    }
+    // Unlike v4, v3 reports a mismatched version comment but does not repair it.
+    ["fix bad file and mismatched version comment"] =
+      testMaker.fixFail(
+        """
+        name: pinact test
+        on:
+          push:
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@v6.0.1
+              - uses: jdx/mise-action@d16887ba50704baed7de72bd1e82e04391e4457a # v3.5.1
+
+        """,
+        """
+        name: pinact test
+        on:
+          push:
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+              - uses: jdx/mise-action@d16887ba50704baed7de72bd1e82e04391e4457a # v3.5.1
+
+        """,
+        1,
+      )
+  }
+}

--- a/test/builtin_tool_stubs/pinact
+++ b/test/builtin_tool_stubs/pinact
@@ -1,4 +1,4 @@
 #!/usr/bin/env -S mise tool-stub
 
-version = "3.8.0"
+version = "4.1.0"
 tool = "aqua:suzuki-shunsuke/pinact"

--- a/test/builtin_tool_stubs/pinact
+++ b/test/builtin_tool_stubs/pinact
@@ -1,4 +1,4 @@
 #!/usr/bin/env -S mise tool-stub
 
-version = "4.1.0"
+version = "4.1.1"
 tool = "aqua:suzuki-shunsuke/pinact"

--- a/test/builtin_tool_stubs_v3/pinact
+++ b/test/builtin_tool_stubs_v3/pinact
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "3.10.1"
+tool = "aqua:suzuki-shunsuke/pinact"

--- a/test/builtins_tests.bats
+++ b/test/builtins_tests.bats
@@ -15,8 +15,13 @@ amends "$PKL_PATH/Config.pkl"
 import "$PKL_PATH/Builtins.pkl" as Builtins
 hooks {
   ["check"] {
-    // Include all Builtins.* steps
-    steps = Builtins.toMap().toMapping()
+    // Include all Builtins.* steps except versioned builtins that require a
+    // different tool stub. Those are exercised separately below.
+    steps =
+      Builtins
+        .toMap()
+        .filter((name, _) -> name != "pinact_v3")
+        .toMapping()
   }
 }
 PKL
@@ -28,6 +33,25 @@ PKL
     assert_success
     # At least the newlines builtin has a test
     assert_output --partial "ok - newlines :: fix bad file"
+}
+
+@test "pinact v3 builtin tests run with pinact v3" {
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl" as Builtins
+hooks {
+  ["check"] {
+    steps {
+      ["pinact_v3"] = Builtins.pinact_v3
+    }
+  }
+}
+PKL
+
+    PATH="$PROJECT_ROOT/test/builtin_tool_stubs_v3:$PATH"
+    run hk test --step pinact_v3
+    assert_success
+    assert_output --partial "ok - pinact_v3 :: fix bad file and mismatched version comment"
 }
 
 @test "shell builtins select extensionless sh scripts but not fish" {


### PR DESCRIPTION
## Summary

- Keep `pinact` and `pinact_update` on the latest major version, currently pinact v4.1.1.
- Update the latest builtins to use the v4-native `--verify-comment` flag.
- Add `pinact_v3` and `pinact_update_v3` alternatives for projects that still use pinact v3.
- Exercise `pinact_v3` against pinact v3.10.1 separately from the v4 builtin suite.
- Preserve the major-version behavior difference for mismatched version comments: v4 repairs them, while v3 reports the remaining violation.

## Usage

Projects using pinact v4 can continue using the unversioned builtins:

```pkl
["pinact"] = Builtins.pinact
["pinact_update"] = Builtins.pinact_update
```

Projects using pinact v3 can select the versioned alternatives without changing their step names:

```pkl
["pinact"] = Builtins.pinact_v3
["pinact_update"] = Builtins.pinact_update_v3
```

## Test plan

- [x] `hk check --all`
- [x] Targeted Bats coverage for `pinact_v3` with pinact v3.10.1
- [x] Generated builtin catalog validation
- [x] Full GitHub CI matrix

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*
