### PR TITLE
feat(builtins): add ls_lint linter

### DIFF
--- a/pkl/builtins/ls_lint.pkl
+++ b/pkl/builtins/ls_lint.pkl
@@ -1,0 +1,49 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+import "./test/helpers.pkl"
+
+@Builtins.meta {
+  category = "Special Purpose"
+  description = "Directory and filename naming linter"
+  // https://ls-lint.org/2.0/getting-started/installation.html
+  project_indicators {
+    new { file = ".ls-lint.yml" }
+    new { file = ".ls-lint.yaml" }
+  }
+}
+ls_lint = new Config.Step {
+  // ls-lint validates the whole tree against .ls-lint.yml itself and defaults
+  // to ".", so it takes no file arguments and runs once per invocation. The
+  // glob only gates whether the step runs at all when files change; naming
+  // violations can be introduced by adding a file of any type.
+  glob = "**/*"
+  // ls-lint only reads names, never contents, so the default filters would
+  // wrongly skip the step when a changeset holds only a binary file or symlink
+  // whose name breaks the rules.
+  allow_binary = true
+  allow_symlinks = true
+  batch = false
+  check = new Config.CommandSpec {
+    command = new Config.Command { argv = List("ls-lint") }
+    effect = "read"
+  }
+  // No fix: ls-lint reports naming violations but will not rename files.
+  tests {
+    // ls-lint checks filenames rather than contents, so the tests vary the
+    // filename and ship a config that requires snake_case for .go files.
+    local const config = "ls:\n  .go: snake_case\n"
+    local const extraFiles = new Mapping<String, String> {
+      [".ls-lint.yml"] = config
+    }
+    local const badMaker = new helpers.TestMaker {
+      filename = "BadName.go"
+      extra_files = extraFiles
+    }
+    local const goodMaker = new helpers.TestMaker {
+      filename = "good_name.go"
+      extra_files = extraFiles
+    }
+    ["check bad filename"] = badMaker.checkFail("package x\n", 1)
+    ["check good filename"] = goodMaker.checkPass("package x\n")
+  }
+}

--- a/test/builtin_tool_stubs/ls-lint
+++ b/test/builtin_tool_stubs/ls-lint
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "2.3.1"
+tool = "aqua:loeffel-io/ls-lint"


### PR DESCRIPTION
Implements proposal 3 of #1234.

Adds a builtin for [ls-lint](https://ls-lint.org), which enforces directory and filename naming conventions. There was no builtin for it, so users hand-rolled the entire step. Also adds a `test/builtin_tool_stubs/ls-lint` stub pinned to 2.3.1.

ls-lint validates the whole tree against `.ls-lint.yml` itself and takes no file arguments, so the step runs once per invocation (`batch = false`, no `{{files}}`) — same shape as the `mise` builtin. The `glob = "**/*"` only gates whether the step runs at all. No `fix`: ls-lint reports naming violations but will not rename files.

The discussion left open whether batching would cause multiple invocations. With a counting wrapper around the binary, `hk check --all` across 7 mixed files produced exactly one `ls-lint` call with no file arguments, and `**/*` matched root-level files — so the glob doesn't need to be dropped.

Tests vary the filename and ship an `.ls-lint.yml` requiring `snake_case` for `.go` files: `BadName.go` → exit 1, `good_name.go` → exit 0.

One thing worth knowing: ls-lint does not search `.config/`, so projects keeping the config there still need to override `check` with `-config .config/.ls-lint.yml`, or move it to the root. Same as `ryl`/`yamlfmt` with non-standard config paths.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing and managing the `ls-lint` tool through `mise`.
  * Uses the current tool configuration format for improved compatibility.
  * Sources `ls-lint` from the Aqua registry, providing a consistent and reliable installation experience.
  * This makes `ls-lint` available alongside other tools managed through the project’s standard tooling workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->