### PR TITLE
docs: clarify subproject monorepo setup

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -4,7 +4,7 @@ outline: "deep"
 
 # Built-in Linters Reference
 
-hk provides 140+ pre-configured linters and formatters through the `Builtins` module. These are production-ready configurations that work out of the box.
+hk provides 140+ pre-configured linters and formatters through the `Builtins` module. They provide the command, file matching, batching, and other hk behavior, while the corresponding tool must be available in the step's environment.
 
 ## Usage
 
@@ -32,6 +32,30 @@ You can also customize builtins:
   glob = List("*.js", "*.ts")  // Override file patterns
 }
 ```
+
+### Tool availability
+
+Builtins configure how hk invokes a tool; they do not install that tool. The
+executable used by the builtin must be on `PATH`, or the step must use a `prefix`
+that resolves it.
+
+With [`HK_MISE=1`](/mise_integration#per-directory-environments-monorepos), hk
+resolves the mise environment for the step's directory, so tools declared in a
+subproject's `mise.toml` are available without a prefix. For a Node tool installed
+locally by aube, prefix its builtin with `aube exec`:
+
+```pkl
+["eslint"] = (Builtins.eslint) {
+  prefix = List("aube", "exec")
+}
+```
+
+Use an argv list for builtins backed by structured commands. A string prefix such
+as `"aube exec"` or `"mise x --"` cannot be combined with those commands.
+
+The generated list below summarizes each builtin. Its complete command and defaults
+are the corresponding Pkl file in
+[`pkl/builtins`](https://github.com/jdx/hk/tree/main/pkl/builtins).
 
 ## Available Builtins
 

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -53,8 +53,8 @@ locally by aube, prefix its builtin with `aube exec`:
 Use an argv list for builtins backed by structured commands. A string prefix such
 as `"aube exec"` or `"mise x --"` cannot be combined with those commands.
 
-The generated list below summarizes each builtin. Its complete command and defaults
-are the corresponding Pkl file in
+The generated list below summarizes each builtin. The complete command and defaults
+for each builtin are defined in the corresponding Pkl file in
 [`pkl/builtins`](https://github.com/jdx/hk/tree/main/pkl/builtins).
 
 ## Available Builtins

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,6 +89,35 @@ hooks {
 
 The first line (`amends`) is critical because that imports the base configuration pkl for extending.
 
+### Subprojects
+
+In a monorepo, the root config can load an `hk.pkl` owned by each component:
+
+```pkl
+subprojects = List("frontend", "backend", "packages/*")
+```
+
+Subproject paths are relative to the root config and may be literal directories or
+glob patterns. hk merges a subproject's steps into the root hook with the same name,
+then scopes their working directories and file matching to that subproject. A step
+named `eslint` in `frontend/hk.pkl` is exposed as `frontend:eslint` for `--step` and
+`skip_steps`.
+
+Keep these composition rules in mind:
+
+- Hooks are not copied between events. A subproject step under `check` does not also
+  run in `pre-commit` or `fix`; add it to every event where it should run.
+- Hook-wide behavior such as `fix`, `stash`, `stage`, and `report` should be set in
+  the root config. Subprojects contribute steps and their local environment.
+- Subprojects are loaded one level deep. A `subprojects` declaration inside a
+  subproject config is ignored with a warning.
+- A subproject's literal `dir` is relative to that subproject. Templated workspace
+  directories have an additional caveat described under
+  [Step working directory](#step-working-directory).
+
+See the complete [monorepo example](/reference/examples/monorepo#nested-configs-with-subprojects),
+including per-directory mise environments and locally installed Node tools.
+
 ### `hk.local.pkl`
 
 If `hk.local.pkl` exists, it will be used instead of `hk.pkl`. It is intended to be used for local config, and should

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -120,7 +120,10 @@ subprojects = List("frontend", "backend", "packages/*")
 
 hooks {
   ["check"] {}
-  ["pre-commit"] { fix = true }
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+  }
 }
 ```
 
