### PR TITLE
fix(hook): preserve worktree root for scoped steps

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -182,6 +182,18 @@ impl Git {
                 .and_then(|p| p.parent().map(|p| p.to_path_buf()))
                 .ok_or(eyre!("failed to find git repository"))?
         };
+        // Git invokes hooks from the work-tree root, so GIT_DIR alone is
+        // sufficient until hk scopes a step to a subdirectory. Preserve that
+        // original work-tree root explicitly for Git commands run by scoped
+        // steps. Keep GIT_INDEX_FILE intact since it may refer to the temporary
+        // index used by `git commit -a` or a path-limited commit.
+        if std::env::var_os("GIT_DIR").is_some()
+            && std::env::var_os("GIT_WORK_TREE").is_none()
+            && root.join(".git").exists()
+        {
+            // SAFETY: this runs before any worker threads are spawned.
+            unsafe { std::env::set_var("GIT_WORK_TREE", &root) };
+        }
         // Always cd into the work tree root so libgit2 and shell-git return
         // relative paths that resolve against the correct directory.
         std::env::set_current_dir(&root)?;

--- a/src/git.rs
+++ b/src/git.rs
@@ -182,18 +182,6 @@ impl Git {
                 .and_then(|p| p.parent().map(|p| p.to_path_buf()))
                 .ok_or(eyre!("failed to find git repository"))?
         };
-        // Git invokes hooks from the work-tree root, so GIT_DIR alone is
-        // sufficient until hk scopes a step to a subdirectory. Preserve that
-        // original work-tree root explicitly for Git commands run by scoped
-        // steps. Keep GIT_INDEX_FILE intact since it may refer to the temporary
-        // index used by `git commit -a` or a path-limited commit.
-        if std::env::var_os("GIT_DIR").is_some()
-            && std::env::var_os("GIT_WORK_TREE").is_none()
-            && root.join(".git").exists()
-        {
-            // SAFETY: this runs before any worker threads are spawned.
-            unsafe { std::env::set_var("GIT_WORK_TREE", &root) };
-        }
         // Always cd into the work tree root so libgit2 and shell-git return
         // relative paths that resolve against the correct directory.
         std::env::set_current_dir(&root)?;

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -320,6 +320,16 @@ impl Step {
                 .stdout(Stdio::inherit())
                 .stderr(Stdio::inherit());
         }
+        // Git invokes hooks from the work-tree root, so GIT_DIR alone is
+        // sufficient until hk scopes a step to a subdirectory. Make the root
+        // explicit only in the child process, keeping the temporary index from
+        // GIT_INDEX_FILE without mutating the environment shared by workers.
+        if std::env::var_os("GIT_DIR").is_some() && std::env::var_os("GIT_WORK_TREE").is_none() {
+            let root = std::env::current_dir()?;
+            if root.join(".git").exists() {
+                cmd = cmd.env("GIT_WORK_TREE", root);
+            }
+        }
         if let Some(dir) = &self.dir {
             cmd = cmd.current_dir(dir);
             // With HK_MISE enabled, resolve the mise environment for the step's

--- a/test/worktree.bats
+++ b/test/worktree.bats
@@ -98,6 +98,33 @@ EOF
     assert_output --partial "linter-ran"
 }
 
