### PR TITLE
feat(step): render `dir` through tera

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,7 +166,9 @@ File selection happens before hk knows which workspace a job will run in, so `gl
 
 Literal `dir` values contain no template expression, so they behave exactly as before.
 
-Two limitations follow from that. `stage` patterns cannot follow a per-job workspace either — staging runs once per step, after every job — so hk warns when `stage` is combined with a fully templated `dir`. And `{{workspace}}` is always relative to the repo root, never to a subproject, so a subproject config that sets a templated `dir` resolves to the wrong path; use a literal `dir` there for now.
+`stage` patterns are handled separately. Staging runs once per step, after every job, so hk re-resolves a templated `dir` against each matched workspace: `stage = List("generated/**")` stages `packages/a/generated/...` and `packages/b/generated/...`, and leaves a same-named path at the repo root alone. If no workspace matches, the patterns fall back to the repo root and hk warns.
+
+One caveat: `{{workspace}}` is always relative to the repo root, never to a subproject, so a subproject config that sets a templated `dir` resolves to the wrong path. hk reports it as a missing working directory rather than failing obscurely; use a literal `dir` in subprojects for now.
 
 ### Focus checks on failing files
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,6 +166,8 @@ File selection happens before hk knows which workspace a job will run in, so `gl
 
 Literal `dir` values contain no template expression, so they behave exactly as before.
 
+Two limitations follow from that. `stage` patterns cannot follow a per-job workspace either — staging runs once per step, after every job — so hk warns when `stage` is combined with a fully templated `dir`. And `{{workspace}}` is always relative to the repo root, never to a subproject, so a subproject config that sets a templated `dir` resolves to the wrong path; use a literal `dir` there for now.
+
 ### Focus checks on failing files
 
 For tools whose detailed `check` output cannot identify failing files in a machine-readable form, set `check_failed_files = true` and provide either `check_list_files` or `check_diff`:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,29 @@ Structured commands cannot be combined with the step's `shell` option or a strin
 structured command should run through a launcher. Other step behavior, including
 `dir`, `env`, and automatic batching for large file lists, continues to apply.
 
+### Step working directory
+
+`dir` sets the directory a step's commands run in. It is rendered as a template, so a step with `workspace_indicator` can follow each job's workspace rather than opening every command with a `cd`:
+
+```pkl
+local linters = new Mapping<String, Step> {
+    ["go-vet"] {
+        glob = "**/*.go"
+        workspace_indicator = "go.mod"
+        dir = "{{workspace}}"
+        check = "go vet ./..."
+    }
+}
+```
+
+hk creates one job per matched workspace, so this runs `go vet ./...` in `packages/api`, then in `packages/worker`, and so on. Because the `cd` is gone, the command no longer needs a shell and can be written as a structured `Command`.
+
+`{{files}}` is relative to the rendered directory, the same as it already is for a literal `dir`.
+
+File selection happens before hk knows which workspace a job will run in, so `glob` matching, `exclude`, and `stage` pathspecs use only the literal part of `dir` that precedes the first template expression — `sub/{{workspace}}` scopes them to `sub`, and `{{workspace}}` scopes them to nothing. Use `glob` and `workspace_indicator` to select files for a step with a fully templated `dir`.
+
+Literal `dir` values contain no template expression, so they behave exactly as before.
+
 ### Focus checks on failing files
 
 For tools whose detailed `check` output cannot identify failing files in a machine-readable form, set `check_failed_files = true` and provide either `check_list_files` or `check_diff`:

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -33,10 +33,12 @@ local custom_linters = new Mapping<String, Step> {
   // Custom workspace-based build tool
   ["custom_build"] {
     workspace_indicator = "build.toml"
-    check = "cd {{workspace}} && custom-build check"
-    fix = "cd {{workspace}} && custom-build fix"
+    // `dir` is templated, so commands run in each matched workspace
+    dir = "{{workspace}}"
+    check = "custom-build check"
+    fix = "custom-build fix"
     // Use check_diff for efficient patching
-    check_diff = "cd {{workspace}} && custom-build diff"
+    check_diff = "custom-build diff"
   }
 
   // Interactive migration tool

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -35,10 +35,12 @@ local custom_linters = new Mapping<String, Step> {
   // Custom workspace-based build tool
   ["custom_build"] {
     workspace_indicator = "build.toml"
-    check = "cd {{workspace}} && custom-build check"
-    fix = "cd {{workspace}} && custom-build fix"
+    // `dir` is templated, so commands run in each matched workspace
+    dir = "{{workspace}}"
+    check = "custom-build check"
+    fix = "custom-build fix"
     // Use check_diff for efficient patching
-    check_diff = "cd {{workspace}} && custom-build diff"
+    check_diff = "custom-build diff"
   }
 
   // Interactive migration tool

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -625,6 +625,29 @@ class Step {
   ///     }
   /// }
   /// ```
+  ///
+  /// `dir` is a template, so with `workspace_indicator` set it can follow each
+  /// job's workspace instead of the command opening with a `cd`:
+  ///
+  /// ```pkl
+  /// local linters = new Mapping<String, Step> {
+  ///     ["go-vet"] {
+  ///         glob = "**/*.go"
+  ///         workspace_indicator = "go.mod"
+  ///         dir = "{{workspace}}"
+  ///         check = "go vet ./..."
+  ///     }
+  /// }
+  /// ```
+  ///
+  /// `{{files}}` is relative to the rendered directory, as it already is for a
+  /// literal `dir`.
+  ///
+  /// Note that file selection — `glob` matching, `exclude`, and `stage`
+  /// pathspecs — happens before hk knows which workspace a job will run in, so
+  /// it can only use the literal part of `dir` that precedes the first template
+  /// expression. `dir = "{{workspace}}"` therefore scopes nothing, and file
+  /// selection is left to `glob` and `workspace_indicator`.
   dir: String?
 
   /// Profiles are a way to enable/disable linters based on the current profile.

--- a/pkl/builtins/cargo_deny.pkl
+++ b/pkl/builtins/cargo_deny.pkl
@@ -25,8 +25,9 @@ cargo_deny = new Config.Step {
       "**/.deny.exceptions.toml",
     )
   workspace_indicator = "Cargo.toml"
+  dir = "{{workspace}}"
   check = new Config.CommandSpec {
-    command = "cd {{workspace}} && cargo-deny --locked --workspace check"
+    command = "cargo-deny --locked --workspace check"
     effect = "write"
   }
   tests {

--- a/pkl/builtins/err_check.pkl
+++ b/pkl/builtins/err_check.pkl
@@ -8,8 +8,9 @@ import "../Config.pkl"
 err_check = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
+  dir = "{{workspace}}"
   check = new Config.CommandSpec {
-    command = "cd {{workspace}} && errcheck ./..."
+    command = "errcheck ./..."
     effect = "write"
   }
 }

--- a/pkl/builtins/go_sec.pkl
+++ b/pkl/builtins/go_sec.pkl
@@ -8,8 +8,9 @@ import "../Config.pkl"
 go_sec = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
+  dir = "{{workspace}}"
   check = new Config.CommandSpec {
-    command = "cd {{workspace}} && gosec ./..."
+    command = "gosec ./..."
     effect = "write"
   }
 }

--- a/pkl/builtins/go_vet.pkl
+++ b/pkl/builtins/go_vet.pkl
@@ -8,8 +8,9 @@ import "../Config.pkl"
 go_vet = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
+  dir = "{{workspace}}"
   check = new Config.CommandSpec {
-    command = "cd {{workspace}} && go vet ./..."
+    command = "go vet ./..."
     effect = "write"
   }
   tests {

--- a/pkl/builtins/go_vuln_check.pkl
+++ b/pkl/builtins/go_vuln_check.pkl
@@ -8,8 +8,9 @@ import "../Config.pkl"
 go_vuln_check = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
+  dir = "{{workspace}}"
   check = new Config.CommandSpec {
-    command = "cd {{workspace}} && govulncheck ./..."
+    command = "govulncheck ./..."
     effect = "write"
   }
 }

--- a/pkl/builtins/golangci_lint.pkl
+++ b/pkl/builtins/golangci_lint.pkl
@@ -11,12 +11,13 @@ import "../Config.pkl"
 golangci_lint = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
+  dir = "{{workspace}}"
   check = new Config.CommandSpec {
-    command = "cd {{workspace}} && golangci-lint run --fix=false ./..."
+    command = "golangci-lint run --fix=false ./..."
     effect = "write"
   }
   fix = new Config.CommandSpec {
-    command = "cd {{workspace}} && golangci-lint run --fix ./..."
+    command = "golangci-lint run --fix ./..."
     effect = "write"
   }
 }

--- a/pkl/builtins/revive.pkl
+++ b/pkl/builtins/revive.pkl
@@ -8,8 +8,9 @@ import "../Config.pkl"
 revive = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
+  dir = "{{workspace}}"
   check = new Config.CommandSpec {
-    command = "cd {{workspace}} && revive ./..."
+    command = "revive ./..."
     effect = "read"
   }
 }

