### PR TITLE
feat(builtins): add go_fix linter

### DIFF
--- a/pkl/builtins/go_fix.pkl
+++ b/pkl/builtins/go_fix.pkl
@@ -1,0 +1,35 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+import "./test/helpers.pkl"
+
+@Builtins.meta {
+  category = "Go"
+  description = "Go modernizer (requires Go 1.26+)"
+}
+go_fix = new Config.Step {
+  glob = "**/*.go"
+  workspace_indicator = "go.mod"
+  dir = "{{workspace}}"
+  check_diff = new Config.CommandSpec {
+    command = "go fix -diff ./..."
+    effect = "write"
+  }
+  fix = new Config.CommandSpec {
+    command = "go fix ./..."
+    effect = "write"
+  }
+  tests {
+    local const testMaker = new helpers.TestMaker {
+      filename = "main.go"
+      extra_files = new Mapping<String, String> {
+        ["go.mod"] = "module example.com/test\n\ngo 1.21\n"
+      }
+    }
+    local const before = "package main\n\nvar x interface{}\n\nfunc main() { _ = x }\n"
+    local const after = "package main\n\nvar x any\n\nfunc main() { _ = x }\n"
+    ["check bad file"] = testMaker.checkFail(before, 1)
+    ["check good file"] = testMaker.checkPass(after)
+    ["fix bad file"] = testMaker.fixPass(before, after)
+    ["fix good file"] = testMaker.fixPass(after, after)
+  }
+}

--- a/src/step/check_parsing.rs
+++ b/src/step/check_parsing.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use xx::file::display_path;
 
-use super::strip_orig_suffix;
+use super::normalize_diff_paths;
 use super::types::Step;
 
 /// Attempt to canonicalize a path, falling back to the original if it fails.
@@ -90,7 +90,7 @@ impl Step {
         original_files: &[PathBuf],
         stdout: &str,
     ) -> (Vec<PathBuf>, Vec<PathBuf>) {
-        let stdout = strip_orig_suffix(stdout);
+        let stdout = normalize_diff_paths(stdout);
 
         // Parse unified diff format to extract file names from --- and +++ lines
         let mut listed: HashSet<PathBuf> = HashSet::new();

--- a/src/step/diff.rs
+++ b/src/step/diff.rs
@@ -6,9 +6,40 @@
 
 use crate::Result;
 use std::io::Write;
+use std::path::{Path, PathBuf};
 
-use super::strip_orig_suffix;
+use super::normalize_diff_paths;
 use super::types::Step;
+
+/// Rewrite absolute paths in diff headers to be relative to `base`.
+///
+/// `git apply` rejects absolute paths outright -- `--unsafe-paths` does not
+/// change that, and `-p<n>` would need a strip depth that varies per checkout --
+/// so a tool reporting absolute paths cannot be applied without this. `go fix
+/// -diff` is one such tool.
+///
+/// Paths outside `base` are left as they are; `git apply` will reject them and
+/// the caller falls back to running the fixer.
+fn relativize_diff_paths(diff: &str, base: &Path) -> String {
+    let mut out: Vec<String> = Vec::new();
+    for line in diff.lines() {
+        let rewritten = ["--- ", "+++ "].into_iter().find_map(|prefix| {
+            let rest = line.strip_prefix(prefix)?;
+            // Keep any tab-separated timestamp attached to the path.
+            let (path, tail) = match rest.split_once('\t') {
+                Some((p, t)) => (p, Some(t)),
+                None => (rest, None),
+            };
+            let rel = Path::new(path).strip_prefix(base).ok()?.to_str()?;
+            Some(match tail {
+                Some(t) => format!("{prefix}{rel}\t{t}"),
+                None => format!("{prefix}{rel}"),
+            })
+        });
+        out.push(rewritten.unwrap_or_else(|| line.to_string()));
+    }
+    out.join("\n") + "\n"
+}
 
 impl Step {
     /// Apply a unified diff directly to files using `git apply`.
@@ -38,7 +69,13 @@ impl Step {
             debug!("{}: no diff content to apply", self.name);
             return Ok(false);
         }
-        let diff_content = strip_orig_suffix(stdout);
+        let diff_content = normalize_diff_paths(stdout);
+
+        // Resolve against wherever `git apply` will run, so absolute paths
+        // reported by the check command become paths git will accept.
+        let base = PathBuf::from(dir.unwrap_or("."));
+        let base = base.canonicalize().unwrap_or(base);
+        let diff_content = relativize_diff_paths(&diff_content, &base);
 
         // Detect if this diff uses a/ and b/ prefixes (git-style)
         // Use -p1 to strip prefixes if present, -p0 otherwise
@@ -106,5 +143,50 @@ impl Step {
             debug!("{}: git apply failed: {}", self.name, stderr_output);
             Ok(false)
         }
+    }
+}
+
+#[cfg(test)]
+mod relativize_diff_paths_tests {
+    use super::relativize_diff_paths;
+    use std::path::Path;
+
+    #[test]
+    fn rewrites_absolute_paths_under_base() {
+        let diff = "--- /w/svc/main.go\n+++ /w/svc/main.go\n@@ -1 +1 @@\n-a\n+b\n";
+        assert_eq!(
+            relativize_diff_paths(diff, Path::new("/w/svc")),
+            "--- main.go\n+++ main.go\n@@ -1 +1 @@\n-a\n+b\n"
+        );
+    }
+
+    #[test]
+    fn leaves_paths_outside_base_alone() {
+        let diff = "--- /elsewhere/main.go\n+++ /elsewhere/main.go\n";
+        assert_eq!(relativize_diff_paths(diff, Path::new("/w/svc")), diff);
+    }
+
+    #[test]
+    fn leaves_relative_paths_alone() {
+        let diff = "--- main.go\n+++ main.go\n";
+        assert_eq!(relativize_diff_paths(diff, Path::new("/w/svc")), diff);
+    }
+
+    #[test]
+    fn preserves_a_tab_separated_timestamp() {
+        let diff = "--- /w/svc/main.go\t2025-01-01 12:00:00\n+++ /w/svc/main.go\n";
+        assert_eq!(
+            relativize_diff_paths(diff, Path::new("/w/svc")),
+            "--- main.go\t2025-01-01 12:00:00\n+++ main.go\n"
+        );
+    }
+
+    #[test]
+    fn does_not_touch_diff_body_lines() {
+        let diff = "--- /w/svc/a.go\n+++ /w/svc/a.go\n@@ -1 +1 @@\n---- not a header\n";
+        assert_eq!(
+            relativize_diff_paths(diff, Path::new("/w/svc")),
+            "--- a.go\n+++ a.go\n@@ -1 +1 @@\n---- not a header\n"
+        );
     }
 }

