### PR TITLE
docs: fix mobile banner and homepage overflow

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -108,10 +108,17 @@ export default defineConfig({
       `(function () {
   try {
     var d = document.documentElement;
-    var id = localStorage.getItem("jdx-banner-id");
-    var h = localStorage.getItem("jdx-banner-height");
-    if (id && h && localStorage.getItem("jdx-banner-dismissed") !== id)
-      d.style.setProperty("--vp-layout-top-height", h);
+    var c = JSON.parse(localStorage.getItem("jdx-banner-cache") || "null");
+    var expires = c && c.expires ? Date.parse(c.expires) : NaN;
+    if (
+      c &&
+      c.id &&
+      c.height &&
+      c.width === innerWidth &&
+      (!c.expires || isNaN(expires) || Date.now() < expires) &&
+      localStorage.getItem("jdx-banner-dismissed") !== c.id
+    )
+      d.style.setProperty("--vp-layout-top-height", c.height);
   } catch (e) {}
 })();`,
     ],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -111,19 +111,25 @@ export default defineConfig({
     var c = JSON.parse(localStorage.getItem("jdx-banner-cache") || "null");
     var expires = c && c.expires ? Date.parse(c.expires) : NaN;
     var now = Date.now();
-    if (
+    var valid =
       c &&
-      c.id &&
-      c.height &&
+      typeof c.id === "string" &&
+      typeof c.height === "string" &&
+      /^[1-9]\d*(?:\.\d+)?px$/.test(c.height) &&
+      Number.isFinite(c.width) &&
       c.width === innerWidth &&
+      typeof c.fontSize === "string" &&
       c.fontSize === getComputedStyle(d).fontSize &&
+      Number.isFinite(c.pixelRatio) &&
       c.pixelRatio === devicePixelRatio &&
       Number.isFinite(c.cachedAt) &&
+      c.cachedAt <= now &&
       now - c.cachedAt < 300000 &&
-      (!c.expires || (Number.isFinite(expires) && now < expires)) &&
-      localStorage.getItem("jdx-banner-dismissed") !== c.id
-    )
+      (!c.expires || (typeof c.expires === "string" && Number.isFinite(expires) && now < expires));
+    if (valid && localStorage.getItem("jdx-banner-dismissed") !== c.id)
       d.style.setProperty("--vp-layout-top-height", c.height);
+    else if (c)
+      localStorage.removeItem("jdx-banner-cache");
   } catch (e) {}
 })();`,
     ],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -102,6 +102,19 @@ export default defineConfig({
     }]
   },
   head: [
+    [
+      "script",
+      {},
+      `(function () {
+  try {
+    var d = document.documentElement;
+    var id = localStorage.getItem("jdx-banner-id");
+    var h = localStorage.getItem("jdx-banner-height");
+    if (id && h && localStorage.getItem("jdx-banner-dismissed") !== id)
+      d.style.setProperty("--vp-layout-top-height", h);
+  } catch (e) {}
+})();`,
+    ],
     // OpenGraph
     ["meta", { property: "og:site_name", content: "hk" }],
     ["meta", { property: "og:type", content: "website" }],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -111,24 +111,26 @@ export default defineConfig({
     var c = JSON.parse(localStorage.getItem("jdx-banner-cache") || "null");
     var expires = c && c.expires ? Date.parse(c.expires) : NaN;
     var now = Date.now();
-    var valid =
+    var metadataValid =
       c &&
       typeof c.id === "string" &&
       typeof c.height === "string" &&
-      /^[1-9]\d*(?:\.\d+)?px$/.test(c.height) &&
+      /^[1-9]\\d*(?:\\.\\d+)?px$/.test(c.height) &&
       Number.isFinite(c.width) &&
-      c.width === innerWidth &&
       typeof c.fontSize === "string" &&
-      c.fontSize === getComputedStyle(d).fontSize &&
       Number.isFinite(c.pixelRatio) &&
-      c.pixelRatio === devicePixelRatio &&
       Number.isFinite(c.cachedAt) &&
       c.cachedAt <= now &&
       now - c.cachedAt < 300000 &&
       (!c.expires || (typeof c.expires === "string" && Number.isFinite(expires) && now < expires));
-    if (valid && localStorage.getItem("jdx-banner-dismissed") !== c.id)
+    var contextMatches =
+      metadataValid &&
+      c.width === innerWidth &&
+      c.fontSize === getComputedStyle(d).fontSize &&
+      c.pixelRatio === devicePixelRatio;
+    if (contextMatches && localStorage.getItem("jdx-banner-dismissed") !== c.id)
       d.style.setProperty("--vp-layout-top-height", c.height);
-    else if (c)
+    else if (c && !metadataValid)
       localStorage.removeItem("jdx-banner-cache");
   } catch (e) {}
 })();`,

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -110,12 +110,17 @@ export default defineConfig({
     var d = document.documentElement;
     var c = JSON.parse(localStorage.getItem("jdx-banner-cache") || "null");
     var expires = c && c.expires ? Date.parse(c.expires) : NaN;
+    var now = Date.now();
     if (
       c &&
       c.id &&
       c.height &&
       c.width === innerWidth &&
-      (!c.expires || isNaN(expires) || Date.now() < expires) &&
+      c.fontSize === getComputedStyle(d).fontSize &&
+      c.pixelRatio === devicePixelRatio &&
+      Number.isFinite(c.cachedAt) &&
+      now - c.cachedAt < 300000 &&
+      (!c.expires || (Number.isFinite(expires) && now < expires)) &&
       localStorage.getItem("jdx-banner-dismissed") !== c.id
     )
       d.style.setProperty("--vp-layout-top-height", c.height);

--- a/docs/.vitepress/theme/HomePage.vue
+++ b/docs/.vitepress/theme/HomePage.vue
@@ -407,7 +407,7 @@ const copyToClipboard = async () => {
 
 .features-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(300px, 100%), 1fr));
   gap: 2rem;
 }
 

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -14,6 +14,7 @@
   font-size: 0.9rem;
   line-height: 1.4;
   text-align: center;