--- a/pkl/builtins/staticcheck.pkl
+++ b/pkl/builtins/staticcheck.pkl
@@ -8,8 +8,9 @@ import "../Config.pkl"
 staticcheck = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
+  dir = "{{workspace}}"
   check = new Config.CommandSpec {
-    command = "cd {{workspace}} && staticcheck ./..."
+    command = "staticcheck ./..."
     effect = "write"
   }
 }

--- a/src/step/batching.rs
+++ b/src/step/batching.rs
@@ -494,7 +494,7 @@ impl Step {
     pub(crate) fn has_filters(&self) -> bool {
         self.glob.is_some()
             || self.match_any.is_some()
-            || self.dir.is_some()
+            || self.dir_prefix().is_some()
             || self
                 .exclude
                 .as_ref()

--- a/src/step/diff.rs
+++ b/src/step/diff.rs
@@ -26,13 +26,15 @@ impl Step {
     /// # Arguments
     ///
     /// * `stdout` - The unified diff output from the check_diff command
+    /// * `dir` - The job's working directory (`dir` already rendered), or
+    ///   `None` to apply from the repo root
     ///
     /// # Returns
     ///
     /// * `Ok(true)` - Diff was applied successfully
     /// * `Ok(false)` - Diff application failed (caller should fall back to fixer)
     /// * `Err(_)` - Unexpected error
-    pub(crate) fn apply_diff_output(&self, stdout: &str) -> Result<bool> {
+    pub(crate) fn apply_diff_output(&self, stdout: &str, dir: Option<&str>) -> Result<bool> {
         if stdout.trim().is_empty() {
             debug!("{}: no diff content to apply", self.name);
             return Ok(false);
@@ -67,7 +69,7 @@ impl Step {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
 
-        if let Some(dir) = &self.dir {
+        if let Some(dir) = dir {
             cmd.current_dir(dir);
         }
 

--- a/src/step/diff.rs
+++ b/src/step/diff.rs
@@ -26,8 +26,7 @@ impl Step {
     /// # Arguments
     ///
     /// * `stdout` - The unified diff output from the check_diff command
-    /// * `dir` - The job's working directory (`dir` already rendered), or
-    ///   `None` to apply from the repo root
+    /// * `dir` - The job's rendered working directory, or `None` for the repo root
     ///
     /// # Returns
     ///

--- a/src/step/dir.rs
+++ b/src/step/dir.rs
@@ -1,57 +1,39 @@
-//! Resolution of a step's `dir`.
+//! Working directory resolution for steps.
 //!
-//! `dir` is a Tera template, so a step can point its working directory at a
-//! value that is only known per job — most usefully `{{workspace}}`:
+//! `dir` is a Tera template, so a step can follow each job's workspace with
+//! `dir = "{{workspace}}"` instead of opening its command with a `cd`. It is
+//! read for two purposes:
 //!
-//! ```ignore
-//! ["go-vet"] {
-//!     glob = "**/*.go"
-//!     workspace_indicator = "go.mod"
-//!     dir = "{{workspace}}"
-//!     check = "go vet ./..."
-//! }
-//! ```
-//!
-//! That template can only be rendered once a job exists, because the workspace
-//! is picked per job. `dir` is read at two kinds of site:
-//!
-//! - **Execution sites** ([`Step::render_dir`]) — the child process cwd and the
-//!   cwd for `git apply`. These run per job, so they render the template.
-//! - **Selection sites** ([`Step::dir_prefix`]) — file filtering, glob
-//!   prefixing, and stage pathspecs. These run before jobs exist, so they fall
-//!   back to the literal path prefix that precedes the first template
-//!   expression: `sub/{{workspace}}` scopes to `sub`, and a `dir` that is
-//!   entirely a template scopes to nothing.
-//!
-//! Both accessors strip a leading `./`, which `Path::components` would
-//! otherwise keep as a `CurDir` component that matches no repo-relative file
-//! path. Literal `dir` values contain no template expression, so apart from
-//! that normalization both accessors return the input unchanged.
+//! - Execution ([`Step::render_dir`]) - the working directory for the command
+//!   and for `git apply`, rendered per job once the workspace is known
+//! - Selection ([`Step::dir_prefix`]) - file filtering, glob prefixing, and
+//!   stage pathspecs, which run before jobs exist and so can only use the
+//!   literal prefix of `dir`
 
 use crate::{Result, tera};
 
-use super::types::Step;
+use super::Step;
 
 /// Tera expression/statement openers. A `dir` containing either is a template.
 const TEMPLATE_OPENERS: [&str; 2] = ["{{", "{%"];
 
 impl Step {
-    /// The literal directory prefix of `dir`, used to select files before jobs
+    /// The literal directory prefix of `dir`, for selecting files before jobs
     /// (and therefore workspaces) exist.
     ///
-    /// Returns the whole value for a literal `dir`. For a templated `dir`, this
-    /// is the path prefix preceding the first template expression, which every
-    /// value the template can render to lives under — so filtering by it stays
-    /// a superset of the eventual working directory. Returns `None` when the
-    /// template starts in the first path segment and there is no such prefix,
-    /// and when the prefix is the repo root itself.
+    /// # Returns
+    ///
+    /// The whole value for a literal `dir`, otherwise the path prefix preceding
+    /// the first template expression. Every directory the template can render
+    /// to lives under that prefix, so filtering by it stays a superset of the
+    /// eventual working directory. `None` when there is no such prefix or it
+    /// names the repo root.
     pub fn dir_prefix(&self) -> Option<&str> {
         dir_prefix(self.dir.as_deref()?)
     }
 
-    /// The step's working directory for this job, with `dir` rendered against
-    /// the job's template context (so `{{workspace}}` resolves to the
-    /// workspace this job was built for).
+    /// Render `dir` against a job's template context, resolving `{{workspace}}`
+    /// to the workspace that job was built for.
     pub fn render_dir(&self, tctx: &tera::Context) -> Result<Option<String>> {
         let Some(dir) = self.dir.as_deref() else {
             return Ok(None);
@@ -61,8 +43,8 @@ impl Step {
     }
 }
 
-/// The literal path prefix of `dir` — everything before the path separator
-/// that precedes the first template expression.
+/// The literal path prefix of `dir`: everything before the separator preceding
+/// the first template expression.
 fn dir_prefix(dir: &str) -> Option<&str> {
     let dir = strip_cur_dir(dir);
     let Some(template_start) = TEMPLATE_OPENERS
@@ -70,34 +52,31 @@ fn dir_prefix(dir: &str) -> Option<&str> {
         .filter_map(|opener| dir.find(opener))
         .min()
     else {
-        return keep_narrowing_prefix(dir);
+        return subdir_prefix(dir);
     };
-    // Only whole path segments count: in `pkg-{{workspace}}` the text before
-    // the expression is not a directory of its own.
-    let head = &dir[..template_start];
-    keep_narrowing_prefix(head[..head.rfind(['/', '\\'])?].trim_end_matches(['/', '\\']))
+    // Only whole segments count: "pkg-" in `pkg-{{workspace}}` is not a directory.
+    let (prefix, _) = dir[..template_start].rsplit_once(['/', '\\'])?;
+    subdir_prefix(prefix.trim_end_matches(['/', '\\']))
 }
 
-/// Drop prefixes that name the repo root rather than a subdirectory — there is
-/// nothing to narrow file selection to, and prefixing a stage glob with them
-/// would corrupt the pathspec.
-fn keep_narrowing_prefix(prefix: &str) -> Option<&str> {
+/// Discard a prefix that names the repo root rather than a subdirectory, which
+/// narrows nothing and would corrupt a stage pathspec built from it.
+fn subdir_prefix(prefix: &str) -> Option<&str> {
     (!prefix.is_empty() && prefix != ".").then_some(prefix)
 }
 
-/// Strip leading `./` (and `.\`) segments from a directory.
+/// Strip leading `./` (and `.\`) segments.
 ///
-/// `Path::components` preserves a leading `.` as `Component::CurDir`, so
-/// `Path::new("sub/a.go").starts_with("./sub")` is false and
-/// `strip_prefix("./sub")` fails where the bare `sub` form succeeds. Without
-/// this, `dir = "./sub"` selects no files at all, and a `dir` that renders to
-/// `./sub` leaves `{{files}}` repo-root-relative while the command runs in
-/// `sub`, so every path is doubled. Both separators are handled on every
-/// platform, matching how [`dir_prefix`] splits segments.
+/// `Path::components` keeps a leading `.` as `Component::CurDir`, so
+/// `Path::new("sub/a.go").starts_with("./sub")` is false and `strip_prefix`
+/// fails where the bare `sub` form succeeds. Without this, `dir = "./sub"`
+/// matches no files at all and `{{files}}` keeps a prefix the command has
+/// already changed into. Non-leading `.` needs no handling: `Path` normalizes
+/// it away.
 fn strip_cur_dir(dir: &str) -> &str {
     let mut rest = dir;
     while let Some(stripped) = rest.strip_prefix("./").or_else(|| rest.strip_prefix(".\\")) {
-        // `./` on its own is the repo root, not an empty path.
+        // `./` alone is the repo root, not an empty path.
         if stripped.is_empty() {
             return ".";
         }
@@ -125,8 +104,8 @@ mod tests {
 
     #[test]
     fn templated_dir_keeps_its_literal_prefix() {
-        // A subproject scopes its steps by prefixing `dir` with the subproject
-        // directory; that prefix must keep scoping file selection.
+        // A subproject prefixes `dir` with its own directory; that must keep
+        // scoping file selection.
         assert_eq!(dir_prefix("sub/{{workspace}}"), Some("sub"));
         assert_eq!(dir_prefix("a/b/{{workspace}}/c"), Some("a/b"));
         assert_eq!(dir_prefix("sub\\{{workspace}}"), Some("sub"));
@@ -134,16 +113,11 @@ mod tests {
 
     #[test]
     fn partial_segment_before_template_is_not_a_directory() {
-        // `pkg-{{workspace}}` has no complete literal segment: "pkg-" is not a
-        // directory, so selection must not be narrowed to it.
         assert_eq!(dir_prefix("pkg-{{workspace}}"), None);
     }
 
     #[test]
     fn leading_cur_dir_is_normalized_away() {
-        // `Path::starts_with` keeps a leading "." as a CurDir component, so an
-        // un-normalized "./sub" would match no repo-relative path and select
-        // nothing at all.
         assert_eq!(dir_prefix("./sub"), Some("sub"));
         assert_eq!(dir_prefix(".\\sub"), Some("sub"));
         assert_eq!(dir_prefix("./sub/{{workspace}}"), Some("sub"));

--- a/src/step/dir.rs
+++ b/src/step/dir.rs
@@ -23,8 +23,10 @@
 //!   expression: `sub/{{workspace}}` scopes to `sub`, and a `dir` that is
 //!   entirely a template scopes to nothing.
 //!
-//! Literal `dir` values contain no template expression, so both accessors
-//! return the same string and behavior is unchanged.
+//! Both accessors strip a leading `./`, which `Path::components` would
+//! otherwise keep as a `CurDir` component that matches no repo-relative file
+//! path. Literal `dir` values contain no template expression, so apart from
+//! that normalization both accessors return the input unchanged.
 
 use crate::{Result, tera};
 
@@ -41,7 +43,8 @@ impl Step {
     /// is the path prefix preceding the first template expression, which every
     /// value the template can render to lives under — so filtering by it stays
     /// a superset of the eventual working directory. Returns `None` when the
-    /// template starts in the first path segment and there is no such prefix.
+    /// template starts in the first path segment and there is no such prefix,
+    /// and when the prefix is the repo root itself.
     pub fn dir_prefix(&self) -> Option<&str> {
         dir_prefix(self.dir.as_deref()?)
     }
@@ -50,30 +53,57 @@ impl Step {
     /// the job's template context (so `{{workspace}}` resolves to the
     /// workspace this job was built for).
     pub fn render_dir(&self, tctx: &tera::Context) -> Result<Option<String>> {
-        self.dir
-            .as_deref()
-            .map(|dir| tera::render(dir, tctx))
-            .transpose()
+        let Some(dir) = self.dir.as_deref() else {
+            return Ok(None);
+        };
+        let rendered = tera::render(dir, tctx)?;
+        Ok(Some(strip_cur_dir(&rendered).to_string()))
     }
 }
 
 /// The literal path prefix of `dir` — everything before the path separator
 /// that precedes the first template expression.
 fn dir_prefix(dir: &str) -> Option<&str> {
+    let dir = strip_cur_dir(dir);
     let Some(template_start) = TEMPLATE_OPENERS
         .iter()
         .filter_map(|opener| dir.find(opener))
         .min()
     else {
-        return Some(dir);
+        return keep_narrowing_prefix(dir);
     };
     // Only whole path segments count: in `pkg-{{workspace}}` the text before
     // the expression is not a directory of its own.
     let head = &dir[..template_start];
-    let prefix = head[..head.rfind(['/', '\\'])?].trim_end_matches(['/', '\\']);
-    // `{{workspace}}` and `./{{workspace}}` are both rooted at the repo root:
-    // there is no literal directory to narrow file selection to.
+    keep_narrowing_prefix(head[..head.rfind(['/', '\\'])?].trim_end_matches(['/', '\\']))
+}
+
+/// Drop prefixes that name the repo root rather than a subdirectory — there is
+/// nothing to narrow file selection to, and prefixing a stage glob with them
+/// would corrupt the pathspec.
+fn keep_narrowing_prefix(prefix: &str) -> Option<&str> {
     (!prefix.is_empty() && prefix != ".").then_some(prefix)
+}
+
+/// Strip leading `./` (and `.\`) segments from a directory.
+///
+/// `Path::components` preserves a leading `.` as `Component::CurDir`, so
+/// `Path::new("sub/a.go").starts_with("./sub")` is false and
+/// `strip_prefix("./sub")` fails where the bare `sub` form succeeds. Without
+/// this, `dir = "./sub"` selects no files at all, and a `dir` that renders to
+/// `./sub` leaves `{{files}}` repo-root-relative while the command runs in
+/// `sub`, so every path is doubled. Both separators are handled on every
+/// platform, matching how [`dir_prefix`] splits segments.
+fn strip_cur_dir(dir: &str) -> &str {
+    let mut rest = dir;
+    while let Some(stripped) = rest.strip_prefix("./").or_else(|| rest.strip_prefix(".\\")) {
+        // `./` on its own is the repo root, not an empty path.
+        if stripped.is_empty() {
+            return ".";
+        }
+        rest = stripped;
+    }
+    rest
 }
 
 #[cfg(test)]
@@ -107,5 +137,56 @@ mod tests {
         // `pkg-{{workspace}}` has no complete literal segment: "pkg-" is not a
         // directory, so selection must not be narrowed to it.
         assert_eq!(dir_prefix("pkg-{{workspace}}"), None);
+    }
+
+    #[test]
+    fn leading_cur_dir_is_normalized_away() {
+        // `Path::starts_with` keeps a leading "." as a CurDir component, so an
+        // un-normalized "./sub" would match no repo-relative path and select
+        // nothing at all.
+        assert_eq!(dir_prefix("./sub"), Some("sub"));
+        assert_eq!(dir_prefix(".\\sub"), Some("sub"));
+        assert_eq!(dir_prefix("./sub/{{workspace}}"), Some("sub"));
+        assert_eq!(dir_prefix(".\\sub\\{{workspace}}"), Some("sub"));
+        assert_eq!(dir_prefix("././sub"), Some("sub"));
+    }
+
+    #[test]
+    fn repo_root_dir_narrows_nothing() {
+        assert_eq!(dir_prefix("."), None);
+        assert_eq!(dir_prefix("./"), None);
+        assert_eq!(dir_prefix(""), None);
+    }
+
+    #[test]
+    fn strip_cur_dir_leaves_other_paths_alone() {
+        assert_eq!(strip_cur_dir("sub/api"), "sub/api");
+        assert_eq!(strip_cur_dir("."), ".");
+        assert_eq!(strip_cur_dir(".hidden/api"), ".hidden/api");
+        assert_eq!(strip_cur_dir("sub/./api"), "sub/./api");
+    }
+
+    #[test]
+    fn render_dir_normalizes_the_rendered_value() {
+        let mut tctx = tera::Context::default();
+        tctx.insert("workspace", "sub/api");
+        let step = Step {
+            dir: Some("./{{workspace}}".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(step.render_dir(&tctx).unwrap().as_deref(), Some("sub/api"));
+    }
+
+    #[test]
+    fn render_dir_keeps_a_workspace_at_the_repo_root() {
+        // `{{workspace}}` is "." for an indicator at the repo root: a valid cwd
+        // that must not collapse to an empty path.
+        let mut tctx = tera::Context::default();
+        tctx.insert("workspace", ".");
+        let step = Step {
+            dir: Some("{{workspace}}".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(step.render_dir(&tctx).unwrap().as_deref(), Some("."));
     }
 }

--- a/src/step/dir.rs
+++ b/src/step/dir.rs
@@ -11,6 +11,9 @@
 //!   literal prefix of `dir`
 
 use crate::{Result, tera};
+use indexmap::IndexSet;
+use itertools::Itertools;
+use std::path::PathBuf;
 
 use super::Step;
 
@@ -41,22 +44,79 @@ impl Step {
         let rendered = tera::render(dir, tctx)?;
         Ok(Some(strip_cur_dir(&rendered).to_string()))
     }
+
+    /// Every directory `dir` resolved to across a step's jobs.
+    ///
+    /// Staging runs once per step rather than per job, so a templated `dir`
+    /// has to be resolved again here: rendering it against each workspace the
+    /// jobs were built from recovers the directories they ran in. Falls back
+    /// to [`Step::dir_prefix`] when there are no workspaces to render with.
+    ///
+    /// # Returns
+    ///
+    /// An empty vector when `dir` is unset, meaning the repo root.
+    pub fn resolved_dirs(
+        &self,
+        base: &tera::Context,
+        files: &IndexSet<PathBuf>,
+    ) -> Result<Vec<String>> {
+        let Some(dir) = self.dir.as_deref() else {
+            return Ok(Vec::new());
+        };
+        if template_start(dir).is_none() {
+            return Ok(vec![strip_cur_dir(dir).to_string()]);
+        }
+        let workspaces = self
+            .workspaces_for_files(&files.iter().cloned().collect_vec())?
+            .unwrap_or_default();
+        if workspaces.is_empty() {
+            return Ok(self
+                .dir_prefix()
+                .map(ToString::to_string)
+                .into_iter()
+                .collect());
+        }
+        render_per_workspace(self, base, &workspaces)
+    }
+}
+
+/// Render `dir` once per workspace, as each job did.
+fn render_per_workspace(
+    step: &Step,
+    base: &tera::Context,
+    workspaces: &IndexSet<PathBuf>,
+) -> Result<Vec<String>> {
+    let mut dirs = Vec::new();
+    for workspace_indicator in workspaces {
+        let mut tctx = base.clone();
+        tctx.insert("step", &step.name);
+        tctx.with_workspace_indicator(workspace_indicator);
+        let dir = step.render_dir(&tctx)?.unwrap_or_default();
+        if !dir.is_empty() && !dirs.contains(&dir) {
+            dirs.push(dir);
+        }
+    }
+    Ok(dirs)
 }
 
 /// The literal path prefix of `dir`: everything before the separator preceding
 /// the first template expression.
 fn dir_prefix(dir: &str) -> Option<&str> {
     let dir = strip_cur_dir(dir);
-    let Some(template_start) = TEMPLATE_OPENERS
-        .iter()
-        .filter_map(|opener| dir.find(opener))
-        .min()
-    else {
+    let Some(start) = template_start(dir) else {
         return subdir_prefix(dir);
     };
     // Only whole segments count: "pkg-" in `pkg-{{workspace}}` is not a directory.
-    let (prefix, _) = dir[..template_start].rsplit_once(['/', '\\'])?;
+    let (prefix, _) = dir[..start].rsplit_once(['/', '\\'])?;
     subdir_prefix(prefix.trim_end_matches(['/', '\\']))
+}
+
+/// Byte offset of the first template expression, or `None` for a literal `dir`.
+fn template_start(dir: &str) -> Option<usize> {
+    TEMPLATE_OPENERS
+        .iter()
+        .filter_map(|opener| dir.find(opener))
+        .min()
 }
 
 /// Discard a prefix that names the repo root rather than a subdirectory, which

--- a/src/step/dir.rs
+++ b/src/step/dir.rs
@@ -1,0 +1,111 @@
+//! Resolution of a step's `dir`.
+//!
+//! `dir` is a Tera template, so a step can point its working directory at a
+//! value that is only known per job — most usefully `{{workspace}}`:
+//!
+//! ```ignore
+//! ["go-vet"] {
+//!     glob = "**/*.go"
+//!     workspace_indicator = "go.mod"
+//!     dir = "{{workspace}}"
+//!     check = "go vet ./..."
+//! }
+//! ```
+//!
+//! That template can only be rendered once a job exists, because the workspace
+//! is picked per job. `dir` is read at two kinds of site:
+//!
+//! - **Execution sites** ([`Step::render_dir`]) — the child process cwd and the
+//!   cwd for `git apply`. These run per job, so they render the template.
+//! - **Selection sites** ([`Step::dir_prefix`]) — file filtering, glob
+//!   prefixing, and stage pathspecs. These run before jobs exist, so they fall
+//!   back to the literal path prefix that precedes the first template
+//!   expression: `sub/{{workspace}}` scopes to `sub`, and a `dir` that is
+//!   entirely a template scopes to nothing.
+//!
+//! Literal `dir` values contain no template expression, so both accessors
+//! return the same string and behavior is unchanged.
+
+use crate::{Result, tera};
+
+use super::types::Step;
+
+/// Tera expression/statement openers. A `dir` containing either is a template.
+const TEMPLATE_OPENERS: [&str; 2] = ["{{", "{%"];
+
+impl Step {
+    /// The literal directory prefix of `dir`, used to select files before jobs
+    /// (and therefore workspaces) exist.
+    ///
+    /// Returns the whole value for a literal `dir`. For a templated `dir`, this
+    /// is the path prefix preceding the first template expression, which every
+    /// value the template can render to lives under — so filtering by it stays
+    /// a superset of the eventual working directory. Returns `None` when the
+    /// template starts in the first path segment and there is no such prefix.
+    pub fn dir_prefix(&self) -> Option<&str> {
+        dir_prefix(self.dir.as_deref()?)
+    }
+
+    /// The step's working directory for this job, with `dir` rendered against
+    /// the job's template context (so `{{workspace}}` resolves to the
+    /// workspace this job was built for).
+    pub fn render_dir(&self, tctx: &tera::Context) -> Result<Option<String>> {
+        self.dir
+            .as_deref()
+            .map(|dir| tera::render(dir, tctx))
+            .transpose()
+    }
+}
+
+/// The literal path prefix of `dir` — everything before the path separator
+/// that precedes the first template expression.
+fn dir_prefix(dir: &str) -> Option<&str> {
+    let Some(template_start) = TEMPLATE_OPENERS
+        .iter()
+        .filter_map(|opener| dir.find(opener))
+        .min()
+    else {
+        return Some(dir);
+    };
+    // Only whole path segments count: in `pkg-{{workspace}}` the text before
+    // the expression is not a directory of its own.
+    let head = &dir[..template_start];
+    let prefix = head[..head.rfind(['/', '\\'])?].trim_end_matches(['/', '\\']);
+    // `{{workspace}}` and `./{{workspace}}` are both rooted at the repo root:
+    // there is no literal directory to narrow file selection to.
+    (!prefix.is_empty() && prefix != ".").then_some(prefix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn literal_dir_is_its_own_prefix() {
+        assert_eq!(dir_prefix("packages/web"), Some("packages/web"));
+        assert_eq!(dir_prefix("frontend"), Some("frontend"));
+    }
+
+    #[test]
+    fn fully_templated_dir_has_no_prefix() {
+        assert_eq!(dir_prefix("{{workspace}}"), None);
+        assert_eq!(dir_prefix("./{{workspace}}"), None);
+        assert_eq!(dir_prefix("{% if x %}a{% endif %}"), None);
+    }
+
+    #[test]
+    fn templated_dir_keeps_its_literal_prefix() {
+        // A subproject scopes its steps by prefixing `dir` with the subproject
+        // directory; that prefix must keep scoping file selection.
+        assert_eq!(dir_prefix("sub/{{workspace}}"), Some("sub"));
+        assert_eq!(dir_prefix("a/b/{{workspace}}/c"), Some("a/b"));
+        assert_eq!(dir_prefix("sub\\{{workspace}}"), Some("sub"));
+    }
+
+    #[test]
+    fn partial_segment_before_template_is_not_a_directory() {
+        // `pkg-{{workspace}}` has no complete literal segment: "pkg-" is not a
+        // directory, so selection must not be narrowed to it.
+        assert_eq!(dir_prefix("pkg-{{workspace}}"), None);
+    }
+}

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -397,6 +397,14 @@ impl Step {
                 .collect::<Result<Vec<_>>>()?
         };
 
+        // A fully templated `dir` has no literal prefix, so stage patterns stay
+        // rooted at the repo root rather than following each workspace.
+        if !rendered_patterns.is_empty() && self.dir.is_some() && self.dir_prefix().is_none() {
+            warn!(
+                "{self}: `stage` patterns are relative to the repo root: `dir` is templated, so hk cannot scope them to a workspace"
+            );
+        }
+
         let mut stage_globs: Vec<String> = Vec::new();
         for pat in rendered_patterns {
             // Always include the base pattern (with dir prefix if present)

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -191,7 +191,11 @@ impl Step {
                                 if matches!(check_first_cmd, Some(CheckFirstCmd::Diff(_)))
                                     && prev_run_type == RunType::Fix
                                 {
-                                    match step.apply_diff_output(stdout) {
+                                    // `dir` is rendered against this job's
+                                    // context so `git apply` runs where the
+                                    // check_diff command ran.
+                                    let dir = step.render_dir(&job.tctx(&ctx.hook_ctx.tctx))?;
+                                    match step.apply_diff_output(stdout, dir.as_deref()) {
                                         Ok(true) => {
                                             // Diff applied successfully - no need to run fixer
                                             debug!("{step}: diff applied successfully, skipping fixer");
@@ -365,7 +369,9 @@ impl Step {
         all_job_files: &IndexSet<PathBuf>,
         actual_job_files: &IndexSet<PathBuf>,
     ) -> Result<()> {
-        // Build stage pathspecs; if `dir` is set, stage entries are relative to it
+        // Build stage pathspecs; if `dir` is set, stage entries are relative to
+        // it — to its literal prefix when `dir` is templated, since staging runs
+        // once per step, after every job, with no single workspace to render with.
         // Compute "root" variants for patterns that start with "**/" BEFORE prefixing with `dir`.
         // Determine effective stage: explicit setting wins, otherwise default to <JOB_FILES>
         // for steps with fix commands when staging is enabled.
@@ -396,7 +402,7 @@ impl Step {
         let mut stage_globs: Vec<String> = Vec::new();
         for pat in rendered_patterns {
             // Always include the base pattern (with dir prefix if present)
-            if let Some(dir) = &self.dir {
+            if let Some(dir) = self.dir_prefix() {
                 stage_globs.push(format!("{}/{}", dir.trim_end_matches('/'), pat));
             } else {
                 stage_globs.push(pat.clone());
@@ -407,7 +413,7 @@ impl Step {
             if let Some(rest) = pat.strip_prefix("**/")
                 && !rest.is_empty()
             {
-                if let Some(dir) = &self.dir {
+                if let Some(dir) = self.dir_prefix() {
                     stage_globs.push(format!("{}/{}", dir.trim_end_matches('/'), rest));
                 } else {
                     stage_globs.push(rest.to_string());

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -191,9 +191,7 @@ impl Step {
                                 if matches!(check_first_cmd, Some(CheckFirstCmd::Diff(_)))
                                     && prev_run_type == RunType::Fix
                                 {
-                                    // `dir` is rendered against this job's
-                                    // context so `git apply` runs where the
-                                    // check_diff command ran.
+                                    // Apply where the check_diff command ran.
                                     let dir = step.render_dir(&job.tctx(&ctx.hook_ctx.tctx))?;
                                     match step.apply_diff_output(stdout, dir.as_deref()) {
                                         Ok(true) => {
@@ -369,9 +367,9 @@ impl Step {
         all_job_files: &IndexSet<PathBuf>,
         actual_job_files: &IndexSet<PathBuf>,
     ) -> Result<()> {
-        // Build stage pathspecs; if `dir` is set, stage entries are relative to
-        // it — to its literal prefix when `dir` is templated, since staging runs
-        // once per step, after every job, with no single workspace to render with.
+        // Build stage pathspecs; if `dir` is set, stage entries are relative to it
+        // (its literal prefix when templated: staging runs once per step, after
+        // every job, so there is no single workspace to render with).
         // Compute "root" variants for patterns that start with "**/" BEFORE prefixing with `dir`.
         // Determine effective stage: explicit setting wins, otherwise default to <JOB_FILES>
         // for steps with fix commands when staging is enabled.

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -367,9 +367,7 @@ impl Step {
         all_job_files: &IndexSet<PathBuf>,
         actual_job_files: &IndexSet<PathBuf>,
     ) -> Result<()> {
-        // Build stage pathspecs; if `dir` is set, stage entries are relative to it
-        // (its literal prefix when templated: staging runs once per step, after
-        // every job, so there is no single workspace to render with).
+        // Build stage pathspecs; if `dir` is set, stage entries are relative to it.
         // Compute "root" variants for patterns that start with "**/" BEFORE prefixing with `dir`.
         // Determine effective stage: explicit setting wins, otherwise default to <JOB_FILES>
         // for steps with fix commands when staging is enabled.
@@ -397,33 +395,27 @@ impl Step {
                 .collect::<Result<Vec<_>>>()?
         };
 
-        // A fully templated `dir` has no literal prefix, so stage patterns stay
-        // rooted at the repo root rather than following each workspace.
-        if !rendered_patterns.is_empty() && self.dir.is_some() && self.dir_prefix().is_none() {
+        // One root per directory the step's jobs ran in: a templated `dir` needs
+        // a pattern per workspace, or `generated/**` would resolve at the repo
+        // root and both miss the per-workspace files and match unrelated ones.
+        let stage_roots = self.resolved_dirs(&ctx.hook_ctx.tctx, all_job_files)?;
+        if !rendered_patterns.is_empty() && self.dir.is_some() && stage_roots.is_empty() {
             warn!(
-                "{self}: `stage` patterns are relative to the repo root: `dir` is templated, so hk cannot scope them to a workspace"
+                "{self}: `stage` patterns are relative to the repo root: `dir` is templated and no workspace matched, so hk cannot scope them"
             );
         }
 
         let mut stage_globs: Vec<String> = Vec::new();
         for pat in rendered_patterns {
-            // Always include the base pattern (with dir prefix if present)
-            if let Some(dir) = self.dir_prefix() {
-                stage_globs.push(format!("{}/{}", dir.trim_end_matches('/'), pat));
-            } else {
-                stage_globs.push(pat.clone());
-            }
+            // Always include the base pattern (under each dir if present)
+            push_stage_globs(&mut stage_globs, &stage_roots, &pat);
 
             // If the original (un-prefixed) pattern starts with "**/", also include a root-level variant
             // without that prefix. When `dir` is set, make the root variant relative to `dir`.
             if let Some(rest) = pat.strip_prefix("**/")
                 && !rest.is_empty()
             {
-                if let Some(dir) = self.dir_prefix() {
-                    stage_globs.push(format!("{}/{}", dir.trim_end_matches('/'), rest));
-                } else {
-                    stage_globs.push(rest.to_string());
-                }
+                push_stage_globs(&mut stage_globs, &stage_roots, rest);
             }
         }
         // Guard against empty pathspecs (e.g., when pattern is exactly "**/")
@@ -538,5 +530,21 @@ impl Step {
             }
         }
         Ok(())
+    }
+}
+
+/// Push `pat` once per stage root, or bare when there are none (the repo root).
+fn push_stage_globs(globs: &mut Vec<String>, roots: &[String], pat: &str) {
+    if roots.is_empty() {
+        globs.push(pat.to_string());
+        return;
+    }
+    for root in roots {
+        let root = root.trim_end_matches('/');
+        if root.is_empty() || root == "." {
+            globs.push(pat.to_string());
+        } else {
+            globs.push(format!("{root}/{pat}"));
+        }
     }
 }

--- a/src/step/filtering.rs
+++ b/src/step/filtering.rs
@@ -181,7 +181,7 @@ impl Step {
     ///
     /// Applies the following filters in order:
     /// 1. Directory filter (`dir`) - only files under this directory
-    ///    (its literal prefix when `dir` is templated, see [`Step::dir_prefix`])
+    ///    (its literal prefix when templated, see [`Step::dir_prefix`])
     /// 2. Positive selectors (`glob` + `types`, or `match_any` clauses)
     /// 3. Exclusion pattern (`exclude`) - must not match
     /// 4. Binary filter (`allow_binary`) - skip binary files unless allowed

--- a/src/step/filtering.rs
+++ b/src/step/filtering.rs
@@ -106,7 +106,7 @@ impl Step {
     ) -> Result<Vec<PathBuf>> {
         let mut files = files.to_vec();
         if let Some(pattern) = pattern {
-            files = glob::get_pattern_matches(pattern, &files, self.dir.as_deref())?;
+            files = glob::get_pattern_matches(pattern, &files, self.dir_prefix())?;
         }
         if let Some(types) = types {
             files.retain(|f| crate::file_type::matches_types(f, types));
@@ -181,6 +181,7 @@ impl Step {
     ///
     /// Applies the following filters in order:
     /// 1. Directory filter (`dir`) - only files under this directory
+    ///    (its literal prefix when `dir` is templated, see [`Step::dir_prefix`])
     /// 2. Positive selectors (`glob` + `types`, or `match_any` clauses)
     /// 3. Exclusion pattern (`exclude`) - must not match
     /// 4. Binary filter (`allow_binary`) - skip binary files unless allowed
@@ -195,7 +196,7 @@ impl Step {
     /// The filtered list of files that match all criteria
     pub fn filter_files(&self, files: &[PathBuf]) -> Result<Vec<PathBuf>> {
         let mut files = files.to_vec();
-        if let Some(dir) = &self.dir {
+        if let Some(dir) = self.dir_prefix() {
             files.retain(|f| f.starts_with(dir));
             if files.is_empty() {
                 debug!("{self}: no files in {dir}");
@@ -218,7 +219,7 @@ impl Step {
         if let Some(pattern) = self.exclude.as_ref().filter(|pattern| !pattern.is_empty()) {
             // Use get_pattern_matches consistently for excludes too
             let excluded: HashSet<_> =
-                glob::get_pattern_matches(pattern, &files, self.dir.as_deref())?
+                glob::get_pattern_matches(pattern, &files, self.dir_prefix())?
                     .into_iter()
                     .collect();
             files.retain(|f| !excluded.contains(f));

--- a/src/step/mod.rs
+++ b/src/step/mod.rs
@@ -14,6 +14,7 @@
 //! - [`runner`] - Single job execution
 //! - [`check_parsing`] - Parsing check_list_files and check_diff output
 //! - [`diff`] - Applying unified diffs directly
+//! - [`dir`] - Resolving a step's working directory
 //! - [`output`] - Output capture and fix suggestions
 //! - [`progress`] - Progress bar management
 //! - [`expr_env`] - Expression evaluation for conditions
@@ -34,6 +35,7 @@
 mod batching;
 mod check_parsing;
 mod diff;
+mod dir;
 mod execution;
 mod expr_env;
 mod filtering;

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -330,14 +330,19 @@ impl Step {
                 cmd = cmd.env("GIT_WORK_TREE", root);
             }
         }
-        if let Some(dir) = &self.dir {
-            cmd = cmd.current_dir(dir);
+        // `dir` is a template so a step can follow the job's workspace with
+        // `dir = "{{workspace}}"` instead of opening its command with a `cd`.
+        if let Some(dir) = self
+            .render_dir(&tctx)
+            .wrap_err_with(|| format!("{self}: failed to render dir template"))?
+        {
+            cmd = cmd.current_dir(&dir);
             // With HK_MISE enabled, resolve the mise environment for the step's
             // directory so tools/env from that directory's mise config (e.g. a
             // subproject's mise.toml) are available even when hk was started
             // from the repo root. Explicit step env still wins below.
             if *env::HK_MISE {
-                let mise_env = crate::mise_env::mise_env_for_dir(Path::new(dir)).await;
+                let mise_env = crate::mise_env::mise_env_for_dir(Path::new(&dir)).await;
                 for (key, value) in mise_env.iter() {
                     cmd = cmd.env(key, value);
                 }

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -330,8 +330,7 @@ impl Step {
                 cmd = cmd.env("GIT_WORK_TREE", root);
             }
         }
-        // `dir` is a template so a step can follow the job's workspace with
-        // `dir = "{{workspace}}"` instead of opening its command with a `cd`.
+        // `dir` is a template: it may resolve to this job's workspace.
         if let Some(dir) = self
             .render_dir(&tctx)
             .wrap_err_with(|| format!("{self}: failed to render dir template"))?

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -335,6 +335,11 @@ impl Step {
             .render_dir(&tctx)
             .wrap_err_with(|| format!("{self}: failed to render dir template"))?
         {
+            // A rendered `dir` that does not exist fails at spawn with a bare
+            // "No such file or directory"; name the step and the path instead.
+            if !Path::new(&dir).is_dir() {
+                eyre::bail!("{self}: working directory does not exist: {dir}");
+            }
             cmd = cmd.current_dir(&dir);
             // With HK_MISE enabled, resolve the mise environment for the step's
             // directory so tools/env from that directory's mise config (e.g. a

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -335,10 +335,14 @@ impl Step {
             .render_dir(&tctx)
             .wrap_err_with(|| format!("{self}: failed to render dir template"))?
         {
-            // A rendered `dir` that does not exist fails at spawn with a bare
-            // "No such file or directory"; name the step and the path instead.
-            if !Path::new(&dir).is_dir() {
+            // A bad `dir` fails at spawn with a bare "No such file or directory";
+            // name the step, the path, and which of the two went wrong.
+            let dir_path = Path::new(&dir);
+            if !dir_path.exists() {
                 eyre::bail!("{self}: working directory does not exist: {dir}");
+            }
+            if !dir_path.is_dir() {
+                eyre::bail!("{self}: working directory is not a directory: {dir}");
             }
             cmd = cmd.current_dir(&dir);
             // With HK_MISE enabled, resolve the mise environment for the step's

--- a/src/step_job.rs
+++ b/src/step_job.rs
@@ -69,8 +69,23 @@ impl StepJob {
 
         tctx.insert("step", &self.step.name);
 
-        // Handle directory stripping for command execution context
-        let command_files = if let Some(dir) = &self.step.dir {
+        // Workspace variables first: `dir` is a template that may reference
+        // them (`dir = "{{workspace}}"`), and `{{files}}` is relative to the
+        // directory the command runs in, so it needs the rendered `dir`.
+        if let Some(workspace_indicator) = &self.workspace_indicator {
+            tctx.with_workspace_indicator(workspace_indicator);
+            let workspace_dir = workspace_indicator
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())
+                .unwrap_or(std::path::Path::new("."));
+            tctx.with_workspace_files(self.step.shell_type(), workspace_dir, &self.files);
+        }
+
+        // Handle directory stripping for command execution context. A `dir`
+        // that fails to render strips nothing here; the runner renders it
+        // again and reports the error before the command runs.
+        let dir = self.step.render_dir(&tctx).unwrap_or_default();
+        let command_files = if let Some(dir) = &dir {
             self.files
                 .iter()
                 .map(|f| f.strip_prefix(dir).unwrap_or(f).to_path_buf())
@@ -80,14 +95,6 @@ impl StepJob {
         };
 
         tctx.with_files(self.step.shell_type(), &command_files);
-        if let Some(workspace_indicator) = &self.workspace_indicator {
-            tctx.with_workspace_indicator(workspace_indicator);
-            let workspace_dir = workspace_indicator
-                .parent()
-                .filter(|p| !p.as_os_str().is_empty())
-                .unwrap_or(std::path::Path::new("."));
-            tctx.with_workspace_files(self.step.shell_type(), workspace_dir, &self.files);
-        }
         tctx
     }
 

--- a/src/step_job.rs
+++ b/src/step_job.rs
@@ -69,9 +69,8 @@ impl StepJob {
 
         tctx.insert("step", &self.step.name);
 
-        // Workspace variables first: `dir` is a template that may reference
-        // them (`dir = "{{workspace}}"`), and `{{files}}` is relative to the
-        // directory the command runs in, so it needs the rendered `dir`.
+        // Workspace variables first: `dir` may reference them, and the files
+        // below are made relative to the rendered `dir`.
         if let Some(workspace_indicator) = &self.workspace_indicator {
             tctx.with_workspace_indicator(workspace_indicator);
             let workspace_dir = workspace_indicator
@@ -82,9 +81,9 @@ impl StepJob {
         }
 
         // Handle directory stripping for command execution context. A `dir`
-        // that fails to render strips nothing here; the runner renders it
-        // again and reports the error before the command runs.
-        let dir = self.step.render_dir(&tctx).unwrap_or_default();
+        // that fails to render strips nothing; the runner renders it again and
+        // reports the error before the command runs.
+        let dir = self.step.render_dir(&tctx).ok().flatten();
         let command_files = if let Some(dir) = &dir {
             self.files
                 .iter()

--- a/test/dir_template.bats
+++ b/test/dir_template.bats
@@ -1,0 +1,138 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "dir renders {{workspace}} so a step runs in each workspace" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["workspace-cwd"] {
+                glob = List("**/*.go")
+                workspace_indicator = "go.mod"
+                dir = "{{workspace}}"
+                check = "pwd"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "initial commit"
+
+    mkdir -p pkgs/api pkgs/worker
+    echo "module example.com/api" > pkgs/api/go.mod
+    echo "package api" > pkgs/api/main.go
+    echo "module example.com/worker" > pkgs/worker/go.mod
+    echo "package worker" > pkgs/worker/main.go
+    git add pkgs
+
+    run hk check -v
+    assert_success
+
+    # One job per workspace, each running in the workspace directory.
+    assert_output --partial "pkgs/api"
+    assert_output --partial "pkgs/worker"
+}
+
+@test "templated dir makes {{files}} relative to the rendered directory" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["workspace-files"] {
+                glob = List("**/*.go")
+                workspace_indicator = "go.mod"
+                dir = "{{workspace}}"
+                check = "echo 'checking {{files}}' && test -f {{files}}"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "initial commit"
+
+    mkdir -p pkgs/api/internal
+    echo "module example.com/api" > pkgs/api/go.mod
+    echo "package internal" > pkgs/api/internal/svc.go
+    git add pkgs
+
+    run hk check -v
+    assert_success
+    assert_output --partial "checking internal/svc.go"
+}
+
+@test "templated dir does not filter files by the literal template text" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["workspace-glob"] {
+                glob = List("**/*.go")
+                workspace_indicator = "go.mod"
+                dir = "{{workspace}}"
+                check = "echo 'ran in {{workspace}}'"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "initial commit"
+
+    mkdir -p pkgs/api
+    echo "module example.com/api" > pkgs/api/go.mod
+    echo "package api" > pkgs/api/main.go
+    git add pkgs
+
+    run hk check -v
+    assert_success
+    # A literal "{{workspace}}" prefix would match no file and skip the step.
+    refute_output --partial "no files to process"
+    assert_output --partial "ran in pkgs/api"
+}
+
+@test "the literal prefix of a templated dir still scopes file selection" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["api"] {
+                dir = "sub/{{step}}"
+                glob = List("**/*.txt")
+                check = "echo 'found {{files}}'"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "initial commit"
+
+    mkdir -p sub/api other
+    echo "a" > sub/api/a.txt
+    echo "b" > other/b.txt
+    echo "c" > root.txt
+    git add sub other root.txt
+
+    run hk check -v
+    assert_success
+
+    # "sub" is the literal prefix of the templated dir, so selection stays
+    # scoped to it, and paths are relative to the rendered "sub/api".
+    assert_output --partial "found a.txt"
+    refute_output --partial "found other/b.txt"
+    refute_output --partial "found root.txt"
+}

--- a/test/dir_template.bats
+++ b/test/dir_template.bats
@@ -136,3 +136,47 @@ EOF
     refute_output --partial "found other/b.txt"
     refute_output --partial "found root.txt"
 }
+
+@test "a leading ./ in dir does not break file selection or {{files}}" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["dot-slash-literal"] {
+                dir = "./sub"
+                glob = List("**/*.txt")
+                check = "echo 'literal {{files}}' && test -f {{files}}"
+            }
+            ["dot-slash-template"] {
+                dir = "./sub/{{step}}"
+                glob = List("**/*.md")
+                check = "echo 'templated {{files}}' && test -f {{files}}"
+            }
+            ["repo-root"] {
+                dir = "."
+                glob = List("**/*.txt")
+                check = "echo 'root {{files}}' && test -f {{files}}"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "initial commit"
+
+    mkdir -p "sub/dot-slash-template"
+    echo "a" > sub/a.txt
+    echo "b" > sub/dot-slash-template/b.md
+    git add sub
+
+    run hk check -v
+    assert_success
+
+    # "./sub" must behave exactly like "sub": the file is selected and the path
+    # is made relative to it, not left repo-root-relative and doubled.
+    assert_output --partial "literal a.txt"
+    assert_output --partial "templated b.md"
+    # "." is the repo root, so it narrows nothing and paths stay as they are.
+    assert_output --partial "root sub/a.txt"
+}

--- a/test/dir_template.bats
+++ b/test/dir_template.bats
@@ -180,3 +180,66 @@ EOF
     # "." is the repo root, so it narrows nothing and paths stay as they are.
     assert_output --partial "root sub/a.txt"
 }
+
+@test "a dir that renders to a missing directory names the step and the path" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["missing"] {
+                glob = List("**/*.txt")
+                dir = "nope/{{step}}"
+                check = "true"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "initial commit"
+
+    mkdir -p nope
+    echo "a" > nope/a.txt
+    git add nope
+
+    run hk check -v
+    assert_failure
+    # Without this the spawn fails with a bare "No such file or directory".
+    assert_output --partial "missing: working directory does not exist: nope/missing"
+}
+
+@test "stage patterns warn when dir is fully templated" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["fix"] {
+        fix = true
+        steps {
+            ["gen"] {
+                glob = List("**/*.txt")
+                workspace_indicator = "marker"
+                dir = "{{workspace}}"
+                stage = List("generated/**")
+                fix = "mkdir -p generated && echo out > generated/o.txt"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "initial commit"
+
+    mkdir -p pkgs/a
+    touch pkgs/a/marker
+    echo "x" > pkgs/a/in.txt
+    git add pkgs
+    git commit -m "add workspace"
+    echo "y" >> pkgs/a/in.txt
+    git add pkgs/a/in.txt
+
+    run hk fix
+    assert_success
+    # Staging runs once per step, so it cannot follow a per-job workspace.
+    assert_output --partial "\`stage\` patterns are relative to the repo root"
+}

--- a/test/dir_template.bats
+++ b/test/dir_template.bats
@@ -209,7 +209,7 @@ EOF
     assert_output --partial "missing: working directory does not exist: nope/missing"
 }
 
-@test "stage patterns warn when dir is fully templated" {
+@test "stage patterns are scoped to each workspace when dir is templated" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
 hooks {
@@ -230,16 +230,51 @@ EOF
     git add hk.pkl
     git commit -m "initial commit"
 
-    mkdir -p pkgs/a
-    touch pkgs/a/marker
+    mkdir -p pkgs/a pkgs/b generated
+    touch pkgs/a/marker pkgs/b/marker
     echo "x" > pkgs/a/in.txt
+    echo "x" > pkgs/b/in.txt
+    echo "unrelated" > generated/root.txt
     git add pkgs
-    git commit -m "add workspace"
+    git commit -m "add workspaces"
     echo "y" >> pkgs/a/in.txt
-    git add pkgs/a/in.txt
+    echo "y" >> pkgs/b/in.txt
+    git add pkgs/a/in.txt pkgs/b/in.txt
 
     run hk fix
     assert_success
-    # Staging runs once per step, so it cannot follow a per-job workspace.
-    assert_output --partial "\`stage\` patterns are relative to the repo root"
+
+    run git diff --cached --name-only
+    # The pattern is resolved once per workspace, so both generated files are
+    # staged and the same-named path at the repo root is left alone.
+    assert_line "pkgs/a/generated/o.txt"
+    assert_line "pkgs/b/generated/o.txt"
+    refute_line "generated/root.txt"
+}
+
+@test "a dir that renders to a file says so instead of reporting it missing" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["notadir"] {
+                glob = List("**/*.txt")
+                dir = "{{step}}"
+                check = "true"
+            }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "initial commit"
+
+    echo "i am a file" > notadir
+    echo "a" > a.txt
+    git add notadir a.txt
+
+    run hk check -v
+    assert_failure
+    assert_output --partial "notadir: working directory is not a directory: notadir"
 }


### PR DESCRIPTION
## Summary

Implements [#953](https://github.com/jdx/hk/discussions/953): render `dir` through Tera so a workspace-aware step can point its working directory at the workspace it was matched for, instead of opening every command with `cd {{workspace}} && ...`.

```pkl
["go-vet"] {
  glob = "**/*.go"
  workspace_indicator = "go.mod"
  dir = "{{workspace}}"
  check = "go vet ./..."
}
```

`dir` is read at two kinds of site, and they need different answers:

- **Execution** — child process cwd and the cwd for `git apply`. Per job, so they render the template (`Step::render_dir`). `{{files}}` is stripped by the rendered value, as it already was for a literal `dir`.
- **Selection** — `glob` matching, `exclude`, stage pathspecs. These run before hk knows a job's workspace, so they use `Step::dir_prefix`: the literal path prefix before the first template expression.

A literal `dir` contains no template expression, renders to itself, and returns the same string from both accessors — and `dir` never accepted `{{...}}` before, so existing configs are unaffected.

The eight workspace-aware builtins (the seven Go ones plus `cargo_deny`) drop their `cd` prefix in the second commit. I left them as string commands; converting them to argv for direct exec is now unblocked but separable.

## One deviation from the discussion

Option 1 suggested letting the selection sites read the literal string. That's worse than "filtering disabled" in practice: `files.retain(|f| f.starts_with("{{workspace}}"))` matches nothing, so the step is skipped with *no files to process*. And since a subproject prefixes `dir`, a builtin used there becomes `sub/{{workspace}}` and loses that subproject's scoping too.

`dir_prefix()` handles both — `{{workspace}}` scopes nothing (selection is left to `glob` and `workspace_indicator`, which these builtins rely on anyway), while `sub/{{workspace}}` stays scoped to `sub`.

## Validation

- `cargo test` — 265 pass, including 4 new unit tests for `dir_prefix`
- new `test/dir_template.bats` (4 tests), plus `multiple_dirs`, `workspace_indicator`, `subprojects`, `apply_check_diff`, `dir_glob_relative`, `dir_traversal`, `glob_dir_bug`, `stage_*`, `group_inheritance`, `mise_env`
- `cargo fmt --check` clean, no new clippy warnings vs `main`, `pkl format` clean
- with a stub `go` on PATH, `Builtins.go_vet` produced two jobs running in `pkgs/api` and `pkgs/worker`, no `cd`

`test/dir.bats` and two `test/exclude.bats` cases fail locally for want of `prettier`; they fail identically on `main`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for templated working directories, enabling commands to run directly within matched workspaces.
  * Improved workspace-relative file paths, directory filtering, glob matching, and leading relative-path handling.
  * Diff application now respects the configured working directory.

* **Bug Fixes**
  * Improved consistency when matching files, staging changes, resolving environments, and applying diffs.
  * Added clearer errors for invalid rendered directories and warnings for unexpected staging paths.

* **Documentation**
  * Documented templated `dir` settings, workspace execution, path selection, and relative file handling.
  * Updated custom linter examples for workspace-aware directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->