### PR TITLE
fix(pre-push): peel annotated tags before diffing

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1617,8 +1617,11 @@ impl Git {
                 .revparse_single(to_ref)
                 .wrap_err(format!("Failed to parse reference: {to_ref}"))?;
 
-            let to_tree = to_obj
-                .peel_to_tree()
+            let to_commit = to_obj
+                .peel_to_commit()
+                .wrap_err(format!("Failed to get commit for reference: {to_ref}"))?;
+            let to_tree = to_commit
+                .tree()
                 .wrap_err(format!("Failed to get tree for reference: {to_ref}"))?;
 
             let from_obj = match repo.revparse_single(from_ref) {
@@ -1638,11 +1641,14 @@ impl Git {
                     return Err(err).wrap_err(format!("Failed to resolve from-ref: {from_ref}"));
                 }
             };
+            let from_commit = from_obj
+                .peel_to_commit()
+                .wrap_err(format!("Failed to get commit for reference: {from_ref}"))?;
 
             // Prefer merge-base semantics (`from...to`). In shallow clones the
             // merge base can be missing, so fall back to a direct `from..to`
             // diff instead of failing the whole run.
-            let diff = match repo.merge_base(from_obj.id(), to_obj.id()) {
+            let diff = match repo.merge_base(from_commit.id(), to_commit.id()) {
                 Ok(merge_base) => {
                     let merge_base_obj = repo
                         .find_object(merge_base, None)
@@ -1668,8 +1674,8 @@ impl Git {
                         repo.diff_tree_to_tree(Some(&merge_base_tree), Some(&to_tree), None)
                             .wrap_err("Failed to get diff between references")?
                     } else {
-                        let from_tree = from_obj
-                            .peel_to_tree()
+                        let from_tree = from_commit
+                            .tree()
                             .wrap_err(format!("Failed to get tree for reference: {from_ref}"))?;
                         repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), None)
                             .wrap_err("Failed to get fallback diff between references")?

--- a/test/pre_push.bats
+++ b/test/pre_push.bats
@@ -62,18 +62,20 @@ hooks {
 }
 EOF
     git add hk.pkl
-    git commit -m "install hk"
+    git commit -m "test(pre-push): install hk"
     git push origin main
+    git remote set-head origin --auto
 
     echo "tagged content" > tagged.txt
     git add tagged.txt
-    git commit -m "add tagged content"
+    git commit -m "test(pre-push): add tagged content"
     git tag -a v1.0.0 -m v1.0.0
     hk install --legacy
 
     run git push origin v1.0.0
 
     assert_success
+    assert_output --partial "print-files – tagged.txt"
     run git ls-remote --exit-code origin refs/tags/v1.0.0
     assert_success
 }

--- a/test/pre_push.bats
+++ b/test/pre_push.bats
@@ -50,6 +50,34 @@ EOF
     assert_output --partial "[warn] test.js"
 }
 
+@test "pre-push hook allows pushing annotated tags" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-push"] {
+        steps {
+            ["print-files"] { check = "echo '{{files}}'" }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "install hk"
+    git push origin main
+
+    echo "tagged content" > tagged.txt
+    git add tagged.txt
+    git commit -m "add tagged content"
+    git tag -a v1.0.0 -m v1.0.0
+    hk install --legacy
+
+    run git push origin v1.0.0
+
+    assert_success
+    run git ls-remote --exit-code origin refs/tags/v1.0.0
+    assert_success
+}
+
 @test "config-based pre-push hook checks pushed files" {
     require_git_2_54
     export NO_COLOR=1


### PR DESCRIPTION
## Summary

- peel resolved refs to commits before calculating their merge base with libgit2
- preserve file-diff behavior for commits referenced by annotated tags
- add an end-to-end regression test that pushes an annotated tag through an hk-managed pre-push hook

## Root cause

The pre-push hook passes the pushed object's SHA into `files_between_refs`. For annotated tags, that SHA identifies a tag object. The libgit2 path peeled the object when reading its tree, but passed the original tag object ID to `Repository::merge_base`, which only accepts commit objects.

This fixes [discussion #1196](https://github.com/jdx/hk/discussions/1196).

## Testing

- `mise run test:bats test/pre_push.bats`
- `mise run test:cargo` (254 passed)

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core git diff/merge-base logic used by pre-push file selection; behavior change is narrow but affects ref resolution for all libgit2 range diffs.
> 
> **Overview**
> Fixes pre-push failures when pushing **annotated tags** by resolving both ends of a ref range to **commits** before computing merge bases and trees in the libgit2 path of `files_between_refs`.
> 
> Previously, a pushed tag’s OID could refer to a **tag object** while `merge_base` only accepts commit IDs; peeling happened for trees but not for merge-base calculation. The change uses `peel_to_commit()` for `from`/`to` refs and builds trees from those commits, keeping existing fallbacks (empty `from_ref`, shallow clone merge-base retry, direct `from..to` diff).
> 
> Adds a **bats** regression that pushes an annotated tag through a legacy hk pre-push hook and asserts the hook sees the tagged commit’s changed files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a5da41333b3654ddd63e0c959c32bbff614bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved comparison of changes between repository references, especially when resolving merge bases and fallback differences.
  - Preserved existing behavior when references cannot be resolved.

- **Tests**
  - Added coverage confirming that annotated tags can be pushed successfully using the legacy pre-push hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->