### PR TITLE
chore(ci): adopt mbx for Rust builds

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,0 +1,13 @@
+name: Set up mbx
+description: Select the trusted jdx server or fork-safe GitHub cache backend
+
+runs:
+  using: composite
+  steps:
+    - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
+      with:
+        version: 0.3.0
+        backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
+        server-url: https://cache.mise.jdx.dev
+        namespace: jdx/hk
+        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
-        version: 0.3.0
+        version: 0.4.0
         backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/hk

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
+        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/hk
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && matrix.os || matrix.runner }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -95,7 +95,7 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
       - run: brew install parallel
@@ -135,7 +135,7 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
       - run: brew install parallel
@@ -216,7 +216,7 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
       - run: brew install parallel
@@ -244,7 +244,7 @@ jobs:
       - name: mise run lint
         run: mise run lint
   msrv:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -303,7 +303,7 @@ jobs:
       - ci-windows
       - mcp-ui
       - msrv
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 1
     # Run on success or upstream failure but skip when the workflow is cancelled
     # — `always()` would override `cancel-in-progress` and waste a runner.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
       - name: Build
-        run: mbx build build --features git2/vendored-libgit2,git2/vendored-openssl
+        run: mbx build --features git2/vendored-libgit2,git2/vendored-openssl
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: hk-windows-latest
@@ -280,7 +280,7 @@ jobs:
       - name: Generate builtins metadata
         run: mise run pkl:gen
       - name: Run cargo tests
-        run: mbx build test --features git2/vendored-libgit2,git2/vendored-openssl -- --skip settings::tests::test_settings
+        run: mbx test --features git2/vendored-libgit2,git2/vendored-openssl -- --skip settings::tests::test_settings
       - name: Run Pester e2e tests
         run: |
           $env:PKL_PATH = "${{ github.workspace }}/pkl"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
   build:
     permissions:
       contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -50,15 +51,13 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
-        with:
-          cache: rust
+      - uses: ./.github/actions/mbx
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false
@@ -72,13 +71,14 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # zizmor: ignore[cache-poisoning] v2
+      - uses: ./.github/actions/mbx
       - name: Build
-        run: cargo build --features git2/vendored-libgit2,git2/vendored-openssl
+        run: mbx build build --features git2/vendored-libgit2,git2/vendored-openssl
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: hk-windows-latest
@@ -95,7 +95,7 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
       - run: brew install parallel
@@ -135,7 +135,7 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
       - run: brew install parallel
@@ -207,6 +207,7 @@ jobs:
   ci-other:
     permissions:
       contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -215,7 +216,7 @@ jobs:
             runner: namespace-profile-endev-macos-arm64
           - os: ubuntu-latest
             runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && matrix.os || matrix.runner }}
     timeout-minutes: 20
     steps:
       - run: brew install parallel
@@ -223,9 +224,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
-        with:
-          cache: rust
+      - uses: ./.github/actions/mbx
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false
@@ -245,17 +244,16 @@ jobs:
       - name: mise run lint
         run: mise run lint
   msrv:
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 10
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
-        with:
-          cache: rust
+      - uses: ./.github/actions/mbx
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false
@@ -266,11 +264,12 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # zizmor: ignore[cache-poisoning] v2
+      - uses: ./.github/actions/mbx
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           cache: false
@@ -281,7 +280,7 @@ jobs:
       - name: Generate builtins metadata
         run: mise run pkl:gen
       - name: Run cargo tests
-        run: cargo test --features git2/vendored-libgit2,git2/vendored-openssl -- --skip settings::tests::test_settings
+        run: mbx build test --features git2/vendored-libgit2,git2/vendored-openssl -- --skip settings::tests::test_settings
       - name: Run Pester e2e tests
         run: |
           $env:PKL_PATH = "${{ github.workspace }}/pkl"
@@ -304,7 +303,7 @@ jobs:
       - ci-windows
       - mcp-ui
       - msrv