@@ -129,14 +132,75 @@ hooks {
 amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
 import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
 
-hooks {
-  ["check"] {
-    steps {
-      ["eslint"] = (Builtins.eslint) { batch = true }
-      ["prettier"] = (Builtins.prettier) { batch = true }
-    }
+local linters = new Mapping<String, Step> {
+  // aube resolves these executables from frontend/node_modules/.bin
+  ["eslint"] = (Builtins.eslint) {
+    prefix = List("aube", "exec")
+  }
+  ["prettier"] = (Builtins.prettier) {
+    prefix = List("aube", "exec")
   }
 }
+
+hooks {
+  ["check"] {
+    steps = linters
+  }
+  // Hooks compose by name, so list the steps again for pre-commit.
+  ["pre-commit"] {
+    steps = linters
+  }
+}
+```
+
+```pkl
+// backend/hk.pkl
+amends "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtins.pkl"
+
+local linters = new Mapping<String, Step> {
+  ["cargo-fmt"] = Builtins.cargo_fmt
+  ["cargo-clippy"] = Builtins.cargo_clippy
+}
+
+hooks {
+  ["check"] { steps = linters }
+  ["pre-commit"] { steps = linters }
+}
+```
+
+The matching mise configuration makes hk, aube, and each component's tools
+available in the directory where its steps run:
+
+```toml
+# mise.toml (repo root)
+monorepo_root = true
+
+[monorepo]
+config_roots = [".", "frontend", "backend"]
+
+[tools]
+aube = "latest"
+hk = "latest"
+pkl = "latest"
+
+[env]
+HK_MISE = 1
+
+[hooks]
+postinstall = "hk install --mise"
+```
+
+```toml
+# frontend/mise.toml
+[tools]
+node = "lts"
+```
+
+```toml
+# backend/mise.toml
+[tools]
+rust = "stable"
 ```
 
 When hk runs from the repo root, each subproject's hooks are merged in, scoped to
@@ -149,6 +213,15 @@ its directory:
 - A subproject's `env` applies to its own steps only.
 - Glob entries like `packages/*` match any directory containing an hk config file;
   directories without one are skipped.
+- Hooks compose by name. Steps declared only under `check` do not automatically run
+  under `pre-commit` or `fix`.
+- Define hook-wide settings such as `fix`, `stash`, `stage`, and `report` in the root
+  config so every subproject uses the same behavior.
+- Only one level of subprojects is supported.
 
 This maps directly onto [mise monorepo config roots](https://mise.jdx.dev/tasks/monorepo.html):
 the same directories that own a `mise.toml` can own their `hk.pkl`.
+
+Use `hk check --all --plan` to inspect the resolved jobs without executing them.
+For this example, the plan includes `frontend:eslint`, `frontend:prettier`,
+`backend:cargo-fmt`, and `backend:cargo-clippy`.


### PR DESCRIPTION
## Summary

- document how subproject hooks compose and where hook-wide settings belong
- expand the monorepo example with root, React frontend, Rust backend, mise, and aube configuration
- clarify that builtins configure invocation but do not install their executables
- show how to inspect scoped subproject jobs with `hk check --all --plan`

Closes the documentation gap raised in discussion #1233.

## Validation

- `mise run docs:build`
- created a fixture from the documented Pkl snippets and verified `hk check --all --plan` resolves all four scoped jobs
- `git diff --check`
- `mise run lint` *(blocked by the local mise environment lacking a ShellCheck version; actionlint aborted before completion)*

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to user-facing documentation with no runtime or configuration code modifications.
> 
> **Overview**
> **Documentation-only** update that closes gaps around monorepo subprojects and how builtins relate to installed tools.
> 
> The **builtins** guide now states that builtins define hk invocation (commands, globs, batching) but **do not install** tools, and adds a **Tool availability** section covering `PATH`, `prefix` (including `aube exec` as an argv list), `HK_MISE` per-directory resolution, and the limitation that string prefixes cannot be used with structured-command builtins.
> 
> **Configuration** gains a **Subprojects** section: how root `subprojects` merges nested `hk.pkl` hooks, scoped working dirs, qualified step names (`frontend:eslint`), and rules that hooks compose by event name (steps are not copied across `check` / `pre-commit` / `fix`), hook-wide settings belong at the root, and nesting is one level deep.
> 
> The **monorepo example** is expanded with reusable linter maps, separate frontend (eslint/prettier + aube) and backend (cargo) configs, matching **mise** monorepo roots and `HK_MISE`, root `stash` on pre-commit, and using **`hk check --all --plan`** to preview scoped jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 591d3d167e4798c15b96464dcc41e598f9f4b467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the built-in tools guide with tool availability, `PATH`, prefixes, mise integration, and structured command requirements.
  - Added documentation for configuring monorepo subprojects, including hook merging, scoped execution, qualified step names, and nesting limits.
  - Updated the monorepo example with component configurations, reusable linter mappings, mise files, and expected plan output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->