### PR TITLE
fix(builtins): broaden gomod_tidy glob to run tidy on .go changes

### DIFF
--- a/pkl/builtins/gomod_tidy.pkl
+++ b/pkl/builtins/gomod_tidy.pkl
@@ -9,7 +9,11 @@ import "../Config.pkl"
   }
 }
 gomod_tidy = new Config.Step {
-  glob = "**/go.mod"
+  // `go mod tidy` derives requirements from the imports in `.go` files, so the
+  // common drift -- adding or removing an import leaves go.mod/go.sum untidy --
+  // never touches go.mod itself. Matching `.go` and go.sum too means the step
+  // actually runs when that happens.
+  glob = List("**/*.go", "**/go.mod", "**/go.sum")
   // `go mod tidy` resolves the module rooted at the working directory, so
   // it has to run in the directory holding the go.mod rather than the repo
   // root. Without this it fails outright on any module outside the root and


### PR DESCRIPTION
Implements proposal 1 of #1234.

## What changed

`gomod_tidy`'s glob goes from `"**/go.mod"` to `List("**/*.go", "**/go.mod", "**/go.sum")`.

## Why

`go mod tidy` derives module requirements from the imports in `.go` files. The most common drift — you add or remove an `import` and `go.mod`/`go.sum` are now out of tidy — never edits `go.mod` itself, so it did not match the old glob and was not caught at commit time. Downstream configs were working around this by overriding the glob to exactly this list.

`workspace_indicator` and `dir` are unchanged, and the command still ignores `{{files}}` (it runs `go mod tidy [-diff]` in the workspace), so nested modules resolve as before.

## Trade-off

The step now runs `go mod tidy -diff` whenever any Go file changes rather than only on `go.mod` edits. `-diff` is cheap in check mode and this is the correct scope, but it does run more often. The alternative — keep the narrow glob and document the broad one as a recommended override — leaves the primary use case silently unhandled, so broadening the builtin seems like the better default.

## Testing

The three existing `gomod_tidy` tests pass unchanged; each writes `go.mod` + `main.go`, both of which match the broadened glob.

Worth noting for reviewers: I tried to add a regression guard that asserts a `.go`-only change triggers the step, but it isn't expressible in the pkl test harness today. `test.files` bypasses glob filtering entirely, and files written via `before` don't exist yet when `workspace_indicator` is resolved, so there's no way to set up "go.mod exists on disk but only main.go changed" for a workspace-scoped step. A `.go`-driven "tidy adds a missing require" test would additionally need network access to resolve a real module. The existing "remove unused require" fix test still covers the tidy path itself.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*