-    runs-on: namespace-profile-endev-linux-amd64
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     timeout-minutes: 1
     # Run on success or upstream failure but skip when the workflow is cancelled
     # — `always()` would override `cancel-in-progress` and waste a runner.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: namespace-profile-endev-linux-amd64
     permissions:
       contents: read
+      id-token: write
       # actions/configure-pages needs pages permission to enable Pages on the repo.
       pages: write
     steps:
@@ -39,9 +40,7 @@ jobs:
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
           persist-credentials: false
-      - uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
-        with:
-          cache: rust
+      - uses: ./.github/actions/mbx
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # Agent Guidelines
 
+## mbx build cache
+
+Compilation-heavy mise tasks and hk checks use `mbx`. If an mbx command fails
+or creates a development papercut, rerun the exact equivalent `cargo` command
+from `CONTRIBUTING.md`; this unblocks work without weakening the check. If Cargo
+succeeds, surface the mismatch and recommend a
+[mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
+the repository and commit, OS, `mbx --version`, both commands and outputs, the
+cache summary, and `MBX_BYPASS_LOG` details when relevant. Do not silently make
+Cargo the permanent path, and do not post externally without user authorization.
+
 This file provides guidance to AI coding agents when working with code in this repository.
 
 ## Conventional Commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,23 @@
 # Contributing
 
 See the [contributing guide](https://hk.jdx.dev/contributing).
+
+## mbx build cache
+
+The normal `mise run build`, `mise run test:cargo`, and `mise run lint`
+workflows use [mbx](https://mr-boxington.jdx.dev) for compilation-heavy Cargo
+work. If mbx appears to be the problem, use the equivalent Cargo commands to
+unblock yourself without skipping or weakening the check:
+
+```sh
+cargo build
+cargo test --all --all-features
+cargo clippy --manifest-path Cargo.toml --quiet -- -D warnings
+cargo +nightly check -Zwarnings --quiet
+```
+
+If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a
+[mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
+Include the repository and commit, operating system, `mbx --version`, both
+commands and their output, the mbx cache summary, and an `MBX_BYPASS_LOG` when
+relevant (for example, `MBX_BYPASS_LOG=mbx-bypasses.log mise run build`).

--- a/hk.pkl
+++ b/hk.pkl
@@ -15,11 +15,11 @@ local linters = new Mapping<String, Step | Group> {
   // predefined formatters+linters
   ["cargo-clippy"] = (Builtins.cargo_clippy) {
     profiles = List("slow")
-    check = "mbx build clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
+    check = "mbx clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
   }
   ["cargo-check"] = (Builtins.cargo_check) {
     profiles = List("!slow")
-    check = "mbx build +nightly check -Zwarnings --quiet"
+    check = "mbx +nightly check -Zwarnings --quiet"
   }
   ["dbg"] = new Step {
     // ensure no dbg! macros are used

--- a/hk.pkl
+++ b/hk.pkl
@@ -15,10 +15,11 @@ local linters = new Mapping<String, Step | Group> {
   // predefined formatters+linters
   ["cargo-clippy"] = (Builtins.cargo_clippy) {
     profiles = List("slow")
-    check = "cargo clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
+    check = "mbx build clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
   }
   ["cargo-check"] = (Builtins.cargo_check) {
     profiles = List("!slow")
+    check = "mbx build +nightly check -Zwarnings --quiet"
   }
   ["dbg"] = new Step {
     // ensure no dbg! macros are used

--- a/hk.pkl
+++ b/hk.pkl
@@ -15,11 +15,17 @@ local linters = new Mapping<String, Step | Group> {
   // predefined formatters+linters
   ["cargo-clippy"] = (Builtins.cargo_clippy) {
     profiles = List("slow")
-    check = "mbx clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
+    check = new CommandSpec {
+      command = "mbx clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
+      effect = "write"
+    }
   }
   ["cargo-check"] = (Builtins.cargo_check) {
     profiles = List("!slow")
-    check = "mbx +nightly check -Zwarnings --quiet"
+    check = new CommandSpec {
+      command = "mbx +nightly check -Zwarnings --quiet"
+      effect = "write"
+    }
   }
   ["dbg"] = new Step {
     // ensure no dbg! macros are used

--- a/mise-tasks/build
+++ b/mise-tasks/build
@@ -6,4 +6,4 @@
 
 set -eu
 
-mbx build build
+mbx build

--- a/mise-tasks/build
+++ b/mise-tasks/build
@@ -6,4 +6,4 @@
 
 set -eu
 
-cargo build
+mbx build build

--- a/mise-tasks/msrv
+++ b/mise-tasks/msrv
@@ -2,4 +2,4 @@
 
 set -eu
 
-cargo msrv verify
+mbx build msrv verify

--- a/mise-tasks/msrv
+++ b/mise-tasks/msrv
@@ -2,4 +2,4 @@
 
 set -eu
 
-mbx build msrv verify
+mbx msrv verify

--- a/mise-tasks/test/cargo
+++ b/mise-tasks/test/cargo
@@ -4,4 +4,4 @@
 
 set -eu
 
-mbx build test --all --all-features
+mbx test --all --all-features

--- a/mise-tasks/test/cargo
+++ b/mise-tasks/test/cargo
@@ -4,4 +4,4 @@
 
 set -eu
 
-cargo test --all --all-features
+mbx build test --all --all-features

--- a/mise.lock
+++ b/mise.lock
@@ -469,6 +469,65 @@ checksum = "sha256:e437443331865218763d44089680f4d36547353e8c3c8b394c24859203e6c
 url = "https://github.com/foresterre/cargo-msrv/releases/download/v0.19.3/cargo-msrv-x86_64-pc-windows-msvc-v0.19.3.zip"
 url_api = "https://api.github.com/repos/foresterre/cargo-msrv/releases/assets/380851496"
 
+[[tools."github:jdx/mr-boxington"]]
+version = "0.3.0"
+backend = "github:jdx/mr-boxington"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
+checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
+checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64"]
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64-baseline"]
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+
+[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+
+[tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
+checksum = "sha256:1803cec79be0b753fc3af23044edc46fd81ffdf9d66fcb7b6637cfb22cc6db4a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704881"
+
+[tools."github:jdx/mr-boxington"."platforms.macos-x64"]
+checksum = "sha256:72a98d019b83859e465d30a91422e7b2eb72cf53fb42e116a277865310392c0c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704883"
+
+[tools."github:jdx/mr-boxington"."platforms.macos-x64-baseline"]
+checksum = "sha256:72a98d019b83859e465d30a91422e7b2eb72cf53fb42e116a277865310392c0c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704883"
+
+[tools."github:jdx/mr-boxington"."platforms.windows-x64"]
+checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+
+[tools."github:jdx/mr-boxington"."platforms.windows-x64-baseline"]
+checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+
 [[tools."github:jdx/tak"]]
 version = "0.0.5"
 backend = "github:jdx/tak"

--- a/mise.lock
+++ b/mise.lock
@@ -470,63 +470,63 @@ url = "https://github.com/foresterre/cargo-msrv/releases/download/v0.19.3/cargo-
 url_api = "https://api.github.com/repos/foresterre/cargo-msrv/releases/assets/380851496"
 
 [[tools."github:jdx/mr-boxington"]]
-version = "0.3.0"
+version = "0.4.0"
 backend = "github:jdx/mr-boxington"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+checksum = "sha256:ed81dab87775bcc8764c7257d8bea0dd8b7f811d6263b71bc7cd83a879661593"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719396"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+checksum = "sha256:ed81dab87775bcc8764c7257d8bea0dd8b7f811d6263b71bc7cd83a879661593"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719396"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-baseline"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:1803cec79be0b753fc3af23044edc46fd81ffdf9d66fcb7b6637cfb22cc6db4a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704881"
+checksum = "sha256:416cab92e23c4652183e4a794af3fdcbc50b56296d8c09f8b6548e7577416307"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719398"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-x64"]
-checksum = "sha256:72a98d019b83859e465d30a91422e7b2eb72cf53fb42e116a277865310392c0c"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704883"
+checksum = "sha256:9f1016b0592ffd3b4b4000640223e10a2100cc6136d722fac5c4829cb89fc7ed"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719400"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-x64-baseline"]
-checksum = "sha256:72a98d019b83859e465d30a91422e7b2eb72cf53fb42e116a277865310392c0c"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704883"
+checksum = "sha256:9f1016b0592ffd3b4b4000640223e10a2100cc6136d722fac5c4829cb89fc7ed"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719400"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+checksum = "sha256:f841b1907cf86c54db4d3d2d1e88f87303ccc8f720efff90b6331d7d5592bf4e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719397"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64-baseline"]
-checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+checksum = "sha256:f841b1907cf86c54db4d3d2d1e88f87303ccc8f720efff90b6331d7d5592bf4e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719397"
 
 [[tools."github:jdx/tak"]]
 version = "0.0.5"

--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,7 @@ communique                      = "latest"
 git-cliff                       = "latest"
 "github:crate-ci/cargo-release" = "latest"
 "github:foresterre/cargo-msrv"  = "latest"
+"github:jdx/mr-boxington"       = "latest"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.


### PR DESCRIPTION
## Summary

- route compilation-heavy local mise tasks and hk checks through mbx
- configure trusted Namespace jobs for the jdx server cache and fork-safe GitHub-hosted cache restores
- document exact Cargo fallbacks and the mr-boxington Discussions escalation path
- use the direct Cargo-subcommand syntax released in mbx 0.4.0
- pin local and CI setup to mbx 0.4.0

## Validation

- resolved the committed mise lock to mbx 0.4.0
- installed the locked tool and confirmed `mbx 0.4.0`
- evaluated the mise configuration and task list
- confirmed `mbx build` direct syntax
- ran actionlint and the repository-specific configuration checks for the original integration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Standardized build caching across build, test, documentation, and MSRV workflows.
  * Improved cache handling for external pull requests and Dependabot changes.
  * Updated documentation builds with enhanced authentication permissions.
  * Improved reliability across supported CI environments.

* **Developer Experience**
  * Build, test, and MSRV tasks now use the shared build system consistently.
  * Added guidance for troubleshooting cache-related compilation issues and reporting failures.
  * Added the build tool to the project’s development environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI and local lint/build paths now depend on mbx and external/OIDC-backed caches; a regression there could fail builds or mask real compile errors until fallbacks are used.
> 
> **Overview**
> This PR routes **compilation-heavy Rust work** through **[mbx](https://mr-boxington.jdx.dev)** (pinned **0.4.0** in mise and CI) instead of calling `cargo` directly or using **nscloud-cache** / **Swatinem/rust-cache**.
> 
> A new composite action **`.github/actions/mbx`** installs mbx via `mr-boxington-action`, uses the **jdx server cache** on trusted runs, and switches to a **GitHub cache backend** for fork PRs and Dependabot. Jobs that use mbx gain **`id-token: write`** for OIDC. Several matrix jobs now run on **GitHub-hosted runners** for those fork/Dependabot PRs while keeping Namespace profiles elsewhere.
> 
> **Local/CI entry points** updated: `mise run build`, `test:cargo`, and `msrv`; Windows workflow **`mbx build` / `mbx test`**; **`hk.pkl`** `cargo-clippy` and `cargo-check` steps call **`mbx clippy`** and **`mbx +nightly check`** with `effect = "write"`. **`AGENTS.md`** and **`CONTRIBUTING.md`** document equivalent **`cargo`** fallbacks and mr-boxington escalation when mbx misbehaves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac14413b05f0fcbabf14914bf172f7522d677e2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->