### PR TITLE
fix(step): preserve condition compatibility with expr v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+ "serde",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,7 +336,7 @@ dependencies = [
  "nix 0.31.3",
  "serde",
  "serde_json",
- "strum 0.28.0",
+ "strum",
  "tera",
  "thiserror",
  "unicode-width 0.2.2",
@@ -703,10 +714,14 @@ dependencies = [
 
 [[package]]
 name = "expr-lang"
-version = "1.1.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e6e9a6990c24970375077a97a392146b5be2155a957d9a4e5337ca0bde0c26"
+checksum = "86283664be0dc99b1247e957cf8234bb0e98fe76096bd36767d8f87ac98f00b7"
 dependencies = [
+ "base64 0.23.1",
+ "chrono",
+ "chrono-tz",
+ "iana-time-zone",
  "indexmap 2.14.0",
  "log",
  "once_cell",
@@ -715,7 +730,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum 0.27.2",
+ "strum",
  "thiserror",
 ]
 
@@ -1004,7 +1019,7 @@ dependencies = [
  "shell-words",
  "similar",
  "siphasher",
- "strum 0.28.0",
+ "strum",
  "tempfile",
  "tera",
  "thiserror",
@@ -1873,6 +1888,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,32 +2717,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "strum_macros",
 ]
 
 [[package]]
@@ -3205,7 +3217,7 @@ dependencies = [
  "roff",
  "serde",
  "shell-words",
- "strum 0.28.0",
+ "strum",
  "tera",
  "thiserror",
  "versions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ dashmap            = "6"
 demand             = "2"
 dirs               = "6"
 ensembler          = "1"
-expr-lang          = { version = "1", features = ["serde"] }
+expr-lang          = { version = "2", features = ["serde"] }
 eyre               = "0.6"
 git2               = { version = "0.21", features = ["vendored-libgit2"] }
 globset            = "0.4"

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -29,7 +29,7 @@ use crate::{
     hook_options::HookOptions,
     plan::{ParallelGroup, Plan, PlannedStep, Reason, ReasonKind, StepStatus},
     settings::Settings,
-    step::{CommandEffect, EXPR_CTX, EXPR_ENV, OutputSummary, RunType, Script, Step},
+    step::{CommandEffect, EXPR_CTX, OutputSummary, RunType, Script, Step, eval_condition},
     step_context::StepContext,
     step_group::{StepGroup, StepGroupContext},
     timings::TimingRecorder,
@@ -755,7 +755,7 @@ impl Hook {
         // Bool(false) causes a skip — any other value (including non-bool
         // results from exec()) is truthy.
         if let Some(condition) = &step.step_condition {
-            match EXPR_ENV.eval(condition, expr_ctx) {
+            match eval_condition(condition, expr_ctx) {
                 Ok(expr::Value::Bool(false)) => {
                     reasons.push(Reason {
                         kind: ReasonKind::ConditionFalse,
@@ -817,7 +817,7 @@ impl Hook {
         // literal Bool(false) skips the step. Truthy values (including strings)
         // pass through.
         if let Some(condition) = &step.job_condition {
-            match EXPR_ENV.eval(condition, expr_ctx) {
+            match eval_condition(condition, expr_ctx) {
                 Ok(expr::Value::Bool(false)) => {
                     reasons.push(Reason {
                         kind: ReasonKind::ConditionFalse,

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -22,7 +22,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, LazyLock};
 use tokio::sync::OwnedSemaphorePermit;
 
-use super::expr_env::EXPR_ENV;
+use super::expr_env::eval_condition;
 use super::types::{CheckFirstCmd, RunType, Step};
 
 /// Default stage pattern for steps with fix commands when staging is enabled.
@@ -56,7 +56,7 @@ impl Step {
         let ctx = Arc::new(ctx);
 
         if let Some(step_condition) = &self.step_condition {
-            let val = EXPR_ENV.eval(step_condition, &ctx.hook_ctx.expr_ctx())?;
+            let val = eval_condition(step_condition, &ctx.hook_ctx.expr_ctx())?;
             debug!("{self}: condition: {step_condition} = {val}");
             if val == expr::Value::Bool(false) {
                 self.mark_skipped(&ctx, &SkipReason::ConditionFalse)?;

--- a/src/step/expr_env.rs
+++ b/src/step/expr_env.rs
@@ -24,3 +24,124 @@ pub static EXPR_ENV: LazyLock<expr::Environment> = LazyLock::new(|| {
 
     env
 });
+
+/// Evaluate an hk condition while preserving expr-lang v1 string behavior.
+///
+/// Pkl decodes escapes before hk sees a condition, so a Pkl string containing
+/// `\n` reaches the expression parser as a literal newline inside a quoted
+/// string. expr-lang v1 accepted that syntax, while v2 requires the newline to
+/// be escaped. Rewrite only raw newlines in interpreted string literals;
+/// multiline backtick strings, comments, and expression whitespace are left
+/// unchanged.
+pub fn eval_condition(code: &str, ctx: &expr::Context) -> expr::Result<expr::Value> {
+    EXPR_ENV.eval(&escape_quoted_newlines(code), ctx)
+}
+
+#[derive(Clone, Copy)]
+enum LexState {
+    Normal,
+    SingleQuoted,
+    DoubleQuoted,
+    BacktickQuoted,
+    LineComment,
+    BlockComment,
+}
+
+fn escape_quoted_newlines(code: &str) -> String {
+    let mut escaped = String::with_capacity(code.len());
+    let mut chars = code.chars().peekable();
+    let mut state = LexState::Normal;
+
+    while let Some(ch) = chars.next() {
+        match state {
+            LexState::Normal => {
+                escaped.push(ch);
+                state = match ch {
+                    '\'' => LexState::SingleQuoted,
+                    '"' => LexState::DoubleQuoted,
+                    '`' => LexState::BacktickQuoted,
+                    '/' if chars.peek() == Some(&'/') => {
+                        escaped.push(chars.next().expect("peeked line-comment delimiter"));
+                        LexState::LineComment
+                    }
+                    '/' if chars.peek() == Some(&'*') => {
+                        escaped.push(chars.next().expect("peeked block-comment delimiter"));
+                        LexState::BlockComment
+                    }
+                    _ => LexState::Normal,
+                };
+            }
+            LexState::SingleQuoted | LexState::DoubleQuoted => {
+                let quote = if matches!(state, LexState::SingleQuoted) {
+                    '\''
+                } else {
+                    '"'
+                };
+                match ch {
+                    '\\' => {
+                        escaped.push(ch);
+                        if let Some(next) = chars.next() {
+                            escaped.push(next);
+                        }
+                    }
+                    '\n' => escaped.push_str("\\n"),
+                    '\r' => escaped.push_str("\\r"),
+                    _ => {
+                        escaped.push(ch);
+                        if ch == quote {
+                            state = LexState::Normal;
+                        }
+                    }
+                }
+            }
+            LexState::BacktickQuoted => {
+                escaped.push(ch);
+                if ch == '`' {
+                    state = LexState::Normal;
+                }
+            }
+            LexState::LineComment => {
+                escaped.push(ch);
+                if ch == '\n' {
+                    state = LexState::Normal;
+                }
+            }
+            LexState::BlockComment => {
+                escaped.push(ch);
+                if ch == '*' && chars.peek() == Some(&'/') {
+                    escaped.push(chars.next().expect("peeked block-comment delimiter"));
+                    state = LexState::Normal;
+                }
+            }
+        }
+    }
+
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EXPR_CTX, escape_quoted_newlines, eval_condition};
+
+    #[test]
+    fn escapes_raw_newlines_in_interpreted_strings() {
+        assert_eq!(
+            escape_quoted_newlines("'line 1\nline 2' == \"line 1\r\nline 2\""),
+            "'line 1\\nline 2' == \"line 1\\r\\nline 2\""
+        );
+    }
+
+    #[test]
+    fn leaves_multiline_strings_comments_and_whitespace_unchanged() {
+        let code = "`raw\nstring` // 'comment\n\n&& true /* \"comment\n */";
+        assert_eq!(escape_quoted_newlines(code), code);
+    }
+
+    #[test]
+    fn evaluates_v1_style_raw_newline_literals() {
+        assert_eq!(
+            eval_condition("'ITWORKS\n' == 'ITWORKS\\n'", &EXPR_CTX).unwrap(),
+            expr::Value::Bool(true)
+        );
+    }
+}

--- a/src/step/mod.rs
+++ b/src/step/mod.rs
@@ -45,7 +45,7 @@ mod shell;
 mod types;
 
 // Re-export public API
-pub use expr_env::{EXPR_CTX, EXPR_ENV};
+pub use expr_env::{EXPR_CTX, eval_condition};
 pub use shell::ShellType;
 pub(crate) use types::RenderedCommand;
 #[cfg(test)]

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -22,7 +22,7 @@ use itertools::Itertools;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
-use super::expr_env::EXPR_ENV;
+use super::expr_env::eval_condition;
 use super::shell::ShellType;
 use super::types::{
     CheckFirstCmd, Command, CommandPrefix, Pattern, RenderedCommand, RunType, Step,
@@ -140,7 +140,7 @@ impl Step {
             return Ok(());
         }
         if let Some(job_condition) = &self.job_condition {
-            let val = EXPR_ENV.eval(job_condition, &ctx.hook_ctx.expr_ctx())?;
+            let val = eval_condition(job_condition, &ctx.hook_ctx.expr_ctx())?;
             debug!("{self}: condition: {job_condition} = {val}");
             if val == expr::Value::Bool(false) {
                 self.mark_skipped(ctx, &SkipReason::ConditionFalse)?;


### PR DESCRIPTION
## Summary

- upgrade `expr-lang` from v1 to v2
- preserve v1 behavior for raw CR/LF characters inside quoted condition strings
- route runtime and plan condition evaluation through the compatibility layer
- cover quoted strings, backtick strings, comments, CRLF, and the existing Pkl-decoded newline behavior

## Root cause

Pkl decodes `\n` before hk evaluates a condition. As a result, existing conditions can contain a raw newline inside an Expr single- or double-quoted string. `expr-lang` v1 accepted that syntax, while v2 rejects it in favor of escaped newlines or backtick strings.

The compatibility layer lexes conditions before evaluation and escapes raw CR/LF characters only inside interpreted quoted strings. It leaves backtick multiline strings, comments, escapes, and expression whitespace unchanged.

## Validation

- `mise run test:cargo` — 257 passed
- `mise run test:bats test/condition.bats` — passed
- `cargo test step::expr_env::tests` — 3 passed
- `cargo fmt --all`
- `./target/debug/hk check --all` — could not complete because nested checks resolve an `hk` mise shim with no global version selected; completed formatting checks passed before fail-fast cancellation

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all step/job conditions are parsed and evaluated; the lexer shim must stay correct for edge cases in quoted strings, comments, and backticks.
> 
> **Overview**
> Upgrades **`expr-lang`** from v1 to v2 and adds a **`eval_condition`** compatibility layer so existing hook **`step_condition`** / **`job_condition`** expressions keep working.
> 
> Pkl can leave **literal newlines** inside single- or double-quoted condition strings after decoding escapes; v2 rejects that syntax where v1 allowed it. Before evaluation, **`escape_quoted_newlines`** rewrites raw `\n`/`\r` only inside interpreted quoted strings, leaving backtick literals, comments, and other text alone.
> 
> Runtime (**`execution.rs`**, **`runner.rs`**) and plan analysis (**`hook.rs`**) now evaluate conditions through **`eval_condition`** instead of calling **`EXPR_ENV.eval`** directly. **`Cargo.lock`** also deduplicates **`strum`** to 0.28.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a1d71a9e9ac5f1b94569a63ea92327b6feffa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->