### PR TITLE
chore: remove pinned rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel    = "1.95.0"
-components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

- remove `rust-toolchain.toml`
- let development, CI, and release environments use their configured default Rust toolchain
- use CI to expose any incompatibilities with the runner-provided compiler and Clippy

## Validation

- `git diff --check`
- confirmed this environment selects its default stable toolchain, Rust 1.97.1, after removal

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change with no runtime behavior; main risk is occasional dev/CI Rust version drift until workflows are aligned.
> 
> **Overview**
> Removes **`rust-toolchain.toml`**, so `rustup` no longer auto-selects **Rust 1.95.0** with **clippy** and **rustfmt** for this repo.
> 
> Local builds and tooling now follow each environment’s **default stable** (or otherwise configured) toolchain instead of a shared pin; CI is expected to surface compiler/Clippy mismatches against whatever the runners provide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea1ed8c60c2735df9c60c5cb55da939e04d9de12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the project’s pinned Rust toolchain configuration.
  * Rust tooling will now follow the environment’s default version and available formatting and linting tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->