+  min-height: 2.75rem;
 }
 .jdx-banner a {
   color: #000;
@@ -31,7 +32,11 @@
   font-size: 1.25rem;
   cursor: pointer;
   line-height: 1;
-  padding: 0 0.5rem;
+  display: grid;
+  place-items: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
   opacity: 0.7;
 }
 .jdx-banner button:hover {
@@ -47,8 +52,8 @@
     text-wrap: balance;
   }
   .jdx-banner button {
-    top: 0.25rem;
-    right: 0.25rem;
-    transform: none;
+    top: 50%;
+    right: 0;
+    transform: translateY(-50%);
   }
 }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -8,7 +8,7 @@
   gap: 0.75rem;
   align-items: center;
   justify-content: center;
-  padding: 0.5rem 2.75rem;
+  padding: 0.5rem 3.25rem 0.5rem 2.75rem;
   background: var(--vp-c-brand-1, #3abff8);
   color: #000;
   font-size: 0.9rem;

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -49,7 +49,7 @@
     flex-direction: column;
     gap: 0.125rem;
     font-size: 0.8rem;
-    padding: 0.5rem 2.75rem;
+    padding: 0.5rem max(2.75rem, 44px);
     line-height: 1.3;
     text-wrap: balance;
   }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -36,6 +36,8 @@
   place-items: center;
   width: 2.75rem;
   height: 2.75rem;
+  min-width: 44px;
+  min-height: 44px;
   padding: 0;
   opacity: 0.7;
 }
@@ -47,7 +49,7 @@
     flex-direction: column;
     gap: 0.125rem;
     font-size: 0.8rem;
-    padding: 0.5rem 2.25rem;
+    padding: 0.5rem 2.75rem;
     line-height: 1.3;
     text-wrap: balance;
   }

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -18,6 +18,7 @@ let activeBanner:
       element: HTMLElement;
       observer: ResizeObserver | null;
       update: (banner: BannerData) => void;
