### PR TITLE
chore: release v1.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,79 @@
 # Changelog
 
+## [1.57.0](https://github.com/jdx/hk/compare/v1.56.1..v1.57.0) - 2026-08-30
+
+### 🚀 Features
+
+- **(builtins)** add go_fix linter by [@sahidvelji](https://github.com/sahidvelji) in [#1224](https://github.com/jdx/hk/pull/1224)
+- **(builtins)** add ls_lint linter by [@sahidvelji](https://github.com/sahidvelji) in [#1238](https://github.com/jdx/hk/pull/1238)
+- **(builtins)** add golangci_lint_fmt formatter by [@sahidvelji](https://github.com/sahidvelji) in [#1244](https://github.com/jdx/hk/pull/1244)
+- **(builtins)** add shellcheck fix via check_diff by [@sahidvelji](https://github.com/sahidvelji) in [#1237](https://github.com/jdx/hk/pull/1237)
+- **(pkl)** embed the matching-version pkl package by [@sahidvelji](https://github.com/sahidvelji) in [#1218](https://github.com/jdx/hk/pull/1218)
+- **(step)** render `dir` through tera by [@sahidvelji](https://github.com/sahidvelji) in [#1219](https://github.com/jdx/hk/pull/1219)
+- **(step)** recheck applied diffs by [@jdx](https://github.com/jdx) in [#1243](https://github.com/jdx/hk/pull/1243)
+- **(step)** allow configured command failures by [@jdx](https://github.com/jdx) in [#1291](https://github.com/jdx/hk/pull/1291)
+
+### 🐛 Bug Fixes
+
+- **(builtins)** repair Go linters that report success on bad code by [@sahidvelji](https://github.com/sahidvelji) in [#1225](https://github.com/jdx/hk/pull/1225)
+- **(builtins)** broaden gomod_tidy glob to run tidy on .go changes by [@sahidvelji](https://github.com/sahidvelji) in [#1236](https://github.com/jdx/hk/pull/1236)
+- **(builtins)** stage gomod_tidy manifest updates by [@jdx](https://github.com/jdx) in [#1240](https://github.com/jdx/hk/pull/1240)
+- **(builtins)** recheck partial diff fixes by [@jdx](https://github.com/jdx) in [#1245](https://github.com/jdx/hk/pull/1245)
+- **(builtins)** correct gitleaks scan modes by [@jdx](https://github.com/jdx) in [#1248](https://github.com/jdx/hk/pull/1248)
+- **(stash)** skip empty pathspec stashes by [@jdx](https://github.com/jdx) in [#1283](https://github.com/jdx/hk/pull/1283)
+- **(step)** resolve Windows command shims by [@jdx](https://github.com/jdx) in [#1221](https://github.com/jdx/hk/pull/1221)
+- **(step)** relativize workspace paths to step directory by [@jdx](https://github.com/jdx) in [#1242](https://github.com/jdx/hk/pull/1242)
+
+### 📚 Documentation
+
+- clarify subproject monorepo setup by [@jdx](https://github.com/jdx) in [#1239](https://github.com/jdx/hk/pull/1239)
+- improve onboarding and navigation by [@jdx](https://github.com/jdx) in [#1247](https://github.com/jdx/hk/pull/1247)
+- disable code ligatures by [@jdx](https://github.com/jdx) in [#1264](https://github.com/jdx/hk/pull/1264)
+- publish llms.txt index by [@jdx](https://github.com/jdx) in [#1272](https://github.com/jdx/hk/pull/1272)
+
+### 🛡️ Security
+
+- add sponsor logos to readme by [@jdx](https://github.com/jdx) in [#1250](https://github.com/jdx/hk/pull/1250)
+
+### 🔍 Other Changes
+
+- **(ci)** adopt mbx for Rust builds by [@jdx](https://github.com/jdx) in [#1229](https://github.com/jdx/hk/pull/1229)
+- **(ci)** restrict trusted mbx runs to jdx by [@jdx](https://github.com/jdx) in [#1254](https://github.com/jdx/hk/pull/1254)
+- **(ci)** isolate mbx OIDC permissions by [@jdx](https://github.com/jdx) in [#1258](https://github.com/jdx/hk/pull/1258)
+- **(ci)** compare mbx with rust-cache by [@jdx](https://github.com/jdx) in [#1267](https://github.com/jdx/hk/pull/1267)
+- **(ci)** adopt mbx 0.5.4 by [@jdx](https://github.com/jdx) in [#1279](https://github.com/jdx/hk/pull/1279)
+- **(ci)** pin mr-boxington-action v1.0.1 by [@jdx](https://github.com/jdx) in [#1280](https://github.com/jdx/hk/pull/1280)
+- **(ci)** use default Rust for cache benchmark by [@jdx](https://github.com/jdx) in [#1284](https://github.com/jdx/hk/pull/1284)
+- **(ci)** bump mr-boxington action by [@jdx](https://github.com/jdx) in [#1282](https://github.com/jdx/hk/pull/1282)
+- **(ci)** use server cache for dispatched benchmarks by [@jdx](https://github.com/jdx) in [#1285](https://github.com/jdx/hk/pull/1285)
+- **(ci)** adopt mbx 0.7.0 by [@jdx](https://github.com/jdx) in [#1286](https://github.com/jdx/hk/pull/1286)
+- **(sponsors)** replace 37signals with omacom foundation by [@jdx](https://github.com/jdx) in [#1249](https://github.com/jdx/hk/pull/1249)
+- generate release notes before publishing by [@jdx](https://github.com/jdx) in [#1227](https://github.com/jdx/hk/pull/1227)
+- automate generated cli versions by [@jdx](https://github.com/jdx) in [#1252](https://github.com/jdx/hk/pull/1252)
+- seed mbx cache for fork PRs by [@jdx](https://github.com/jdx) in [#1262](https://github.com/jdx/hk/pull/1262)
+- notarize the macOS release binary by [@jdx](https://github.com/jdx) in [#1266](https://github.com/jdx/hk/pull/1266)
+- benchmark mbx against rust-cache on Linux by [@jdx](https://github.com/jdx) in [#1275](https://github.com/jdx/hk/pull/1275)
+- remove pinned rust toolchain by [@jdx](https://github.com/jdx) in [#1235](https://github.com/jdx/hk/pull/1235)
+- back mbx with the GitHub Actions cache alone by [@jdx](https://github.com/jdx) in [#1287](https://github.com/jdx/hk/pull/1287)
+
+### 📦️ Dependency Updates
+
+- update rust crate pklr to v1.5.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1222](https://github.com/jdx/hk/pull/1222)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1226](https://github.com/jdx/hk/pull/1226)
+- bump usage to 6.4.0 by [@jdx](https://github.com/jdx) in [#1228](https://github.com/jdx/hk/pull/1228)
+- update anthropics/claude-code-action action to v1.0.194 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1230](https://github.com/jdx/hk/pull/1230)
+- update jdx/mise-action action to v4.2.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1231](https://github.com/jdx/hk/pull/1231)
+- update rust crate demand to v2.1.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1241](https://github.com/jdx/hk/pull/1241)
+- update anthropics/claude-code-action action to v1.0.195 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1251](https://github.com/jdx/hk/pull/1251)
+- update rust crate pklr to v1.5.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1260](https://github.com/jdx/hk/pull/1260)
+- bump usage to 6.4.1 by [@jdx](https://github.com/jdx) in [#1273](https://github.com/jdx/hk/pull/1273)
+- bump tak and mbx by [@jdx](https://github.com/jdx) in [#1274](https://github.com/jdx/hk/pull/1274)
+- remove rust toolchain pins by [@jdx](https://github.com/jdx) in [#1276](https://github.com/jdx/hk/pull/1276)
+
+### New Contributors
+
+- @sahidvelji made their first contribution in [#1237](https://github.com/jdx/hk/pull/1237)
+
 ## [1.56.1](https://github.com/jdx/hk/compare/v1.56.0..v1.56.1) - 2026-08-23
 
 ### 🚜 Refactor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.56.1"
+version = "1.57.0"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "hk"
 repository = "https://github.com/jdx/hk"
 resolver = "3"
 rust-version = "1.91.0"
-version = "1.56.1"
+version = "1.57.0"
 
 [[bin]]
 name = "generate-docs"

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The generated `hk.pkl` uses hk's built-in linter definitions, which you can exte
 needs different behavior:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   ["eslint"] = Builtins.eslint

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 140+ pre-configured linters and formatters through the `Builtins` mo
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -7877,7 +7877,7 @@
     "sources": {},
     "files": []
   },
-  "version": "1.56.1",
+  "version": "1.57.0",
   "usage": "",
   "complete": {
     "directory": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage:** `hk [FLAGS] <SUBCOMMAND>`
 
-**Version:** 1.56.1
+**Version:** 1.57.0
 
 - **Usage:** `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined
@@ -364,8 +364,8 @@ The hkrc file follows the same format as `hk.pkl` and can be used to define glob
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -398,7 +398,7 @@ Add steps to your hkrc. hk merges them into every project's hooks — steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -491,7 +491,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -76,8 +76,8 @@ scripts on older versions. See [`hk install`](/cli/install) for all installation
 A typical configuration shares the same linters between automatic hooks and manual commands:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   ["eslint"] = Builtins.eslint

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -43,7 +43,7 @@ parsing, parallel execution, and more.
 Just run mise in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line which essentially schema validates the config and provides base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,9 +3,9 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,9 +3,9 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,9 +3,9 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,9 +4,9 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -6,8 +6,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -6,8 +6,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -13,8 +13,8 @@ Groups can set common step attributes such as `dir`, `workspace_indicator`, `pre
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {
@@ -114,7 +114,7 @@ its own `hk.pkl` next to its code. The root config lists the subproject director
 
 ```pkl
 // hk.pkl (repo root)
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
 
 subprojects = List("frontend", "backend", "packages/*")
 
@@ -129,8 +129,8 @@ hooks {
 
 ```pkl
 // frontend/hk.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // aube resolves these executables from frontend/node_modules/.bin
@@ -155,8 +155,8 @@ hooks {
 
 ```pkl
 // backend/hk.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   ["cargo-fmt"] = Builtins.cargo_fmt

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -7,8 +7,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,6 +1,6 @@
-amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
 amends "pkl/Config.pkl"
 
 import "pkl/Builtins.pkl"

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name hk
 bin hk
-version "1.56.1"
+version "1.57.0"
 unknown_flags error
 subcommand_required #true
 flagset hook-options {


### PR DESCRIPTION
### 🚀 Features

- **(builtins)** add go_fix linter by [@sahidvelji](https://github.com/sahidvelji) in [#1224](https://github.com/jdx/hk/pull/1224)
- **(builtins)** add ls_lint linter by [@sahidvelji](https://github.com/sahidvelji) in [#1238](https://github.com/jdx/hk/pull/1238)
- **(builtins)** add golangci_lint_fmt formatter by [@sahidvelji](https://github.com/sahidvelji) in [#1244](https://github.com/jdx/hk/pull/1244)
- **(builtins)** add shellcheck fix via check_diff by [@sahidvelji](https://github.com/sahidvelji) in [#1237](https://github.com/jdx/hk/pull/1237)
- **(pkl)** embed the matching-version pkl package by [@sahidvelji](https://github.com/sahidvelji) in [#1218](https://github.com/jdx/hk/pull/1218)
- **(step)** render `dir` through tera by [@sahidvelji](https://github.com/sahidvelji) in [#1219](https://github.com/jdx/hk/pull/1219)
- **(step)** recheck applied diffs by [@jdx](https://github.com/jdx) in [#1243](https://github.com/jdx/hk/pull/1243)
- **(step)** allow configured command failures by [@jdx](https://github.com/jdx) in [#1291](https://github.com/jdx/hk/pull/1291)

### 🐛 Bug Fixes

- **(builtins)** repair Go linters that report success on bad code by [@sahidvelji](https://github.com/sahidvelji) in [#1225](https://github.com/jdx/hk/pull/1225)
- **(builtins)** broaden gomod_tidy glob to run tidy on .go changes by [@sahidvelji](https://github.com/sahidvelji) in [#1236](https://github.com/jdx/hk/pull/1236)
- **(builtins)** stage gomod_tidy manifest updates by [@jdx](https://github.com/jdx) in [#1240](https://github.com/jdx/hk/pull/1240)
- **(builtins)** recheck partial diff fixes by [@jdx](https://github.com/jdx) in [#1245](https://github.com/jdx/hk/pull/1245)
- **(builtins)** correct gitleaks scan modes by [@jdx](https://github.com/jdx) in [#1248](https://github.com/jdx/hk/pull/1248)
- **(stash)** skip empty pathspec stashes by [@jdx](https://github.com/jdx) in [#1283](https://github.com/jdx/hk/pull/1283)
- **(step)** resolve Windows command shims by [@jdx](https://github.com/jdx) in [#1221](https://github.com/jdx/hk/pull/1221)
- **(step)** relativize workspace paths to step directory by [@jdx](https://github.com/jdx) in [#1242](https://github.com/jdx/hk/pull/1242)

### 📚 Documentation

- clarify subproject monorepo setup by [@jdx](https://github.com/jdx) in [#1239](https://github.com/jdx/hk/pull/1239)
- improve onboarding and navigation by [@jdx](https://github.com/jdx) in [#1247](https://github.com/jdx/hk/pull/1247)
- disable code ligatures by [@jdx](https://github.com/jdx) in [#1264](https://github.com/jdx/hk/pull/1264)
- publish llms.txt index by [@jdx](https://github.com/jdx) in [#1272](https://github.com/jdx/hk/pull/1272)

### 🛡️ Security

- add sponsor logos to readme by [@jdx](https://github.com/jdx) in [#1250](https://github.com/jdx/hk/pull/1250)

### 🔍 Other Changes

- **(ci)** adopt mbx for Rust builds by [@jdx](https://github.com/jdx) in [#1229](https://github.com/jdx/hk/pull/1229)
- **(ci)** restrict trusted mbx runs to jdx by [@jdx](https://github.com/jdx) in [#1254](https://github.com/jdx/hk/pull/1254)
- **(ci)** isolate mbx OIDC permissions by [@jdx](https://github.com/jdx) in [#1258](https://github.com/jdx/hk/pull/1258)
- **(ci)** compare mbx with rust-cache by [@jdx](https://github.com/jdx) in [#1267](https://github.com/jdx/hk/pull/1267)
- **(ci)** adopt mbx 0.5.4 by [@jdx](https://github.com/jdx) in [#1279](https://github.com/jdx/hk/pull/1279)
- **(ci)** pin mr-boxington-action v1.0.1 by [@jdx](https://github.com/jdx) in [#1280](https://github.com/jdx/hk/pull/1280)
- **(ci)** use default Rust for cache benchmark by [@jdx](https://github.com/jdx) in [#1284](https://github.com/jdx/hk/pull/1284)
- **(ci)** bump mr-boxington action by [@jdx](https://github.com/jdx) in [#1282](https://github.com/jdx/hk/pull/1282)
- **(ci)** use server cache for dispatched benchmarks by [@jdx](https://github.com/jdx) in [#1285](https://github.com/jdx/hk/pull/1285)
- **(ci)** adopt mbx 0.7.0 by [@jdx](https://github.com/jdx) in [#1286](https://github.com/jdx/hk/pull/1286)
- **(sponsors)** replace 37signals with omacom foundation by [@jdx](https://github.com/jdx) in [#1249](https://github.com/jdx/hk/pull/1249)
- generate release notes before publishing by [@jdx](https://github.com/jdx) in [#1227](https://github.com/jdx/hk/pull/1227)
- automate generated cli versions by [@jdx](https://github.com/jdx) in [#1252](https://github.com/jdx/hk/pull/1252)
- seed mbx cache for fork PRs by [@jdx](https://github.com/jdx) in [#1262](https://github.com/jdx/hk/pull/1262)
- notarize the macOS release binary by [@jdx](https://github.com/jdx) in [#1266](https://github.com/jdx/hk/pull/1266)
- benchmark mbx against rust-cache on Linux by [@jdx](https://github.com/jdx) in [#1275](https://github.com/jdx/hk/pull/1275)
- remove pinned rust toolchain by [@jdx](https://github.com/jdx) in [#1235](https://github.com/jdx/hk/pull/1235)
- back mbx with the GitHub Actions cache alone by [@jdx](https://github.com/jdx) in [#1287](https://github.com/jdx/hk/pull/1287)

### 📦️ Dependency Updates

- update rust crate pklr to v1.5.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1222](https://github.com/jdx/hk/pull/1222)
- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#1226](https://github.com/jdx/hk/pull/1226)
- bump usage to 6.4.0 by [@jdx](https://github.com/jdx) in [#1228](https://github.com/jdx/hk/pull/1228)
- update anthropics/claude-code-action action to v1.0.194 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1230](https://github.com/jdx/hk/pull/1230)
- update jdx/mise-action action to v4.2.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1231](https://github.com/jdx/hk/pull/1231)
- update rust crate demand to v2.1.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1241](https://github.com/jdx/hk/pull/1241)
- update anthropics/claude-code-action action to v1.0.195 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1251](https://github.com/jdx/hk/pull/1251)
- update rust crate pklr to v1.5.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1260](https://github.com/jdx/hk/pull/1260)
- bump usage to 6.4.1 by [@jdx](https://github.com/jdx) in [#1273](https://github.com/jdx/hk/pull/1273)
- bump tak and mbx by [@jdx](https://github.com/jdx) in [#1274](https://github.com/jdx/hk/pull/1274)
- remove rust toolchain pins by [@jdx](https://github.com/jdx) in [#1276](https://github.com/jdx/hk/pull/1276)

### New Contributors

- @sahidvelji made their first contribution in [#1237](https://github.com/jdx/hk/pull/1237)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and documentation URL updates with no runtime code changes in the diff.
> 
> **Overview**
> **Cuts release v1.57.0** by bumping the `hk` crate and CLI metadata from **1.56.1** to **1.57.0** (`Cargo.toml`, `Cargo.lock`, `hk.usage.kdl`, generated CLI docs).
> 
> Adds the **[1.57.0] CHANGELOG** entry (features, fixes, CI/release work, and dependency updates since 1.56.1) and updates every **Pkl `amends` / `import` package URL** in README, docs, examples, and `hk-example.pkl` to point at the new GitHub release artifacts.
> 
> No application logic changes in this diff; it packages already-merged work. Notable themes called out in the new changelog include new builtins (`go_fix`, `ls_lint`, `golangci_lint_fmt`, shellcheck fix), step-engine improvements (Tera `dir`, diff recheck, optional command failures), embedded matching-version Pkl, and assorted builtin/stash/Windows path fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57fec76991536518263b8db7671840d2ad93c127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->