### PR TITLE
feat(pkl): persist packages for offline evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,9 +1884,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pklr"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec01dca22f93da32accd2c1d8dfa01fb5b36a1fba70865a4af70f4be9d44ca18"
+checksum = "59dae64c972421e61074aa3127d10069e19aff1e6e9ed7c320a7e1185b2c444c"
 dependencies = [
  "async-recursion",
  "indexmap 2.14.0",

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -204,7 +204,7 @@ This variable is read directly from the environment before pkl is invoked, so it
 ## `HK_PKL_CACHE_DIR`
 
 Type: `path`
-Default: `~/.cache/pklr`
+Default: the platform cache directory with `pklr` appended (`~/.cache/pklr` on Linux, `~/Library/Caches/pklr` on macOS, and `%LOCALAPPDATA%\pklr` on Windows). Falls back to `~/.cache/pklr` when the platform cache directory is unavailable.
 
 The directory used by the built-in pklr evaluator to persist downloaded Pkl packages. Packages in this cache can be reused after hk's resolved configuration cache is invalidated, including in offline mode.
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -201,6 +201,15 @@ This is useful in corporate environments with SSL-intercepting proxies where pkl
 
 This variable is read directly from the environment before pkl is invoked, so it cannot be configured in `hk.pkl`.
 
+## `HK_PKL_CACHE_DIR`
+
+Type: `path`
+Default: `~/.cache/pklr`
+
+The directory used by the built-in pklr evaluator to persist downloaded Pkl packages. Packages in this cache can be reused after hk's resolved configuration cache is invalidated, including in offline mode.
+
+This variable is read directly from the environment before `hk.pkl` is evaluated, so it cannot be configured in `hk.pkl`.
+
 ## `HK_PKL_HTTP_REWRITE`
 
 Type: `string`
@@ -208,6 +217,15 @@ Type: `string`
 A value to provide `pkl`'s `--http-rewrite` flag when invoking `pkl`, in the form `http(s)://<FROM>/=http(s)://<TO>/`.
 
 This variable is read directly from the environment before pkl is invoked, so it cannot be configured in `hk.pkl`.
+
+## `HK_PKL_OFFLINE`
+
+Type: `bool`
+Default: `false`
+
+Disables network access in the built-in pklr evaluator. Package imports already present in `HK_PKL_CACHE_DIR` remain available; a missing package fails immediately with its URL and cache location.
+
+This variable is read directly from the environment before `hk.pkl` is evaluated, so it cannot be configured in `hk.pkl`.
 
 ## `HK_PROFILE`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -742,18 +742,17 @@ fn run_pklr<T: DeserializeOwned>(path: &Path) -> Result<T> {
         .as_deref()
         .map(|s| s.split(',').map(String::from).collect::<Vec<_>>())
         .unwrap_or_default();
-    let options = pklr::EvalOptions {
-        client: Some(client),
-        http_rewrites,
-    };
+    let evaluator = pklr::EvaluatorBuilder::new()
+        .http_client(client)
+        .http_rewrites(http_rewrites)
+        .package_cache_dir(env::HK_PKL_CACHE_DIR.clone())
+        .offline(*env::HK_PKL_OFFLINE);
     let rt = tokio::runtime::Handle::try_current();
     let json = match rt {
-        Ok(handle) => tokio::task::block_in_place(|| {
-            handle.block_on(pklr::eval_to_json_with_options(path, options))
-        }),
+        Ok(handle) => tokio::task::block_in_place(|| handle.block_on(evaluator.eval_to_json(path))),
         Err(_) => {
             let rt = tokio::runtime::Runtime::new()?;
-            rt.block_on(pklr::eval_to_json_with_options(path, options))
+            rt.block_on(evaluator.eval_to_json(path))
         }
     }
     .map_err(|e| handle_pklr_eval_error(&e.to_string(), path))?;

--- a/src/env.rs
+++ b/src/env.rs
@@ -99,6 +99,16 @@ pub static HK_PKL_HTTP_REWRITE: LazyLock<Option<String>> =
 pub static HK_PKL_CA_CERTIFICATES: LazyLock<Option<PathBuf>> =
     LazyLock::new(|| var_path("HK_PKL_CA_CERTIFICATES"));
 
+pub static HK_PKL_CACHE_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
+    var_path("HK_PKL_CACHE_DIR").unwrap_or(
+        dirs::cache_dir()
+            .unwrap_or(HOME_DIR.join(".cache"))
+            .join("pklr"),
+    )
+});
+
+pub static HK_PKL_OFFLINE: LazyLock<bool> = LazyLock::new(|| var_true("HK_PKL_OFFLINE"));
+
 /// Set to "pkl" to use the pkl CLI instead of the built-in pklr evaluator.
 pub static HK_PKL_BACKEND: LazyLock<String> =
     LazyLock::new(|| var("HK_PKL_BACKEND").unwrap_or_else(|_| "pklr".to_string()));


### PR DESCRIPTION
## Summary

- persist pklr package downloads under `~/.cache/pklr` by default
- add `HK_PKL_CACHE_DIR` to override the persistent package cache location
- add `HK_PKL_OFFLINE=1` for deterministic network-free Pkl evaluation

## Motivation

hk caches its fully evaluated configuration, so unchanged hooks normally avoid package downloads. A config edit, hk upgrade, cache cleanup, or ephemeral hk cache still forces pklr to fetch the pinned package again. That can block local commits during a GitHub outage.

With the persistent pklr cache, a package downloaded during any prior evaluation remains available even after hk's resolved-config cache is invalidated. Offline mode fails immediately with the missing package URL and cache location instead of attempting the network.

This addresses [discussion #1198](https://github.com/jdx/hk/discussions/1198).

## Dependency status

`pklr` 1.4.0 was published by [jdx/pklr#154](https://github.com/jdx/pklr/pull/154), and `Cargo.lock` now resolves to that release. The manifest remains at the lowest compatible requirement, `pklr = "1"`.

## Validation

- `mise run pkl:gen`
- `cargo check --locked`
- `cargo test --locked` (254 passed)
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `HK_PKL_CACHE_DIR` to configure the built-in package cache directory, defaulting to the platform’s standard cache location.
  * Added `HK_PKL_OFFLINE` to disable network access while continuing to use cached packages.
  * Offline mode supports common truthy environment values.

* **Documentation**
  * Documented the new environment variables and their usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to pklr evaluation and env-driven cache/offline behavior; no auth or hook execution changes.
> 
> **Overview**
> **Built-in pklr** now keeps downloaded Pkl packages on disk (default under the platform cache as `pklr`) and wires that through **`EvaluatorBuilder`** instead of the previous one-shot `EvalOptions` eval API. **`HK_PKL_CACHE_DIR`** overrides the cache path; **`HK_PKL_OFFLINE`** blocks network fetches while still using cached packages, with clear errors when a package is missing.
> 
> **`pklr`** is resolved to **1.4.0** in `Cargo.lock` for the new cache/offline support. Docs add both variables and note they are read from the environment before `hk.pkl` is evaluated (not configurable inside `hk.pkl`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 449c2bf09e08137cf03e4291823d8d8281766bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->