--- a/src/step/mod.rs
+++ b/src/step/mod.rs
@@ -63,29 +63,85 @@ pub use types::{
 #[allow(unused_imports)]
 pub use filtering::{is_binary_file, is_symlink_file};
 
-/// Strip ".orig" suffix from "---" lines when the next "+++" line doesn't have it.
-/// Go tools like gofmt add ".orig" only to the "---" line.
-pub(crate) fn strip_orig_suffix(diff: &str) -> String {
+/// Normalize tool-specific quirks in unified diff headers so a diff can be
+/// attributed to files and handed to `git apply`.
+///
+/// Two Go toolchain conventions need this:
+/// - gofmt writes `--- file.go.orig` against a plain `+++ file.go`.
+/// - `go fix -diff` labels both sides: `--- file.go (old)` / `+++ file.go (new)`.
+///
+/// The `(old)`/`(new)` form is only rewritten when both sides carry their label,
+/// so a file genuinely named `foo (old)` is left alone.
+pub(crate) fn normalize_diff_paths(diff: &str) -> String {
     let mut result: Vec<String> = Vec::new();
     let mut lines = diff.lines().peekable();
     while let Some(line) = lines.next() {
         if let Some(after_prefix) = line.strip_prefix("--- ")
             && let Some(next) = lines.peek()
             && next.starts_with("+++ ")
-            && !next.contains(".orig")
         {
-            // Extract path portion (before any tab-separated timestamp)
-            let (path, rest) = after_prefix.split_once('\t').unwrap_or((after_prefix, ""));
-            if let Some(stripped) = path.strip_suffix(".orig") {
-                if rest.is_empty() {
-                    result.push(format!("--- {stripped}"));
-                } else {
-                    result.push(format!("--- {stripped}\t{rest}"));
-                }
+            // `go fix -diff`: both sides labelled.
+            if let Some(old_path) = after_prefix.strip_suffix(" (old)")
+                && let Some(new_path) = next
+                    .strip_prefix("+++ ")
+                    .and_then(|p| p.strip_suffix(" (new)"))
+            {
+                result.push(format!("--- {old_path}"));
+                result.push(format!("+++ {new_path}"));
+                lines.next();
                 continue;
+            }
+            // gofmt: ".orig" on the "---" line only.
+            if !next.contains(".orig") {
+                // Extract path portion (before any tab-separated timestamp)
+                let (path, rest) = after_prefix.split_once('\t').unwrap_or((after_prefix, ""));
+                if let Some(stripped) = path.strip_suffix(".orig") {
+                    if rest.is_empty() {
+                        result.push(format!("--- {stripped}"));
+                    } else {
+                        result.push(format!("--- {stripped}\t{rest}"));
+                    }
+                    continue;
+                }
             }
         }
         result.push(line.to_string());
     }
     result.join("\n") + "\n"
+}
+
+#[cfg(test)]
+mod normalize_diff_paths_tests {
+    use super::normalize_diff_paths;
+
+    #[test]
+    fn strips_go_fix_old_new_labels() {
+        let diff = "--- /w/main.go (old)\n+++ /w/main.go (new)\n@@ -1 +1 @@\n-a\n+b\n";
+        assert_eq!(
+            normalize_diff_paths(diff),
+            "--- /w/main.go\n+++ /w/main.go\n@@ -1 +1 @@\n-a\n+b\n"
+        );
+    }
+
+    #[test]
+    fn strips_gofmt_orig_suffix() {
+        let diff = "--- main.go.orig\n+++ main.go\n@@ -1 +1 @@\n-a\n+b\n";
+        assert_eq!(
+            normalize_diff_paths(diff),
+            "--- main.go\n+++ main.go\n@@ -1 +1 @@\n-a\n+b\n"
+        );
+    }
+
+    #[test]
+    fn leaves_plain_headers_alone() {
+        let diff = "--- a/main.go\n+++ b/main.go\n@@ -1 +1 @@\n-a\n+b\n";
+        assert_eq!(normalize_diff_paths(diff), diff);
+    }
+
+    #[test]
+    fn keeps_a_file_actually_named_old_when_the_pair_is_unlabelled() {
+        // Only the "---" side carries "(old)", so this is a real filename.
+        let diff = "--- notes (old)\n+++ notes (old)\n@@ -1 +1 @@\n-a\n+b\n";
+        assert_eq!(normalize_diff_paths(diff), diff);
+    }
 }

--- a/test/builtin_tool_stubs/go
+++ b/test/builtin_tool_stubs/go
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S mise tool-stub
 
-version = "1.25"
+version = "1.27"
 tool = "go"
 bin = "go"


### PR DESCRIPTION
Adds a `go_fix` builtin wrapping Go's `go fix` command.

Since Go 1.26, `go fix` is an analyzer-driven modernizer rather than the old pre-Go1 API rewriter. It applies the fixes suggested by `cmd/fix`'s analyzers — `interface{}` → `any`, `sort.Slice` → `slices.Sort`, explicit loops → `maps`/`slices` helpers, `wg.Add(1)`/`go`/`wg.Done()` → `wg.Go`, and ~25 others that `go tool fix help` lists.

## Behavior

`check_diff` runs `go fix -diff ./...`, which prints a patch and exits non-zero when it is non-empty, so hk applies the patch directly instead of re-running the fixer. `fix` runs `go fix ./...`. Both resolve the module root through the `go.mod` workspace indicator and run there via `dir`, matching `go_vet` and `golangci_lint`. `effect = "write"` matches those steps too — the Go build cache is written on both paths.

## Why the `check_diff` fix comes first

`go fix -diff` cannot be consumed by hk as-is, which the second commit addresses.

It labels both sides of the header — `--- file.go (old)` / `+++ file.go (new)` — where `strip_orig_suffix` only knew gofmt's `--- file.go.orig` convention. It also reports **absolute** paths, and `git apply` rejects those outright; `--unsafe-paths` does not change that, and `-p<n>` would need a strip depth that varies per checkout.

Without that commit the diff parses to no files and the apply fails, so hk falls back to re-running the fixer — correct results, but with `failed to canonicalize` warnings and the diff machinery doing nothing. Neither form was usable before, so nothing that works today can regress.

## Go version

`go fix -diff` requires **Go 1.26+**. On Go 1.25 `go fix` is the legacy rewriter and rejects `-diff`, so `check` fails outright rather than silently doing nothing. The requirement is noted in the builtin's description, which surfaces in the generated builtins reference.

That is also why the first commit moves `test/builtin_tool_stubs/go` from 1.25 to 1.27. `go_vet` is the only other builtin with tests that uses that stub, and its tests pass on 1.27.

## Testing

Nine unit tests over the two diff helpers, covering both label conventions, a file genuinely named `notes (old)`, absolute paths inside and outside the base, relative paths, and tab-separated timestamps. Four pkl-level tests for the builtin via `TestMaker`. Verified against real modules with the module at the repo root and in a subdirectory, in both check and fix modes. Full `cargo test` passes, and clippy reports the same 21 pre-existing warnings before and after, none in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diff path handling so files under the working directory are displayed with relative paths.
  - Correctly normalizes paths from formatting and automatic-fix tools, including `.orig` suffixes and labeled headers.
  - Preserves timestamps, diff content, and unrelated paths during normalization.
  - Updated the Go tool stub to version 1.27.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->