### PR TITLE
feat(builtins): add shellcheck fix via check_diff

### DIFF
--- a/pkl/builtins/shellcheck.pkl
+++ b/pkl/builtins/shellcheck.pkl
@@ -20,6 +20,16 @@ shellcheck = new Config.Step {
     command = new Config.Command { argv = List("shellcheck", "{{files}}") }
     effect = "read"
   }
+  // shellcheck has no in-place write mode; `--format=diff` is its only autofix
+  // path, and only some findings are fixable. `check_after_diff` reruns
+  // `check` once hk has applied the patch, so a file with both a fixable and a
+  // non-fixable finding is fixed and still fails on what is left, rather than
+  // being masked by the clean apply.
+  check_diff = new Config.CommandSpec {
+    command = new Config.Command { argv = List("shellcheck", "--format=diff", "{{files}}") }
+    effect = "read"
+  }
+  check_after_diff = true
   tests {
     local const testMaker = new helpers.TestMaker {
       filename = "test.sh"
@@ -32,5 +42,12 @@ shellcheck = new Config.Step {
     }
     ["check extensionless shell script"] =
       extensionlessTestMaker.checkFail("#!/bin/sh\necho 'oops I'm escaped'", 1)
+    // With no `fix` command, `hk test` runs `check` for fix-mode tests, so the
+    // apply path itself is covered in test/shellcheck_partial_fix.bats.
+    local const fixTestMaker = new helpers.TestMaker { filename = "test.sh" }
+    local const backtickGood = "#!/bin/sh\nx=$(date)\necho \"$x\"\n"
+    ["fix good file"] = fixTestMaker.fixPass(backtickGood, backtickGood)
+    local const unfixable = "#!/usr/bin/bash\necho 'oops I'm escaped'"
+    ["fix file with no autofixable findings"] = fixTestMaker.fixFail(unfixable, unfixable, 1)
   }
 }

--- a/test/shellcheck_partial_fix.bats
+++ b/test/shellcheck_partial_fix.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+    # shellcheck is provided by a mise tool-stub
+    PATH="$PROJECT_ROOT/test/builtin_tool_stubs:$PATH"
+}
+
+teardown() {
+    _common_teardown
+}
+
+write_config() {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+hooks {
+    ["fix"] {
+        fix = true
+        steps {
+            ["shellcheck"] = Builtins.shellcheck
+        }
+    }
+}
+EOF
+}
+
+@test "shellcheck fix applies autofixable findings and still reports the rest" {
+    write_config
+    # SC2006 (backticks) is autofixable; SC2034 (unused variable) is not.
+    printf '#!/bin/sh\nunused=value\nx=`date`\necho "$x"\n' > mixed.sh
+    git add .
+    git commit -m init
+
+    run hk fix --all
+    # The leftover SC2034 must fail the step rather than being masked by the
+    # successful patch application.
+    assert_failure
+    assert_output --partial "SC2034"
+
+    # The autofixable finding was still applied.
+    run cat mixed.sh
+    assert_output '#!/bin/sh
+unused=value
+x=$(date)
+echo "$x"'
+}
+
+@test "shellcheck fix rewrites a fully autofixable file and succeeds" {
+    write_config
+    printf '#!/bin/sh\nx=`date`\necho "$x"\n' > auto.sh
+    git add .
+    git commit -m init
+
+    run hk fix --all
+    assert_success
+
+    run cat auto.sh
+    assert_output '#!/bin/sh
+x=$(date)
+echo "$x"'
+}
+
+@test "shellcheck fix leaves a file with no autofixable findings unchanged and fails" {
+    write_config
+    printf '#!/bin/sh\nunused=value\n' > only_unfixable.sh
+    git add .
+    git commit -m init
+
+    run hk fix --all
+    assert_failure
+    assert_output --partial "SC2034"
+
+    run cat only_unfixable.sh
+    assert_output '#!/bin/sh
+unused=value'
+}


### PR DESCRIPTION
Implements proposal 2 of #1234. Builds on `check_after_diff` from #1243.

`shellcheck` was check-only. It has no in-place write mode, but `--format=diff` emits a unified diff of the findings it can fix, which hk applies itself:

```pkl
check_diff = new Config.CommandSpec {
  command = new Config.Command { argv = List("shellcheck", "--format=diff", "{{files}}") }
  effect = "read"
}
check_after_diff = true
```

`check` is unchanged, and there's no `fix` command — no inline `git apply` pipeline.

Only a subset of findings are auto-fixable, which is what `check_after_diff` is for: after hk applies the patch it reruns `check`, so a file carrying both a fixable and a non-fixable finding is fixed and still fails on what's left instead of being masked by the clean apply.

## Verified

Real `hk fix --all` runs, with a wrapper counting invocations:

| input | file after | exit | shellcheck invocations |
|---|---|---|---|
| autofixable only | backticks rewritten | 0 | 2 (`--format=diff`, then `check`) |
| fixable + non-fixable | backticks rewritten | 1, SC2034 reported | 2 |
| non-fixable only | unchanged | 1, reported | 2 |
| clean | unchanged | 0 | 1 |

The second invocation is confined to this step; complete formatters keep the single-command path since `check_after_diff` is opt-in.

## Testing

Five pkl tests plus `test/shellcheck_partial_fix.bats` (mixed case, fully-autofixable, nothing-fixable), passing under both `HK_LIBGIT2=1` and `HK_LIBGIT2=`. The bats tests are written against behavior rather than implementation, so they carried over from the pipeline version unchanged — which is a reasonable signal that the observable contract is the same.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for ShellCheck autofix behavior with mixed fixable and unfixable findings.
  * Added validation that fully fixable files are rewritten successfully.
  * Added validation that files with only unfixable findings remain unchanged and report failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->