### PR TITLE
Add `HK_OUTPUT_FILE` env var to control the output file location

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -173,6 +173,13 @@ Default: `HK_LOG`
 
 The log level to use for the log file.
 
+## `HK_OUTPUT_FILE`
+
+Type: `path`
+Default: `~/.local/state/hk/output.log`
+
+The file where hk writes the complete output of a failed command. An empty value uses the default location.
+
 ## `HK_MISE`
 
 Type: `bool`

--- a/settings.toml
+++ b/settings.toml
@@ -280,6 +280,19 @@ Defaults to the same level as `log_level` if not specified.
 This allows you to have different verbosity levels for console and file output.
 """
 
+[output_file]
+type = "path"
+sources.env = ["HK_OUTPUT_FILE"]
+docs = """
+Path to the file where hk writes the complete output of a failed command.
+
+Default location: `~/.local/state/hk/output.log`
+
+An empty value uses the default location.
+
+Useful for preserving full command output when hook summaries are abbreviated.
+"""
+
 [log_level]
 type = "enum"
 default = "info"

--- a/src/env.rs
+++ b/src/env.rs
@@ -38,6 +38,11 @@ pub static HK_LOG_FILE_LEVEL: LazyLock<log::LevelFilter> =
     LazyLock::new(|| var_log_level("HK_LOG_FILE_LEVEL").unwrap_or(*HK_LOG));
 pub static HK_LOG_FILE: LazyLock<PathBuf> =
     LazyLock::new(|| var_path("HK_LOG_FILE").unwrap_or(HK_STATE_DIR.join("hk.log")));
+pub static HK_OUTPUT_FILE: LazyLock<PathBuf> = LazyLock::new(|| {
+    var_path("HK_OUTPUT_FILE")
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| HK_STATE_DIR.join("output.log"))
+});
 
 // When set, write a JSON timing report to this path after the hook finishes
 pub static HK_TIMING_JSON: LazyLock<Option<PathBuf>> = LazyLock::new(|| var_path("HK_TIMING_JSON"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,13 +94,18 @@ fn friendly_error(e: eyre::Report) -> Result<()> {
 }
 
 fn write_output_file(result: &ensembler::CmdResult) {
-    let path = env::HK_STATE_DIR.join("output.log");
-    let Some(parent) = path.parent() else {
-        return;
+    let path = &*env::HK_OUTPUT_FILE;
+    let create_parent = if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+    } else {
+        Ok(())
     };
-    if let Err(e) = std::fs::create_dir_all(parent).and_then(|_| {
+    if let Err(e) = create_parent.and_then(|_| {
         let output = console::strip_ansi_codes(&result.combined_output);
-        std::fs::write(&path, output.as_ref())
+        std::fs::write(path, output.as_ref())
     }) {
         warn!("Error writing output file: {e:?}");
         return;

--- a/test/output_file.bats
+++ b/test/output_file.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "HK_OUTPUT_FILE writes failed command output to a custom path" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["fail"] {
+        check = "echo CUSTOM_OUTPUT_FILE_MARKER 1>&2 && exit 1"
+        glob = List("*.txt")
+      }
+    }
+  }
+}
+EOF
+    echo "content" > file.txt
+    git add file.txt
+
+    output_file="$BATS_TEST_TMPDIR/nested/logs/failed-output.log"
+    HK_OUTPUT_FILE="$output_file" run hk check
+
+    assert_failure
+    assert_output --partial "See $output_file for full command output"
+    assert_file_exist "$output_file"
+    assert_file_contains "$output_file" "CUSTOM_OUTPUT_FILE_MARKER"
+    assert_file_not_exist "$HK_STATE_DIR/output.log"
+}
+
+@test "empty HK_OUTPUT_FILE uses the default location" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["fail"] {
+        check = "echo EMPTY_OUTPUT_FILE_MARKER 1>&2 && exit 1"
+        glob = List("*.txt")
+      }
+    }
+  }
+}
+EOF
+    echo "content" > file.txt
+    git add file.txt
+    export HK_STATE_DIR="$BATS_TEST_TMPDIR/hk_state"
+
+    HK_OUTPUT_FILE="" run hk check
+
+    output_file="$HK_STATE_DIR/output.log"
+    assert_failure
+    assert_output --partial "See $output_file for full command output"
+    assert_file_exist "$output_file"
+    assert_file_contains "$output_file" "EMPTY_OUTPUT_FILE_MARKER"
+}
+
+@test "HK_OUTPUT_FILE writes to a bare filename" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["check"] {
+    steps {
+      ["fail"] {
+        check = "echo BARE_OUTPUT_FILE_MARKER 1>&2 && exit 1"
+        glob = List("*.txt")
+      }
+    }
+  }
+}
+EOF
+    echo "content" > file.txt
+    git add file.txt
+
+    HK_OUTPUT_FILE="failed-output.log" run hk check
+
+    assert_failure
+    assert_output --partial "See failed-output.log for full command output"
+    assert_file_exist "failed-output.log"
+    assert_file_contains "failed-output.log" "BARE_OUTPUT_FILE_MARKER"
+}


### PR DESCRIPTION
Closes #1201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the location of complete failed-command output.
  * The output file defaults to `~/.local/state/hk/output.log` and can be customized with `HK_OUTPUT_FILE`.
  * Custom nested paths are created and reported when commands fail.

* **Documentation**
  * Documented the new environment variable, including its path format, default location, and purpose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->