### PR TITLE
chore(pkl): upgrade formatter to 0.32.1

### DIFF
--- a/benchmark/hk.pkl
+++ b/benchmark/hk.pkl
@@ -1,4 +1,5 @@
 amends "../pkl/Config.pkl"
+
 import "../pkl/Builtins.pkl"
 
 // defines what happens during git pre-commit hook

--- a/benchmark/parallel/hk.pkl
+++ b/benchmark/parallel/hk.pkl
@@ -1,4 +1,5 @@
 amends "../../pkl/Config.pkl"
+
 import "../../pkl/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -4,6 +4,7 @@
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
 amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+
 import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -4,6 +4,7 @@
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
 amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+
 import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 // Configure environment for all tools

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -4,6 +4,7 @@
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+
 import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -5,6 +5,7 @@
 /// * Sorts imports with isort
 /// * Validates with flake8
 amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+
 import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,4 +1,5 @@
 amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
+
 import "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,5 +1,6 @@
 // amends "package://github.com/jdx/hk/releases/download/v1.55.0/hk@1.55.0#/Config.pkl"
 amends "pkl/Config.pkl"
+
 import "pkl/Builtins.pkl"
 
 // defines what happens during git pre-commit hook

--- a/mise.lock
+++ b/mise.lock
@@ -556,68 +556,68 @@ version = "3.6.2"
 backend = "npm:prettier"
 
 [[tools.pkl]]
-version = "0.31.1"
+version = "0.32.1"
 backend = "aqua:apple/pkl"
 
 [tools.pkl."platforms.linux-arm64"]
-checksum = "sha256:7ef10e743daa921fb94ae7bdb9ec6986f362bf250c55814b9ea2aeb13f2d083e"
-url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-linux-aarch64"
-url_api = "https://api.github.com/repos/apple/pkl/releases/assets/382243722"
+checksum = "sha256:a76d2dd47da435a8f911b0347373f47c7e59ea54fb75ff846d20b8df10dba058"
+url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-linux-aarch64"
+url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426568"
 
 [tools.pkl."platforms.linux-arm64-musl"]
-checksum = "sha256:7ef10e743daa921fb94ae7bdb9ec6986f362bf250c55814b9ea2aeb13f2d083e"
-url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-linux-aarch64"
-url_api = "https://api.github.com/repos/apple/pkl/releases/assets/382243722"
+checksum = "sha256:a76d2dd47da435a8f911b0347373f47c7e59ea54fb75ff846d20b8df10dba058"
+url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-linux-aarch64"
+url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426568"
 
 [tools.pkl."platforms.linux-x64"]
-checksum = "sha256:618f13955d755cafbfe8c9cba1d27635848cd49dbc6abffd398d2751db1231bf"
-url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-linux-amd64"
-url_api = "https://api.github.com/repos/apple/pkl/releases/assets/382243718"
+checksum = "sha256:3180b62da95c0cad1d904e9bb6c5f4a8f9032413c21e53194bb91ff1ee5f3211"
+url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-linux-amd64"
+url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426567"
 
 [tools.pkl."platforms.linux-x64-baseline"]
-checksum = "sha256:618f13955d755cafbfe8c9cba1d27635848cd49dbc6abffd398d2751db1231bf"
-url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-linux-amd64"
-url_api = "https://api.github.com/repos/apple/pkl/releases/assets/382243718"
+checksum = "sha256:3180b62da95c0cad1d904e9bb6c5f4a8f9032413c21e53194bb91ff1ee5f3211"
+url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-linux-amd64"
+url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426567"
 
 [tools.pkl."platforms.linux-x64-musl"]