+      cancelExpiration: () => void;
     }
   | undefined;
 
@@ -142,6 +143,7 @@ function cacheBanner(b: BannerData, height: number): void {
 }
 
 function removeActiveBanner(): void {
+  activeBanner?.cancelExpiration();
   activeBanner?.observer?.disconnect();
   activeBanner?.element.remove();
   activeBanner = undefined;
@@ -191,9 +193,35 @@ function render(b: BannerData, persist = true): void {
     typeof ResizeObserver !== "undefined"
       ? new ResizeObserver(syncHeight)
       : null;
+  let expirationTimer: number | undefined;
+  const cancelExpiration = () => {
+    if (expirationTimer !== undefined) window.clearTimeout(expirationTimer);
+    expirationTimer = undefined;
+  };
+  const scheduleExpiration = () => {
+    cancelExpiration();
+    if (!currentBanner.expires) return;
+    const expiresAt = Date.parse(currentBanner.expires);
+    if (Number.isNaN(expiresAt)) return;
+    const expire = () => {
+      if (activeBanner?.element !== el) return;
+      const remaining = expiresAt - Date.now();
+      if (remaining <= 0) {
+        removeActiveBanner();
+        clearReserved();
+        return;
+      }
+      expirationTimer = window.setTimeout(
+        expire,
+        Math.min(remaining, 2_147_483_647),
+      );
+    };
+    expire();
+  };
   const update = (next: BannerData) => {
     shouldPersist = true;
     updateContent(next);
+    scheduleExpiration();
     requestAnimationFrame(syncHeight);
   };
 
@@ -213,7 +241,14 @@ function render(b: BannerData, persist = true): void {
   el.appendChild(btn);
 
   document.body.prepend(el);
-  activeBanner = { id: b.id, element: el, observer, update };
+  activeBanner = {
+    id: b.id,
+    element: el,
+    observer,
+    update,
+    cancelExpiration,
+  };
+  scheduleExpiration();
 
   requestAnimationFrame(syncHeight);
   observer?.observe(el);

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -11,33 +11,46 @@ interface BannerData {
 
 const ENDPOINT = "https://jdx.dev/banner.json";
 const STORAGE_KEY = "jdx-banner-dismissed";
-const ID_KEY = "jdx-banner-id";
-const HEIGHT_KEY = "jdx-banner-height";
+const CACHE_KEY = "jdx-banner-cache";
+
+function getDismissedId(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
 
 export function initBanner(): void {
   if (typeof window === "undefined") return;
-  fetch(ENDPOINT)
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), 5000);
+  fetch(ENDPOINT, { signal: controller.signal })
     .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
     .then((b) => {
       if (
         !b ||
         !b.enabled ||
         isExpired(b.expires) ||
-        localStorage.getItem(STORAGE_KEY) === b.id
+        getDismissedId() === b.id
       ) {
         clearReserved();
         return;
       }
       render(b);
     })
-    .catch(clearReserved);
+    .catch(clearCurrentReservation)
+    .finally(() => window.clearTimeout(timeout));
+}
+
+function clearCurrentReservation(): void {
+  document.documentElement.style.removeProperty("--vp-layout-top-height");
 }
 
 function clearReserved(): void {
-  document.documentElement.style.removeProperty("--vp-layout-top-height");
+  clearCurrentReservation();
   try {
-    localStorage.removeItem(ID_KEY);
-    localStorage.removeItem(HEIGHT_KEY);
+    localStorage.removeItem(CACHE_KEY);
   } catch {
     // localStorage unavailable — nothing cached to clear.
   }
@@ -84,8 +97,15 @@ function render(b: BannerData): void {
       `${el.offsetHeight}px`,
     );
     try {
-      localStorage.setItem(ID_KEY, b.id);
-      localStorage.setItem(HEIGHT_KEY, `${el.offsetHeight}px`);
+      localStorage.setItem(
+        CACHE_KEY,
+        JSON.stringify({
+          id: b.id,
+          height: `${el.offsetHeight}px`,
+          width: window.innerWidth,
+          expires: b.expires ?? null,
+        }),
+      );
     } catch {
       // localStorage unavailable — skip caching.
     }
@@ -101,7 +121,11 @@ function render(b: BannerData): void {
   btn.setAttribute("aria-label", "Dismiss");
   btn.textContent = "\u00d7";
   btn.addEventListener("click", () => {
-    localStorage.setItem(STORAGE_KEY, b.id);
+    try {
+      localStorage.setItem(STORAGE_KEY, b.id);
+    } catch {
+      // Dismiss for this page even when localStorage is unavailable.
+    }
     observer?.disconnect();
     el.remove();
     clearReserved();

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -11,18 +11,36 @@ interface BannerData {
 
 const ENDPOINT = "https://jdx.dev/banner.json";
 const STORAGE_KEY = "jdx-banner-dismissed";
+const ID_KEY = "jdx-banner-id";
+const HEIGHT_KEY = "jdx-banner-height";
 
 export function initBanner(): void {
   if (typeof window === "undefined") return;
   fetch(ENDPOINT)
     .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
     .then((b) => {
-      if (!b || !b.enabled) return;
-      if (isExpired(b.expires)) return;
-      if (localStorage.getItem(STORAGE_KEY) === b.id) return;
+      if (
+        !b ||
+        !b.enabled ||
+        isExpired(b.expires) ||
+        localStorage.getItem(STORAGE_KEY) === b.id
+      ) {
+        clearReserved();
+        return;
+      }
       render(b);
     })
-    .catch(() => {});
+    .catch(clearReserved);
+}
+
+function clearReserved(): void {
+  document.documentElement.style.removeProperty("--vp-layout-top-height");
+  try {
+    localStorage.removeItem(ID_KEY);
+    localStorage.removeItem(HEIGHT_KEY);
+  } catch {
+    // localStorage unavailable — nothing cached to clear.
+  }
 }
 
 function isExpired(expires: string | undefined): boolean {
@@ -65,6 +83,12 @@ function render(b: BannerData): void {
       "--vp-layout-top-height",
       `${el.offsetHeight}px`,
     );
+    try {
+      localStorage.setItem(ID_KEY, b.id);
+      localStorage.setItem(HEIGHT_KEY, `${el.offsetHeight}px`);
+    } catch {
+      // localStorage unavailable — skip caching.
+    }
   };
 
   const observer =
@@ -80,7 +104,7 @@ function render(b: BannerData): void {
     localStorage.setItem(STORAGE_KEY, b.id);
     observer?.disconnect();
     el.remove();
-    document.documentElement.style.removeProperty("--vp-layout-top-height");
+    clearReserved();
   });
   el.appendChild(btn);
 

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -26,7 +26,10 @@ export function initBanner(): void {
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), 5000);
   fetch(ENDPOINT, { signal: controller.signal })
-    .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
+    .then((r) => {
+      if (!r.ok) throw new Error(`banner request failed: ${r.status}`);
+      return r.json() as Promise<BannerData>;
+    })
     .then((b) => {
       if (
         !b ||
@@ -39,8 +42,16 @@ export function initBanner(): void {
       }
       render(b);
     })
-    .catch(clearCurrentReservation)
+    .catch(clearCachedReservation)
     .finally(() => window.clearTimeout(timeout));
+}
+
+function clearCachedReservation(): void {
+  try {
+    localStorage.removeItem(CACHE_KEY);
+  } catch {
+    // localStorage unavailable — nothing cached to clear.
+  }
 }
 
 function clearCurrentReservation(): void {
@@ -49,11 +60,7 @@ function clearCurrentReservation(): void {
 
 function clearReserved(): void {
   clearCurrentReservation();
-  try {
-    localStorage.removeItem(CACHE_KEY);
-  } catch {
-    // localStorage unavailable — nothing cached to clear.
-  }
+  clearCachedReservation();
 }
 
 function isExpired(expires: string | undefined): boolean {
@@ -103,6 +110,9 @@ function render(b: BannerData): void {
           id: b.id,
           height: `${el.offsetHeight}px`,
           width: window.innerWidth,
+          fontSize: getComputedStyle(document.documentElement).fontSize,
+          pixelRatio: window.devicePixelRatio,
+          cachedAt: Date.now(),
           expires: b.expires ?? null,
         }),
       );

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -17,6 +17,7 @@ let activeBanner:
       id: string;
       element: HTMLElement;
       observer: ResizeObserver | null;
+      update: (banner: BannerData) => void;
     }
   | undefined;
 
@@ -52,7 +53,7 @@ export function initBanner(): void {
         return;
       }
       if (activeBanner?.id === b.id) {
-        cacheBanner(b, activeBanner.element.offsetHeight);
+        activeBanner.update(b);
         return;
       }
       render(b);
@@ -148,36 +149,53 @@ function removeActiveBanner(): void {
 
 function render(b: BannerData, persist = true): void {
   removeActiveBanner();
+  let currentBanner = b;
+  let shouldPersist = persist;
   const el = document.createElement("div");
   el.className = "jdx-banner";
   el.setAttribute("role", "region");
   el.setAttribute("aria-label", "Site announcement");
 
   const msg = document.createElement("span");
-  msg.textContent = b.message;
   el.appendChild(msg);
 
-  if (b.link && isHttpUrl(b.link)) {
-    const a = document.createElement("a");
-    a.href = b.link;
-    a.target = "_blank";
-    a.rel = "noopener";
-    a.textContent = b.linkText || "Learn more";
-    el.appendChild(a);
-  }
+  const link = document.createElement("a");
+  link.target = "_blank";
+  link.rel = "noopener";
+  el.appendChild(link);
+
+  const updateContent = (next: BannerData) => {
+    currentBanner = next;
+    msg.textContent = next.message;
+    if (next.link && isHttpUrl(next.link)) {
+      link.href = next.link;
+      link.textContent = next.linkText || "Learn more";
+      link.hidden = false;
+    } else {
+      link.removeAttribute("href");
+      link.textContent = "";
+      link.hidden = true;
+    }
+  };
+  updateContent(b);
 
   const syncHeight = () => {
     document.documentElement.style.setProperty(
       "--vp-layout-top-height",
       `${el.offsetHeight}px`,
     );
-    if (persist) cacheBanner(b, el.offsetHeight);
+    if (shouldPersist) cacheBanner(currentBanner, el.offsetHeight);
   };
 
   const observer =
     typeof ResizeObserver !== "undefined"
       ? new ResizeObserver(syncHeight)
       : null;
+  const update = (next: BannerData) => {
+    shouldPersist = true;
+    updateContent(next);
+    requestAnimationFrame(syncHeight);
+  };
 
   const btn = document.createElement("button");
   btn.type = "button";
@@ -185,7 +203,7 @@ function render(b: BannerData, persist = true): void {
   btn.textContent = "\u00d7";
   btn.addEventListener("click", () => {
     try {
-      localStorage.setItem(STORAGE_KEY, b.id);
+      localStorage.setItem(STORAGE_KEY, currentBanner.id);
     } catch {
       // Dismiss for this page even when localStorage is unavailable.
     }
@@ -195,7 +213,7 @@ function render(b: BannerData, persist = true): void {
   el.appendChild(btn);
 
   document.body.prepend(el);
-  activeBanner = { id: b.id, element: el, observer };
+  activeBanner = { id: b.id, element: el, observer, update };
 
   requestAnimationFrame(syncHeight);
   observer?.observe(el);

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -13,7 +13,12 @@ const ENDPOINT = "https://jdx.dev/banner.json";
 const STORAGE_KEY = "jdx-banner-dismissed";
 const CACHE_KEY = "jdx-banner-cache";
 let activeBanner:
-  { element: HTMLElement; observer: ResizeObserver | null } | undefined;
+  | {
+      id: string;
+      element: HTMLElement;
+      observer: ResizeObserver | null;
+    }
+  | undefined;
 
 function getDismissedId(): string | null {
   try {
@@ -44,6 +49,10 @@ export function initBanner(): void {
       ) {
         removeActiveBanner();
         clearReserved();
+        return;
+      }
+      if (activeBanner?.id === b.id) {
+        cacheBanner(b, activeBanner.element.offsetHeight);
         return;
       }
       render(b);
@@ -111,6 +120,26 @@ function isHttpUrl(value: string): boolean {
   }
 }
 
+function cacheBanner(b: BannerData, height: number): void {
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({
+        id: b.id,
+        height: `${height}px`,
+        width: window.innerWidth,
+        fontSize: getComputedStyle(document.documentElement).fontSize,
+        pixelRatio: window.devicePixelRatio,
+        cachedAt: Date.now(),
+        expires: b.expires ?? null,
+        banner: b,
+      }),
+    );
+  } catch {
+    // localStorage unavailable — skip caching.
+  }
+}
+
 function removeActiveBanner(): void {
   activeBanner?.observer?.disconnect();
   activeBanner?.element.remove();
@@ -142,24 +171,7 @@ function render(b: BannerData, persist = true): void {
       "--vp-layout-top-height",
       `${el.offsetHeight}px`,
     );
-    try {
-      if (!persist) return;
-      localStorage.setItem(
-        CACHE_KEY,
-        JSON.stringify({
-          id: b.id,
-          height: `${el.offsetHeight}px`,
-          width: window.innerWidth,
-          fontSize: getComputedStyle(document.documentElement).fontSize,
-          pixelRatio: window.devicePixelRatio,
-          cachedAt: Date.now(),
-          expires: b.expires ?? null,
-          banner: b,
-        }),
-      );
-    } catch {
-      // localStorage unavailable — skip caching.
-    }
+    if (persist) cacheBanner(b, el.offsetHeight);
   };
 
   const observer =
@@ -183,7 +195,7 @@ function render(b: BannerData, persist = true): void {
   el.appendChild(btn);
 
   document.body.prepend(el);
-  activeBanner = { element: el, observer };
+  activeBanner = { id: b.id, element: el, observer };
 
   requestAnimationFrame(syncHeight);
   observer?.observe(el);

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -12,6 +12,8 @@ interface BannerData {
 const ENDPOINT = "https://jdx.dev/banner.json";
 const STORAGE_KEY = "jdx-banner-dismissed";
 const CACHE_KEY = "jdx-banner-cache";
+let activeBanner:
+  { element: HTMLElement; observer: ResizeObserver | null } | undefined;
 
 function getDismissedId(): string | null {
   try {
@@ -23,6 +25,9 @@ function getDismissedId(): string | null {
 
 export function initBanner(): void {
   if (typeof window === "undefined") return;
+  const cachedBanner = readCachedBanner();
+  if (cachedBanner) render(cachedBanner, false);
+
   const controller = new AbortController();
   const timeout = window.setTimeout(() => controller.abort(), 5000);
   fetch(ENDPOINT, { signal: controller.signal })
@@ -37,13 +42,40 @@ export function initBanner(): void {
         isExpired(b.expires) ||
         getDismissedId() === b.id
       ) {
+        removeActiveBanner();
         clearReserved();
         return;
       }
       render(b);
     })
-    .catch(clearCachedReservation)
+    .catch(() => {
+      clearCachedReservation();
+      if (!activeBanner) clearCurrentReservation();
+    })
     .finally(() => window.clearTimeout(timeout));
+}
+
+function readCachedBanner(): BannerData | null {
+  if (
+    !document.documentElement.style.getPropertyValue("--vp-layout-top-height")
+  ) {
+    return null;
+  }
+  try {
+    const cached = JSON.parse(localStorage.getItem(CACHE_KEY) ?? "null");
+    const b = cached?.banner;
+    return b &&
+      typeof b.id === "string" &&
+      typeof b.enabled === "boolean" &&
+      typeof b.message === "string" &&
+      (!b.link || typeof b.link === "string") &&
+      (!b.linkText || typeof b.linkText === "string") &&
+      (!b.expires || typeof b.expires === "string")
+      ? b
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function clearCachedReservation(): void {
@@ -79,7 +111,14 @@ function isHttpUrl(value: string): boolean {
   }
 }
 
-function render(b: BannerData): void {
+function removeActiveBanner(): void {
+  activeBanner?.observer?.disconnect();
+  activeBanner?.element.remove();
+  activeBanner = undefined;
+}
+
+function render(b: BannerData, persist = true): void {
+  removeActiveBanner();
   const el = document.createElement("div");
   el.className = "jdx-banner";
   el.setAttribute("role", "region");
@@ -104,6 +143,7 @@ function render(b: BannerData): void {
       `${el.offsetHeight}px`,
     );
     try {
+      if (!persist) return;
       localStorage.setItem(
         CACHE_KEY,
         JSON.stringify({
@@ -114,6 +154,7 @@ function render(b: BannerData): void {
           pixelRatio: window.devicePixelRatio,
           cachedAt: Date.now(),
           expires: b.expires ?? null,
+          banner: b,
         }),
       );
     } catch {
@@ -136,13 +177,13 @@ function render(b: BannerData): void {
     } catch {
       // Dismiss for this page even when localStorage is unavailable.
     }
-    observer?.disconnect();
-    el.remove();
+    removeActiveBanner();
     clearReserved();
   });
   el.appendChild(btn);
 
   document.body.prepend(el);
+  activeBanner = { element: el, observer };
 
   requestAnimationFrame(syncHeight);
   observer?.observe(el);


### PR DESCRIPTION
## Summary

- cache and pre-reserve the measured announcement height on repeat visits
- clear stale banner reservations and enlarge the dismiss target to 44×44px
- allow homepage feature cards to shrink below their 300px preferred width

## Why

The remote banner shifted the navbar after hydration. Separately, the feature grid's fixed 300px minimum expanded a 320px mobile layout to 332px.

## Validation

- `npm run docs:build`
- Chromium mobile audit at 320px
- verified a delayed warm reload preserves the 51px navbar offset
- verified the homepage layout width is 320px instead of 332px

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site UI and client-side localStorage only; no auth, APIs, or data handling beyond existing banner fetch.
> 
> **Overview**
> Fixes **layout jump** when the remote docs announcement banner loads after hydration, and **horizontal overflow** on narrow homepages.
> 
> A **head inline script** now restores `--vp-layout-top-height` from `jdx-banner-cache` when cache metadata matches the current viewport (width, root font size, pixel ratio), is fresh, and the banner was not dismissed. Invalid cache entries are removed.
> 
> **`initBanner`** was expanded to render from cache immediately, fetch with a 5s abort, persist measured height via `ResizeObserver`, schedule expiration, update the same banner in place, and clear DOM plus cache reservations when the banner is disabled, expired, dismissed, or the fetch fails.
> 
> **Banner CSS** enlarges the dismiss control to at least **44×44px** and adjusts padding/alignment on mobile. The homepage **features grid** uses `minmax(min(300px, 100%), 1fr)` so cards can shrink below 300px on ~320px viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c48a6676bbb7715aa18bc8ba9e0df47449a892a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation banner loading, dismissal, expiration, and error handling.
  * Validated cached banner data to prevent invalid or outdated layout restoration.
  * Improved reliability when storage is unavailable or loading takes too long.
  * Automatically cleared stale banner layout reservations.

* **Style**
  * Improved banner spacing and close-button alignment, especially on mobile devices.
  * Prevented horizontal overflow in the documentation feature grid on narrow screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->