+@test "scoped pre-commit step keeps the linked worktree root" {
+    cd "$WORKTREE_DIR"
+    mkdir -p src
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["git-root"] {
+                dir = "src"
+                check = "test \"\$(git rev-parse --show-toplevel)\" = \"$WORKTREE_DIR\" && test \"\$GIT_WORK_TREE\" = \"$WORKTREE_DIR\""
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "add hk config"
+    hk install
+
+    echo "new content" > src/newfile.txt
+    git add src/newfile.txt
+    run git commit -m "test scoped git command"
+    assert_success
+}
+
 @test "hk run pre-commit works in a git worktree" {
     cd "$WORKTREE_DIR"
 

--- a/test/worktree.bats
+++ b/test/worktree.bats
@@ -13,6 +13,7 @@ setup() {
     # Create a worktree
     WORKTREE_DIR="$TEST_TEMP_DIR/worktree"
     git worktree add "$WORKTREE_DIR" -b test-branch
+    WORKTREE_DIR="$(cd "$WORKTREE_DIR" && pwd -P)"
 }
 
 teardown() {
@@ -101,6 +102,8 @@ EOF
 @test "scoped pre-commit step keeps the linked worktree root" {
     cd "$WORKTREE_DIR"
     mkdir -p src
+    echo "original" > src/tracked.txt
+    NORMAL_INDEX="$(git rev-parse --git-path index)"
 
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
@@ -109,19 +112,18 @@ hooks {
         steps {
             ["git-root"] {
                 dir = "src"
-                check = "test \"\$(git rev-parse --show-toplevel)\" = \"$WORKTREE_DIR\" && test \"\$GIT_WORK_TREE\" = \"$WORKTREE_DIR\""
+                check = "test \"\$(git rev-parse --show-toplevel)\" = \"$WORKTREE_DIR\" && test \"\$GIT_WORK_TREE\" = \"$WORKTREE_DIR\" && test -n \"\$GIT_INDEX_FILE\" && test \"\$GIT_INDEX_FILE\" != \"$NORMAL_INDEX\" && ! git diff --cached --quiet -- tracked.txt"
             }
         }
     }
 }
 EOF
-    git add hk.pkl
+    git add hk.pkl src/tracked.txt
     git commit -m "add hk config"
     hk install
 
-    echo "new content" > src/newfile.txt
-    git add src/newfile.txt
-    run git commit -m "test scoped git command"
+    echo "modified" > src/tracked.txt
+    run git commit -am "test scoped git command"
     assert_success
 }
 

--- a/test/worktree.bats
+++ b/test/worktree.bats
@@ -123,7 +123,7 @@ EOF
     hk install
 
     echo "modified" > src/tracked.txt
-    run git commit -am "test scoped git command"
+    GIT_DIR=.git run git commit -am "test scoped git command"
     assert_success
 }
 


### PR DESCRIPTION
## Summary

- set `GIT_WORK_TREE` to the resolved repository root when Git supplies only `GIT_DIR`
- preserve `GIT_INDEX_FILE` so scoped hook steps continue to inspect the index being committed
- cover scoped pre-commit commands in a linked worktree with both libgit2 modes

## Root cause

Git starts non-bare hooks at the worktree root, where an exported `GIT_DIR` works without `GIT_WORK_TREE`. hk then scopes subproject steps to a child directory. Nested Git commands consequently treat that child directory as the worktree root and misalign index paths with filesystem paths.

## Validation

- `cargo fmt --check`
- `mise run test:bats test/worktree.bats`

Fixes the behavior reported in #1138.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hook command environment setup for all steps with GIT_DIR set; behavior is gated and child-only, but incorrect root detection could affect nested git in hooks.
> 
> **Overview**
> Fixes **scoped hook steps** in linked git worktrees where nested `git` commands saw the step’s subdirectory as the worktree root when only `GIT_DIR` was set.
> 
> In `runner.rs`, child processes now get **`GIT_WORK_TREE`** set to the resolved repo root (current directory when `.git` exists there) when `GIT_DIR` is present and `GIT_WORK_TREE` is unset—without changing the shared worker environment or **`GIT_INDEX_FILE`**.
> 
> **`test/worktree.bats`** canonicalizes the worktree path and adds a scoped pre-commit test that asserts toplevel, `GIT_WORK_TREE`, and a temporary index while running from `dir = "src"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 438eb92b4d61b69367577bf0fd41ca8abbc4f77e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Git hook execution for linked worktrees by preserving the correct repository root.
  - Ensured scoped pre-commit checks detect staged changes while using an isolated temporary index.
  - Standardized worktree paths to their absolute physical locations for more reliable setup.
  - Added coverage to verify linked worktree behavior during scoped pre-commit execution and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->