### PR TITLE
chore: generate release notes before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,7 @@ jobs:
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
             --notes-file release-notes.md \
+            --draft \
             release-assets/*
 
   publish-crate:
@@ -274,3 +275,22 @@ jobs:
           EOF
 
           gh release edit "$TAG_NAME" --notes-file /tmp/release-notes.md
+
+  publish-release:
+    needs: [publish-crate, enhance-release]
+    runs-on: namespace-profile-endev-linux-amd64
+    permissions:
+      contents: write
+    steps:
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUTS_VERSION: ${{ inputs.version }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ -n "${INPUTS_VERSION}" ]]; then
+            TAG_NAME="v${INPUTS_VERSION}"
+          else
+            TAG_NAME="${GITHUB_REF_NAME}"
+          fi
+          gh release edit "$TAG_NAME" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,6 +278,7 @@ jobs:
 
   publish-release:
     needs: [publish-crate, enhance-release]
+    if: ${{ !cancelled() && needs.enhance-release.result == 'success' && (needs.publish-crate.result == 'success' || needs.publish-crate.result == 'skipped') }}
     runs-on: namespace-profile-endev-linux-amd64
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- create the GitHub release as a draft
- enhance and normalize release notes while publishing the crate
- publish the GitHub release only after both operations succeed

## Validation

- actionlint with ShellCheck enabled
- git diff --check
- verified publication depends on publish-crate and enhance-release

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release publication sequence so GitHub releases stay draft until crate publish and note enhancement finish. A failed or skipped `publish-crate` job can block making the GitHub release public.
> 
> **Overview**
> GitHub releases are now created as **drafts**, then published only after crate publishing and release-note enhancement both succeed.
> 
> A new `publish-release` job depends on `publish-crate` and `enhance-release` and flips the draft flag off with `gh release edit --draft=false`. That keeps incomplete notes or a failed crates.io publish from going live.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84bf99de90ca0f1ec340db7744be447d45bbba2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Releases are now created as drafts and published automatically after release enhancement and package publishing steps complete successfully or are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
