### PR TITLE
fix(builtins): repair Go linters that report success on bad code

### DIFF
--- a/pkl/builtins/go_fumpt.pkl
+++ b/pkl/builtins/go_fumpt.pkl
@@ -8,7 +8,7 @@ import "./test/helpers.pkl"
 }
 go_fumpt = new Config.Step {
   glob = "**/*.go"
-  // NB: `gofumpt -l` exits 0 even when it lists files, so the exit code has to
+  // `gofumpt -l` exits 0 even when it lists files, so the exit code has to
   // come from the shell. `gofumpt -d` already exits non-zero on a non-empty
   // diff and needs no wrapper.
   check_list_files = new Config.CommandSpec {

--- a/pkl/builtins/go_fumpt.pkl
+++ b/pkl/builtins/go_fumpt.pkl
@@ -1,5 +1,6 @@
 import "../Builtins.pkl"
 import "../Config.pkl"
+import "./test/helpers.pkl"
 
 @Builtins.meta {
   category = "Go"
@@ -7,11 +8,36 @@ import "../Config.pkl"
 }
 go_fumpt = new Config.Step {
   glob = "**/*.go"
-  // check = "gofumpt -l {{ files }}" // broken, gofumpt always exits with 0
-  // check_list_files = "gofumpt -l {{ files }}" // broken, gofumpt always exits with 0
-  // check_diff = "gofumpt -d {{ files }}" // won't work until #640 is merged
+  // NB: `gofumpt -l` exits 0 even when it lists files, so the exit code has to
+  // come from the shell. `gofumpt -d` already exits non-zero on a non-empty
+  // diff and needs no wrapper.
+  check_list_files = new Config.CommandSpec {
+    command =
+      """
+      FILES=$(gofumpt -l {{files}})
+      if [ -n "$FILES" ]; then
+      echo "$FILES"
+      exit 1
+      fi
+      """
+    effect = "read"
+  }
+  check_diff = new Config.CommandSpec {
+    command = new Config.Command { argv = List("gofumpt", "-d", "{{files}}") }
+    effect = "read"
+  }
   fix = new Config.CommandSpec {
     command = new Config.Command { argv = List("gofumpt", "-w", "{{files}}") }
     effect = "write"
+  }
+  tests {
+    local const testMaker = new helpers.TestMaker { filename = "test.go" }
+    // gofumpt collapses the redundant newline that gofmt leaves alone.
+    local const before = "package name\n\nfunc a() {\n\n\tprintln(1)\n}\n"
+    local const after = "package name\n\nfunc a() {\n\tprintln(1)\n}\n"
+    ["check bad file"] = testMaker.checkFail(before, 1)
+    ["check good file"] = testMaker.checkPass(after)
+    ["fix bad file"] = testMaker.fixPass(before, after)
+    ["fix good file"] = testMaker.fixPass(after, after)
   }
 }

--- a/pkl/builtins/go_imports.pkl
+++ b/pkl/builtins/go_imports.pkl
@@ -1,5 +1,6 @@
 import "../Builtins.pkl"
 import "../Config.pkl"
+import "./test/helpers.pkl"
 
 @Builtins.meta {
   category = "Go"
@@ -7,12 +8,44 @@ import "../Config.pkl"
 }
 go_imports = new Config.Step {
   glob = "**/*.go"
-  check = new Config.CommandSpec {
-    command = new Config.Command { argv = List("goimports", "-l", "{{files}}") }
+  // NB: `goimports` exits 0 for both `-l` and `-d` even when it reports work to
+  // do, so the exit code has to come from the shell.
+  check_list_files = new Config.CommandSpec {
+    command =
+      """
+      FILES=$(goimports -l {{files}})
+      if [ -n "$FILES" ]; then
+      echo "$FILES"
+      exit 1
+      fi
+      """
+    effect = "read"
+  }
+  check_diff = new Config.CommandSpec {
+    command =
+      """
+      DIFF=$(goimports -d {{files}})
+      if [ -n "$DIFF" ]; then
+      echo "$DIFF"
+      exit 1
+      fi
+      """
     effect = "read"
   }
   fix = new Config.CommandSpec {
     command = new Config.Command { argv = List("goimports", "-w", "{{files}}") }
     effect = "write"
+  }
+  tests {
+    local const testMaker = new helpers.TestMaker { filename = "test.go" }
+    // The unused "os" import is dropped by goimports but left alone by gofmt.
+    local const before =
+      "package name\n\nimport (\n\t\"fmt\"\n\t\"os\"\n)\n\nfunc a() { fmt.Println(\"x\") }\n"
+    local const after =
+      "package name\n\nimport (\n\t\"fmt\"\n)\n\nfunc a() { fmt.Println(\"x\") }\n"
+    ["check bad file"] = testMaker.checkFail(before, 1)
+    ["check good file"] = testMaker.checkPass(after)
+    ["fix bad file"] = testMaker.fixPass(before, after)
+    ["fix good file"] = testMaker.fixPass(after, after)
   }
 }

--- a/pkl/builtins/go_imports.pkl
+++ b/pkl/builtins/go_imports.pkl
@@ -8,7 +8,7 @@ import "./test/helpers.pkl"
 }
 go_imports = new Config.Step {
   glob = "**/*.go"
-  // NB: `goimports` exits 0 for both `-l` and `-d` even when it reports work to
+  // `goimports` exits 0 for both `-l` and `-d` even when it reports work to
   // do, so the exit code has to come from the shell.
   check_list_files = new Config.CommandSpec {
     command =

--- a/pkl/builtins/go_lines.pkl
+++ b/pkl/builtins/go_lines.pkl
@@ -1,5 +1,6 @@
 import "../Builtins.pkl"
 import "../Config.pkl"
+import "./test/helpers.pkl"
 
 @Builtins.meta {
   category = "Go"
@@ -7,12 +8,36 @@ import "../Config.pkl"
 }
 go_lines = new Config.Step {
   glob = "**/*.go"
-  check = new Config.CommandSpec {
-    command = new Config.Command { argv = List("golines", "--dry-run", "{{files}}") }
+  // NB: `golines -l` exits 0 even when it lists files, so the exit code has to
+  // come from the shell. `--dry-run` is deliberately not used as a `check_diff`:
+  // it omits blank lines while still counting them in the hunk header, so the
+  // patch it prints is not applicable.
+  check_list_files = new Config.CommandSpec {
+    command =
+      """
+      FILES=$(golines -l {{files}})
+      if [ -n "$FILES" ]; then
+      echo "$FILES"
+      exit 1
+      fi
+      """
     effect = "read"
   }
   fix = new Config.CommandSpec {
     command = new Config.Command { argv = List("golines", "-w", "{{files}}") }
     effect = "write"
+  }
+  tests {
+    local const testMaker = new helpers.TestMaker { filename = "test.go" }
+    // NB: escapes are written literally inside `"""` blocks here, so these
+    // fixtures use single-line strings to get real tabs.
+    local const before =
+      "package name\n\nfunc a(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa int, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb int, cccccccccccccccccccccccccccccc int) int {\n\treturn aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n}\n"
+    local const after =
+      "package name\n\nfunc a(\n\taaaaaaaaaaaaaaaaaaaaaaaaaaaaaa int,\n\tbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb int,\n\tcccccccccccccccccccccccccccccc int,\n) int {\n\treturn aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n}\n"
+    ["check bad file"] = testMaker.checkFail(before, 1)
+    ["check good file"] = testMaker.checkPass(after)
+    ["fix bad file"] = testMaker.fixPass(before, after)
+    ["fix good file"] = testMaker.fixPass(after, after)
   }
 }

--- a/pkl/builtins/go_lines.pkl
+++ b/pkl/builtins/go_lines.pkl
@@ -8,7 +8,7 @@ import "./test/helpers.pkl"
 }
 go_lines = new Config.Step {
   glob = "**/*.go"
-  // NB: `golines -l` exits 0 even when it lists files, so the exit code has to
+  // `golines -l` exits 0 even when it lists files, so the exit code has to
   // come from the shell. `--dry-run` is deliberately not used as a `check_diff`:
   // it omits blank lines while still counting them in the hunk header, so the
   // patch it prints is not applicable.
@@ -29,7 +29,7 @@ go_lines = new Config.Step {
   }
   tests {
     local const testMaker = new helpers.TestMaker { filename = "test.go" }
-    // NB: escapes are written literally inside `"""` blocks here, so these
+    // Escapes are written literally inside `"""` blocks here, so these
     // fixtures use single-line strings to get real tabs.
     local const before =
       "package name\n\nfunc a(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa int, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb int, cccccccccccccccccccccccccccccc int) int {\n\treturn aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n}\n"

--- a/pkl/builtins/gomod_tidy.pkl
+++ b/pkl/builtins/gomod_tidy.pkl
@@ -18,7 +18,7 @@ gomod_tidy = new Config.Step {
   dir = "{{workspace}}"
   check_diff = new Config.CommandSpec {
     command = "go mod tidy -diff"
-    effect = "read"
+    effect = "write"
   }
   fix = new Config.CommandSpec {
     command = "go mod tidy"

--- a/pkl/builtins/gomod_tidy.pkl
+++ b/pkl/builtins/gomod_tidy.pkl
@@ -4,9 +4,18 @@ import "../Config.pkl"
 @Builtins.meta {
   category = "Go"
   description = "Go module maintenance"
+  project_indicators {
+    new { file = "go.mod" }
+  }
 }
 gomod_tidy = new Config.Step {
   glob = "**/go.mod"
+  // NB: `go mod tidy` resolves the module rooted at the working directory, so
+  // it has to run in the directory holding the go.mod rather than the repo
+  // root. Without this it fails outright on any module outside the root and
+  // never reaches nested modules.
+  workspace_indicator = "go.mod"
+  dir = "{{workspace}}"
   check_diff = new Config.CommandSpec {
     command = "go mod tidy -diff"
     effect = "read"
@@ -14,5 +23,40 @@ gomod_tidy = new Config.Step {
   fix = new Config.CommandSpec {
     command = "go mod tidy"
     effect = "write"
+  }
+  tests {
+    ["check tidy module"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["go.mod"] = "module example.com/test\n\ngo 1.21\n"
+        ["main.go"] = "package main\n\nfunc main() {}\n"
+      }
+      expect { code = 0 }
+    }
+    ["check untidy module"] {
+      run = "check"
+      tmpdir = true
+      write {
+        // Nothing imports this module, so tidy drops the require.
+        ["go.mod"] = "module example.com/test\n\ngo 1.21\n\nrequire example.com/unused v1.0.0\n"
+        ["main.go"] = "package main\n\nfunc main() {}\n"
+      }
+      expect { code = 1 }
+    }
+    ["fix untidy module"] {
+      run = "fix"
+      tmpdir = true
+      write {
+        ["go.mod"] = "module example.com/test\n\ngo 1.21\n\nrequire example.com/unused v1.0.0\n"
+        ["main.go"] = "package main\n\nfunc main() {}\n"
+      }
+      expect {
+        code = 0
+        files {
+          ["go.mod"] = "module example.com/test\n\ngo 1.21\n"
+        }
+      }
+    }
   }
 }

--- a/pkl/builtins/gomod_tidy.pkl
+++ b/pkl/builtins/gomod_tidy.pkl
@@ -10,7 +10,7 @@ import "../Config.pkl"
 }
 gomod_tidy = new Config.Step {
   glob = "**/go.mod"
-  // NB: `go mod tidy` resolves the module rooted at the working directory, so
+  // `go mod tidy` resolves the module rooted at the working directory, so
   // it has to run in the directory holding the go.mod rather than the repo
   // root. Without this it fails outright on any module outside the root and
   // never reaches nested modules.

--- a/pkl/builtins/revive.pkl
+++ b/pkl/builtins/revive.pkl
@@ -9,7 +9,7 @@ revive = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
   dir = "{{workspace}}"
-  // NB: revive exits 0 even when it reports findings unless -set_exit_status is
+  // revive exits 0 even when it reports findings unless -set_exit_status is
   // passed.
   check = new Config.CommandSpec {
     command = "revive -set_exit_status ./..."

--- a/pkl/builtins/revive.pkl
+++ b/pkl/builtins/revive.pkl
@@ -13,7 +13,7 @@ revive = new Config.Step {
   // passed.
   check = new Config.CommandSpec {
     command = "revive -set_exit_status ./..."
-    effect = "read"
+    effect = "write"
   }
   tests {
     ["check good file"] {

--- a/pkl/builtins/revive.pkl
+++ b/pkl/builtins/revive.pkl
@@ -9,8 +9,52 @@ revive = new Config.Step {
   glob = "**/*.go"
   workspace_indicator = "go.mod"
   dir = "{{workspace}}"
+  // NB: revive exits 0 even when it reports findings unless -set_exit_status is
+  // passed.
   check = new Config.CommandSpec {
-    command = "revive ./..."
+    command = "revive -set_exit_status ./..."
     effect = "read"
+  }
+  tests {
+    ["check good file"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["go.mod"] =
+          """
+            module example.com/test
+
+            go 1.21
+          """
+        ["main.go"] =
+          """
+            // Package main is a test package.
+            package main
+
+            func main() {}
+          """
+      }
+      expect { code = 0 }
+    }
+    ["check bad file"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["go.mod"] =
+          """
+            module example.com/test
+
+            go 1.21
+          """
+        // Missing the package comment revive requires.
+        ["main.go"] =
+          """
+            package main
+
+            func main() {}
+          """
+      }
+      expect { code = 1 }
+    }
   }
 }

--- a/test/builtin_tool_stubs/gofumpt
+++ b/test/builtin_tool_stubs/gofumpt
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "0.11"
+tool = "aqua:mvdan/gofumpt"

--- a/test/builtin_tool_stubs/goimports
+++ b/test/builtin_tool_stubs/goimports
@@ -1,0 +1,5 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "0.49"
+tool = "go:golang.org/x/tools/cmd/goimports"
+bin = "goimports"

--- a/test/builtin_tool_stubs/golines
+++ b/test/builtin_tool_stubs/golines
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "0.13"
+tool = "aqua:segmentio/golines"

--- a/test/gomod_tidy_nested_module.bats
+++ b/test/gomod_tidy_nested_module.bats
@@ -38,14 +38,20 @@ PKL
 
     PATH="$PROJECT_ROOT/test/builtin_tool_stubs:$PATH"
 
-    # check must report the untidy module rather than failing to find it
+    # check must report the untidy module rather than failing to find it.
+    # `go mod tidy -diff` labels its output current/go.mod and tidy/go.mod, so
+    # the module path is what proves the diff came from svc/ and not the root.
     run hk check --all --step gomod_tidy
     assert_failure
     refute_output --partial "go.mod file not found"
+    assert_output --partial "module example.com/svc"
+    assert_output --partial "-require example.com/unused v1.0.0"
 
     run hk fix --all --step gomod_tidy
     assert_success
 
     run cat svc/go.mod
+    assert_success
+    assert_output --partial "module example.com/svc"
     refute_output --partial "example.com/unused"
 }

--- a/test/gomod_tidy_nested_module.bats
+++ b/test/gomod_tidy_nested_module.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+teardown() {
+    _common_teardown
+}
+
+# gomod_tidy runs `go mod tidy`, which resolves the module rooted at the working
+# directory. Without workspace_indicator/dir it ran at the repo root and failed
+# outright for any module living in a subdirectory.
+@test "gomod_tidy tidies a module in a subdirectory" {
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl" as Builtins
+hooks {
+  ["check"] {
+    steps {
+      ["gomod_tidy"] = Builtins.gomod_tidy
+    }
+  }
+  ["fix"] {
+    steps {
+      ["gomod_tidy"] = Builtins.gomod_tidy
+    }
+  }
+}
+PKL
+
+    mkdir -p svc
+    printf 'module example.com/svc\n\ngo 1.21\n\nrequire example.com/unused v1.0.0\n' > svc/go.mod
+    printf 'package main\n\nfunc main() {}\n' > svc/main.go
+
+    git add -A
+    git commit -m "init" --quiet
+
+    PATH="$PROJECT_ROOT/test/builtin_tool_stubs:$PATH"
+
+    # check must report the untidy module rather than failing to find it
+    run hk check --all --step gomod_tidy
+    assert_failure
+    refute_output --partial "go.mod file not found"
+
+    run hk fix --all --step gomod_tidy
+    assert_success
+
+    run cat svc/go.mod
+    refute_output --partial "example.com/unused"
+}


### PR DESCRIPTION
Audit of every Go builtin against the real tools. Four of them reported success on code they should have flagged, and one could not run at all outside the repo root.

## Linters that passed silently

`check` reported success even with real findings, so these were no-ops in check mode (`hk check`, `HK_FIX=0`, pre-commit in check mode). `fix` was unaffected.

| Builtin | Why it passed |
|---|---|
| `go_imports` | `goimports` exits 0 for both `-l` and `-d` |
| `go_lines` | `golines -l` exits 0 even when it lists files |
| `revive` | exits 0 unless `-set_exit_status` is passed |
| `go_fumpt` | check commands were commented out entirely |

The first three now take their exit code from a shell wrapper, the same pattern `go_fmt` already uses — hk requires `check_list_files` to exit non-zero and warns when it does not.

`go_fumpt`'s `check_diff` was commented out as blocked on parsing Go-style `.orig` diff headers. That landed in #704, so it works now: hk applies the `gofumpt -d` output directly and never runs `gofumpt -w`.

`go_lines` gets `check_list_files` only. Its `--dry-run` output omits blank lines while still counting them in the hunk header, so `git apply` rejects the patch — it is not usable as a `check_diff`.

## gomod_tidy could not run outside the repo root

`go mod tidy` resolves the module rooted at the working directory, but the step set neither `workspace_indicator` nor `dir`, so it always ran at the repo root. Any module in a subdirectory failed with `go.mod file not found` in both check and fix, and nested modules were never reached. Now scoped like the other Go builtins, with the `go.mod` project indicator added so `hk init` suggests it.

## Testing

Every builtin changed here gains a `tests` block; 10 of the 13 Go builtins had none, which is why these went unnoticed. New tool stubs for `gofumpt`, `goimports`, and `golines`.

The nested-module case is covered by an integration test rather than a `tests` block: `hk test` resolves `{{workspace}}` but does not apply `dir`, so a nested workspace cannot be exercised there. The test fails without the fix and passes with it.



*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added built-in tool support for `gofumpt`, `goimports`, and `golines`, including their configured versions and installation sources.

- **Bug Fixes**
  - Improved Go module cleanup for projects containing modules in subdirectories. Unused dependencies can now be detected and removed without incorrectly reporting a missing module file.

- **Tests**
  - Added coverage to verify nested-module checks and automatic fixes work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->