-checksum = "sha256:618f13955d755cafbfe8c9cba1d27635848cd49dbc6abffd398d2751db1231bf"
-url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-linux-amd64"
-url_api = "https://api.github.com/repos/apple/pkl/releases/assets/382243718"
+checksum = "sha256:3180b62da95c0cad1d904e9bb6c5f4a8f9032413c21e53194bb91ff1ee5f3211"
+url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-linux-amd64"
+url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426567"
 
 [tools.pkl."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:618f13955d755cafbfe8c9cba1d27635848cd49dbc6abffd398d2751db1231bf"
-url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-linux-amd64"
-url_api = "https://api.github.com/repos/apple/pkl/releases/assets/382243718"
+checksum = "sha256:3180b62da95c0cad1d904e9bb6c5f4a8f9032413c21e53194bb91ff1ee5f3211"
+url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-linux-amd64"
+url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426567"
 
 [tools.pkl."platforms.macos-arm64"]
-checksum = "sha256:1b6a5438d9624cd2798a7530721bbbfa27ef72efe5c878a1b6c546c6e7ca0e8f"
-url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-macos-aarch64"
-url_api = "https://api.github.com/repos/apple/pkl/releases/assets/382243720"
+checksum = "sha256:563eb51c9a20b16a3625464ed745c675ed9750381f2126722696a0d7cac1d9d3"
+url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-macos-aarch64"
+url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426570"
 
 [tools.pkl."platforms.macos-x64"]
-checksum = "sha256:22123ed4ae4c03afa8c54c69f77f0bec39b0fa0f67b09d6d148e0a376a2a471d"
-url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-macos-amd64"
-url_api = "https://api.github.com/repos/apple/pkl/releases/assets/382243726"
+checksum = "sha256:5b74b903234047960144f66f2cebdd12d267d9b98e8155ed91d2ae5ed27e2d1f"
+url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-macos-amd64"
+url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426599"
 
 [tools.pkl."platforms.macos-x64-baseline"]
-checksum = "sha256:22123ed4ae4c03afa8c54c69f77f0bec39b0fa0f67b09d6d148e0a376a2a471d"
-url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-macos-amd64"
-url_api = "https://api.github.com/repos/apple/pkl/releases/assets/382243726"
+checksum = "sha256:5b74b903234047960144f66f2cebdd12d267d9b98e8155ed91d2ae5ed27e2d1f"
+url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-macos-amd64"
+url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426599"
 
 [tools.pkl."platforms.windows-arm64"]
-checksum = "sha256:a8834481667325b44c539dbb758d7365a16389070f343c04b639bbe525ede013"
-url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-windows-amd64.exe"
-url_api = "https://api.github.com/repos/apple/pkl/releases/assets/382243744"
+checksum = "sha256:8550a00fcf027335e42c5e2cd553b88e98845408cb1880b3e3d1860caf46d22a"
+url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-windows-amd64.exe"
+url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426668"
 
 [tools.pkl."platforms.windows-x64"]
-checksum = "sha256:a8834481667325b44c539dbb758d7365a16389070f343c04b639bbe525ede013"
-url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-windows-amd64.exe"
-url_api = "https://api.github.com/repos/apple/pkl/releases/assets/382243744"
+checksum = "sha256:8550a00fcf027335e42c5e2cd553b88e98845408cb1880b3e3d1860caf46d22a"
+url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-windows-amd64.exe"
+url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426668"
 
 [tools.pkl."platforms.windows-x64-baseline"]
-checksum = "sha256:a8834481667325b44c539dbb758d7365a16389070f343c04b639bbe525ede013"
-url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-windows-amd64.exe"
-url_api = "https://api.github.com/repos/apple/pkl/releases/assets/382243744"
+checksum = "sha256:8550a00fcf027335e42c5e2cd553b88e98845408cb1880b3e3d1860caf46d22a"
+url = "https://github.com/apple/pkl/releases/download/0.32.1/pkl-windows-amd64.exe"
+url_api = "https://api.github.com/repos/apple/pkl/releases/assets/487426668"
 
 [[tools.ripgrep]]
 version = "14.1.1"

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -1,5 +1,6 @@
 @ModuleInfo { minPklVersion = "0.27.2" }
 module hk.Config
+
 import "pkl:base" as base
 
 /// The minimum hk version required by this config.

--- a/pkl/Types.pkl
+++ b/pkl/Types.pkl
@@ -1,5 +1,6 @@
 @ModuleInfo { minPklVersion = "0.27.2" }
 module hk.Types
+
 import "pkl:base"
 
 /// Helper function to create regex patterns with clean syntax

--- a/pkl/builtins/test/helpers.pkl
+++ b/pkl/builtins/test/helpers.pkl
@@ -1,5 +1,6 @@
 /// Helper for hk step tests
 module hk.builtins.test.helpers
+
 import "../../Config.pkl"
 
 class TestMaker {

--- a/scripts/reflect.pkl
+++ b/scripts/reflect.pkl
@@ -1,6 +1,7 @@
 /// A PKL script to help output a reflected module.
 /// Example Invocation: pkl eval <pkl file> --format json -x "import (\"file:$PWD/scripts/reflect.pkl\").render(module)"
 module hk.reflect
+
 import "pkl:reflect"
 
 local renderer = module.output.renderer


### PR DESCRIPTION
## Summary

- upgrade the locked Pkl formatter from 0.31.1 to 0.32.1
- apply Pkl 0.32.1 formatting to the affected modules and examples
- keep the lockfile change scoped to Pkl

## Why

Renovate PR #1202 upgraded Pkl through lockfile maintenance, but Pkl 0.32.1 requires a blank line between module/amends declarations and imports. The `pkl-format` CI step therefore rejected 12 existing files. Landing the formatter migration separately lets future lockfile maintenance use Pkl 0.32.1 without failing lint.

## Validation

- `target/debug/hk check -S pkl-format`
- `mise exec pkl@0.32.1 -- pkl format --diff-name-only .`
- `git diff --check`

The full local lint task reached and passed `pkl-format`, but could not complete because the local `actionlint` process resolves an unconfigured global `shellcheck` shim. CI provisions that dependency.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toolchain and whitespace-only formatting; no runtime or config behavior changes.
> 
> **Overview**
> Bumps the locked **Pkl** toolchain from **0.31.1** to **0.32.1** in `mise.lock` (checksums and download URLs for all platforms).
> 
> Reformats **12** `.pkl` files so they satisfy Pkl **0.32.1** style: a **blank line** between the `amends` / `module` header and the first `import`. Affected paths include root and benchmark `hk.pkl` files, public docs examples, `pkl/Config.pkl`, `pkl/Types.pkl`, test helpers, and `scripts/reflect.pkl`. No hook or config semantics change—only whitespace layout and the tool pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4e57ac58ea7e27dbd13fd612a11cd9ec3f568c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->