### PR TITLE
fix(step): resolve Windows command shims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,8 @@ jobs:
           ./e2e-win/run.ps1 -TestName "*help*"
           # Regression test for discussion #823 (cmd.exe {{files}} quoting)
           ./e2e-win/run.ps1 -TestName "*{{files}} template*"
+          # Regression test for discussion #1220 (structured argv npm shims)
+          ./e2e-win/run.ps1 -TestName "*structured argv resolves*"
   final:
     permissions: {}
     needs:

--- a/e2e-win/check.Tests.ps1
+++ b/e2e-win/check.Tests.ps1
@@ -130,4 +130,64 @@ hooks {
             Remove-Item -Path $testDir -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
+
+    It 'structured argv resolves node_modules cmd shims' {
+        $testDir = Join-Path $TestDrive ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $testDir | Out-Null
+        Set-Location $testDir
+        $originalPath = $env:PATH
+
+        try {
+            git init | Out-Null
+            git config user.email "test@test.com"
+            git config user.name "Test"
+
+            $binDir = New-Item -ItemType Directory -Force -Path "subdir/node_modules/.bin"
+            $capture = @"
+import json
+import sys
+with open('argv.json', 'w') as f:
+    json.dump(sys.argv[1:], f)
+"@
+            Set-Content -Path "subdir/node_modules/capture.py" -Value $capture -Encoding ascii
+            $shim = @'
+@ECHO off
+python "%~dp0\..\capture.py" %*
+'@
+            Set-Content -Path "$binDir/argv-capture.cmd" -Value $shim -Encoding ascii
+            # A relative PATH entry must be resolved from the step's relative dir.
+            $env:PATH = "node_modules/.bin;$originalPath"
+            $env:HK_ARG_EXPAND = "expanded"
+
+            $pklPath = (Resolve-Path $env:PKL_PATH).Path -replace '\\', '/'
+            $pklUri = "file:///$pklPath/Config.pkl"
+            $config = @"
+amends "$pklUri"
+
+hooks {
+    ["check"] {
+        steps {
+            ["capture"] {
+                dir = "subdir"
+                check = new Command {
+                    argv = List("argv-capture", "space value", "amp&ersand", "percent%HK_ARG_EXPAND%", "star*", "caret^value")
+                }
+            }
+        }
+    }
+}
+"@
+            Set-Content -Path "hk.pkl" -Value $config -Encoding ascii
+
+            $output = hk check --all 2>&1 | Out-String
+            $LASTEXITCODE | Should -Be 0 -Because "hk check --all should succeed; output:`n$output"
+            $actual = Get-Content "subdir/argv.json" -Raw | ConvertFrom-Json | ConvertTo-Json -Compress
+            $actual | Should -Be '["space value","amp&ersand","percent%HK_ARG_EXPAND%","star*","caret^value"]'
+        } finally {
+            $env:PATH = $originalPath
+            Remove-Item Env:HK_ARG_EXPAND -ErrorAction SilentlyContinue
+            Set-Location $script:originalPath
+            Remove-Item -Path $testDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
 }

--- a/src/step/command.rs
+++ b/src/step/command.rs
@@ -1,19 +1,21 @@
 use ensembler::CmdLineRunner;
 use std::path::Path;
 
+use crate::Result;
+
 pub(crate) fn argv_runner(
     argv: &[String],
     cwd: &Path,
     path: Option<&str>,
     pathext: Option<&str>,
-) -> CmdLineRunner {
+) -> Result<CmdLineRunner> {
     #[cfg(windows)]
     if let Some(program) = resolve_batch_file(&argv[0], cwd, path, pathext) {
         return batch_runner(&program, &argv[1..]);
     }
 
     let _ = (cwd, path, pathext);
-    CmdLineRunner::new_direct(&argv[0]).args(&argv[1..])
+    Ok(CmdLineRunner::new_direct(&argv[0]).args(&argv[1..]))
 }
 
 #[cfg_attr(not(windows), allow(dead_code))]
@@ -96,7 +98,8 @@ fn is_batch_file(path: &Path) -> bool {
 }
 
 #[cfg_attr(not(windows), allow(dead_code))]
-fn batch_runner(program: &Path, args: &[String]) -> CmdLineRunner {
+fn batch_runner(program: &Path, args: &[String]) -> Result<CmdLineRunner> {
+    reject_batch_newlines(program, args)?;
     let program = program.to_string_lossy().replace('/', "\\");
     let normalized = program.to_ascii_lowercase();
     // npm shims forward `%*` through a second cmd.exe parse, so metacharacters
@@ -107,9 +110,26 @@ fn batch_runner(program: &Path, args: &[String]) -> CmdLineRunner {
         command.push(' ');
         command.push_str(&escape_cmd_arg(arg, double_escape));
     }
-    CmdLineRunner::new_direct(std::env::var_os("COMSPEC").unwrap_or_else(|| "cmd.exe".into()))
-        .args(["/d", "/s", "/c"])
-        .raw_arg(format!("\"{command}\""))
+    Ok(
+        CmdLineRunner::new_direct(std::env::var_os("COMSPEC").unwrap_or_else(|| "cmd.exe".into()))
+            .args(["/d", "/s", "/c"])
+            .raw_arg(format!("\"{command}\"")),
+    )
+}
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn reject_batch_newlines(program: &Path, args: &[String]) -> Result<()> {
+    let contains_newline = |value: &str| value.contains('\r') || value.contains('\n');
+    if contains_newline(&program.to_string_lossy()) {
+        eyre::bail!("Windows batch command path contains a newline");
+    }
+    if let Some(index) = args.iter().position(|arg| contains_newline(arg)) {
+        eyre::bail!(
+            "Windows batch command argument {} contains a newline",
+            index + 1
+        );
+    }
+    Ok(())
 }
 
 #[cfg_attr(not(windows), allow(dead_code))]
@@ -165,6 +185,26 @@ mod tests {
         assert_eq!(
             escape_cmd_arg("amp&percent%caret^", true),
             "^^^\"amp^^^&percent^^^%caret^^^^^^^\""
+        );
+    }
+
+    #[test]
+    fn rejects_newlines_in_batch_commands() {
+        let args = vec!["safe".to_string(), "unsafe\ncommand".to_string()];
+        let error = reject_batch_newlines(Path::new("tool.cmd"), &args)
+            .err()
+            .expect("newline should be rejected");
+        assert_eq!(
+            error.to_string(),
+            "Windows batch command argument 2 contains a newline"
+        );
+
+        let error = reject_batch_newlines(Path::new("unsafe\rtool.cmd"), &[])
+            .err()
+            .expect("newline should be rejected");
+        assert_eq!(
+            error.to_string(),
+            "Windows batch command path contains a newline"
         );
     }
 }

--- a/src/step/command.rs
+++ b/src/step/command.rs
@@ -1,0 +1,170 @@
+use ensembler::CmdLineRunner;
+use std::path::Path;
+
+pub(crate) fn argv_runner(
+    argv: &[String],
+    cwd: &Path,
+    path: Option<&str>,
+    pathext: Option<&str>,
+) -> CmdLineRunner {
+    #[cfg(windows)]
+    if let Some(program) = resolve_batch_file(&argv[0], cwd, path, pathext) {
+        return batch_runner(&program, &argv[1..]);
+    }
+
+    let _ = (cwd, path, pathext);
+    CmdLineRunner::new_direct(&argv[0]).args(&argv[1..])
+}
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn resolve_batch_file(
+    program: &str,
+    cwd: &Path,
+    path: Option<&str>,
+    pathext: Option<&str>,
+) -> Option<std::path::PathBuf> {
+    use std::ffi::OsStr;
+    use std::path::{MAIN_SEPARATOR, PathBuf};
+
+    let program_path = Path::new(program);
+    let has_dir =
+        program_path.is_absolute() || program.contains('/') || program.contains(MAIN_SEPARATOR);
+    let dirs: Vec<PathBuf> = if has_dir {
+        vec![cwd.to_path_buf()]
+    } else {
+        std::iter::once(cwd.to_path_buf())
+            .chain(std::env::split_paths(
+                &path
+                    .map(OsStr::new)
+                    .map(ToOwned::to_owned)
+                    .or_else(|| std::env::var_os("PATH"))
+                    .unwrap_or_default(),
+            ))
+            .map(|dir| {
+                if dir.is_absolute() {
+                    dir
+                } else {
+                    cwd.join(dir)
+                }
+            })
+            .collect()
+    };
+
+    if program_path.extension().is_some() {
+        let candidate = if program_path.is_absolute() {
+            program_path.to_path_buf()
+        } else if has_dir {
+            cwd.join(program_path)
+        } else {
+            dirs.iter()
+                .map(|dir| dir.join(program_path))
+                .find(|candidate| candidate.is_file())?
+        };
+        return is_batch_file(&candidate).then_some(candidate);
+    }
+
+    let extensions = pathext
+        .map(str::to_owned)
+        .or_else(|| std::env::var("PATHEXT").ok())
+        .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".to_string());
+    for dir in dirs {
+        let base = if program_path.is_absolute() {
+            program_path.to_path_buf()
+        } else {
+            dir.join(program_path)
+        };
+        for extension in extensions
+            .split(';')
+            .filter(|extension| !extension.is_empty())
+        {
+            let candidate = PathBuf::from(format!("{}{}", base.display(), extension));
+            if candidate.is_file() {
+                return is_batch_file(&candidate).then_some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn is_batch_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("cmd") || extension.eq_ignore_ascii_case("bat")
+        })
+}
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn batch_runner(program: &Path, args: &[String]) -> CmdLineRunner {
+    let program = program.to_string_lossy().replace('/', "\\");
+    let normalized = program.to_ascii_lowercase();
+    // npm shims forward `%*` through a second cmd.exe parse, so metacharacters
+    // need one additional escape pass to arrive as literal argv values.
+    let double_escape = normalized.contains("\\node_modules\\.bin\\");
+    let mut command = escape_cmd_meta(&program);
+    for arg in args {
+        command.push(' ');
+        command.push_str(&escape_cmd_arg(arg, double_escape));
+    }
+    CmdLineRunner::new_direct(std::env::var_os("COMSPEC").unwrap_or_else(|| "cmd.exe".into()))
+        .args(["/d", "/s", "/c"])
+        .raw_arg(format!("\"{command}\""))
+}
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn escape_cmd_arg(arg: &str, double_escape_meta: bool) -> String {
+    // Match the quoting strategy used by cross-spawn: first apply Windows argv
+    // backslash/quote rules, then protect cmd.exe metacharacters with carets.
+    let mut escaped = String::with_capacity(arg.len() + 2);
+    escaped.push('"');
+    let mut backslashes = 0;
+    for character in arg.chars() {
+        if character == '\\' {
+            backslashes += 1;
+            continue;
+        }
+        if character == '"' {
+            escaped.extend(std::iter::repeat_n('\\', backslashes * 2 + 1));
+        } else {
+            escaped.extend(std::iter::repeat_n('\\', backslashes));
+        }
+        backslashes = 0;
+        escaped.push(character);
+    }
+    escaped.extend(std::iter::repeat_n('\\', backslashes * 2));
+    escaped.push('"');
+    let escaped = escape_cmd_meta(&escaped);
+    if double_escape_meta {
+        escape_cmd_meta(&escaped)
+    } else {
+        escaped
+    }
+}
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn escape_cmd_meta(value: &str) -> String {
+    const META: &str = "()[]%!^\"`<>&|;, *?";
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        if META.contains(character) {
+            escaped.push('^');
+        }
+        escaped.push(character);
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_cmd_shim_arguments() {
+        assert_eq!(escape_cmd_arg("space value", false), "^\"space^ value^\"");
+        assert_eq!(
+            escape_cmd_arg("amp&percent%caret^", true),
+            "^^^\"amp^^^&percent^^^%caret^^^^^^^\""
+        );
+    }
+}

--- a/src/step/mod.rs
+++ b/src/step/mod.rs
@@ -34,6 +34,7 @@
 
 mod batching;
 mod check_parsing;
+mod command;
 mod diff;
 mod dir;
 mod execution;
@@ -47,6 +48,7 @@ mod shell;
 mod types;
 
 // Re-export public API
+pub(crate) use command::argv_runner;
 pub use expr_env::{EXPR_CTX, eval_condition};
 pub use shell::ShellType;
 pub(crate) use types::RenderedCommand;

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -323,7 +323,7 @@ impl Step {
         // cmd.exe delivers tools arguments with literal `"` characters embedded.
         let mut cmd = match &rendered_command {
             RenderedCommand::Argv(argv) => {
-                argv_runner(argv, &command_dir, child_env("PATH"), child_env("PATHEXT"))
+                argv_runner(argv, &command_dir, child_env("PATH"), child_env("PATHEXT"))?
             }
             RenderedCommand::Shell(run) => {
                 let use_raw_cmd = cfg!(windows) && matches!(self.shell_type(), ShellType::Cmd);

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -19,9 +19,10 @@ use clx::progress::ProgressStatus;
 use ensembler::CmdLineRunner;
 use eyre::WrapErr;
 use itertools::Itertools;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Stdio;
 
+use super::command::argv_runner;
 use super::expr_env::eval_condition;
 use super::shell::ShellType;
 use super::types::{
@@ -226,6 +227,54 @@ impl Step {
             .render(&tctx, self.prefix.as_ref())
             .wrap_err_with(|| format!("{self}: failed to render command template"))?;
         let run = rendered_command.display(self.shell_type());
+        let rendered_dir = self
+            .render_dir(&tctx)
+            .wrap_err_with(|| format!("{self}: failed to render dir template"))?;
+        let current_dir = std::env::current_dir()?;
+        let command_dir = rendered_dir
+            .as_deref()
+            .map(PathBuf::from)
+            .map(|dir| {
+                if dir.is_absolute() {
+                    dir
+                } else {
+                    current_dir.join(dir)
+                }
+            })
+            .unwrap_or(current_dir);
+        if let Some(dir) = &rendered_dir {
+            if !command_dir.exists() {
+                eyre::bail!("{self}: working directory does not exist: {dir}");
+            }
+            if !command_dir.is_dir() {
+                eyre::bail!("{self}: working directory is not a directory: {dir}");
+            }
+        }
+        let mise_env = if rendered_dir.is_some() && *env::HK_MISE {
+            Some(crate::mise_env::mise_env_for_dir(&command_dir).await)
+        } else {
+            None
+        };
+        let rendered_env = self
+            .env
+            .iter()
+            .map(|(key, value)| Ok((key.clone(), tera::render(value, &tctx)?)))
+            .collect::<Result<Vec<_>>>()?;
+        let child_env = |name: &str| {
+            rendered_env
+                .iter()
+                .rev()
+                .find(|(key, _)| key.eq_ignore_ascii_case(name))
+                .map(|(_, value)| value.as_str())
+                .or_else(|| {
+                    mise_env.as_ref().and_then(|env| {
+                        env.iter()
+                            .rev()
+                            .find(|(key, _)| key.eq_ignore_ascii_case(name))
+                            .map(|(_, value)| value.as_str())
+                    })
+                })
+        };
         let display_pattern = |pattern: &Pattern| match pattern {
             Pattern::Globs(globs) => globs.join(" "),
             Pattern::Regex { pattern, .. } => format!("regex: {pattern}"),
@@ -273,7 +322,9 @@ impl Step {
         // `raw_arg` — otherwise Rust re-escapes the already-quoted payload and
         // cmd.exe delivers tools arguments with literal `"` characters embedded.
         let mut cmd = match &rendered_command {
-            RenderedCommand::Argv(argv) => CmdLineRunner::new_direct(&argv[0]).args(&argv[1..]),
+            RenderedCommand::Argv(argv) => {
+                argv_runner(argv, &command_dir, child_env("PATH"), child_env("PATHEXT"))
+            }
             RenderedCommand::Shell(run) => {
                 let use_raw_cmd = cfg!(windows) && matches!(self.shell_type(), ShellType::Cmd);
                 if let Some(shell) = &self.shell {
@@ -330,34 +381,19 @@ impl Step {
                 cmd = cmd.env("GIT_WORK_TREE", root);
             }
         }
-        // `dir` is a template: it may resolve to this job's workspace.
-        if let Some(dir) = self
-            .render_dir(&tctx)
-            .wrap_err_with(|| format!("{self}: failed to render dir template"))?
-        {
-            // A bad `dir` fails at spawn with a bare "No such file or directory";
-            // name the step, the path, and which of the two went wrong.
-            let dir_path = Path::new(&dir);
-            if !dir_path.exists() {
-                eyre::bail!("{self}: working directory does not exist: {dir}");
-            }
-            if !dir_path.is_dir() {
-                eyre::bail!("{self}: working directory is not a directory: {dir}");
-            }
-            cmd = cmd.current_dir(&dir);
+        if rendered_dir.is_some() {
+            cmd = cmd.current_dir(&command_dir);
             // With HK_MISE enabled, resolve the mise environment for the step's
             // directory so tools/env from that directory's mise config (e.g. a
             // subproject's mise.toml) are available even when hk was started
             // from the repo root. Explicit step env still wins below.
-            if *env::HK_MISE {
-                let mise_env = crate::mise_env::mise_env_for_dir(Path::new(&dir)).await;
+            if let Some(mise_env) = &mise_env {
                 for (key, value) in mise_env.iter() {
                     cmd = cmd.env(key, value);
                 }
             }
         }
-        for (key, value) in &self.env {
-            let value = tera::render(value, &tctx)?;
+        for (key, value) in rendered_env {
             cmd = cmd.env(key, value);
         }
         let timing_guard = StepTimingGuard::new(ctx.hook_ctx.timing.clone(), self);

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use crate::{
     Result, git_util,
-    step::{RenderedCommand, RunType, Step},
+    step::{RenderedCommand, RunType, Step, argv_runner},
     step_test::{RunKind, StepTest},
     tera,
 };
@@ -30,8 +30,29 @@ async fn execute_cmd(
     command: &RenderedCommand,
     stdin: &Option<String>,
 ) -> Result<(String, String, i32)> {
+    let rendered_step_env = step
+        .env
+        .iter()
+        .map(|(key, value)| Ok((key.clone(), tera::render(value, tctx)?)))
+        .collect::<Result<Vec<_>>>()?;
+    let env_value = |name: &str| {
+        test.env
+            .iter()
+            .rev()
+            .find(|(key, _)| key.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.as_str())
+            .or_else(|| {
+                rendered_step_env
+                    .iter()
+                    .rev()
+                    .find(|(key, _)| key.eq_ignore_ascii_case(name))
+                    .map(|(_, value)| value.as_str())
+            })
+    };
     let mut runner = match command {
-        RenderedCommand::Argv(argv) => CmdLineRunner::new_direct(&argv[0]).args(&argv[1..]),
+        RenderedCommand::Argv(argv) => {
+            argv_runner(argv, base_dir, env_value("PATH"), env_value("PATHEXT"))
+        }
         RenderedCommand::Shell(cmd_str) => {
             let runner = if let Some(shell) = &step.shell {
                 let shell = shell.to_string();
@@ -49,8 +70,7 @@ async fn execute_cmd(
         runner = runner.stdin_string(rendered_stdin);
     }
     runner = runner.current_dir(base_dir);
-    for (k, v) in &step.env {
-        let v = tera::render(v, tctx)?;
+    for (k, v) in rendered_step_env {
         runner = runner.env(k, v);
     }
     for (k, v) in &test.env {

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -51,7 +51,7 @@ async fn execute_cmd(
     };
     let mut runner = match command {
         RenderedCommand::Argv(argv) => {
-            argv_runner(argv, base_dir, env_value("PATH"), env_value("PATHEXT"))
+            argv_runner(argv, base_dir, env_value("PATH"), env_value("PATHEXT"))?
         }
         RenderedCommand::Shell(cmd_str) => {
             let runner = if let Some(shell) = &step.shell {


### PR DESCRIPTION
## Summary

- resolve structured argv executables with the effective Windows `PATH` and `PATHEXT`
- execute `.cmd` and `.bat` targets through `cmd.exe` with argument-boundary-preserving escaping
- keep real executables on the direct process path
- cover npm-style `node_modules/.bin` shims in the Windows Pester suite

Fixes the behavior reported in discussion #1220.

## Validation

- `cargo check`
- `cargo test step::`
- `mise run test:bats test/structured_argv.bats`
- Windows Pester regression test added to CI

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Windows processes are spawned and how cmd.exe arguments are escaped, which can affect command injection and tool invocation. Scope is Windows-only with tests, but escaping bugs would be high-impact.
> 
> **Overview**
> On Windows, structured `argv` steps now resolve `.cmd`/`.bat` targets (including npm `node_modules/.bin` shims) via the step working directory and effective `PATH`/`PATHEXT`, then run them through `cmd.exe` with quoting that preserves argument boundaries. Real executables still spawn directly.
> 
> npm-style shims get an extra metacharacter escape pass so values with spaces, `&`, `%`, `*`, and `^` arrive as literal argv. Newlines in batch paths/args are rejected. Step env is rendered once and used both for PATH lookup and the child process.
> 
> Adds a Windows Pester regression for discussion #1220 and wires it into CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccf9311bc288554f465466e8d092599c977596cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows command execution for structured arguments, including commands with spaces and shell-special characters.
  - Correctly resolves `.cmd` and `.bat` shims using the configured working directory and environment.
  - Preserves command arguments unchanged when running Windows npm-style shims.
  - Applies configured environment values consistently during command execution.
  - Rejects unsafe newline characters in Windows batch command paths and arguments.

- **Tests**
  - Added Windows end-to-end coverage for structured argument resolution, shim execution, and command-line escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->