### PR TITLE
fix(builtins): stage gomod_tidy manifest updates

### DIFF
--- a/pkl/builtins/gomod_tidy.pkl
+++ b/pkl/builtins/gomod_tidy.pkl
@@ -20,6 +20,8 @@ gomod_tidy = new Config.Step {
   // never reaches nested modules.
   workspace_indicator = "go.mod"
   dir = "{{workspace}}"
+  // Tidy can update either manifest when a Go source file triggered the job.
+  stage = List("go.mod", "go.sum")
   check_diff = new Config.CommandSpec {
     command = "go mod tidy -diff"
     effect = "write"

--- a/test/gomod_tidy_nested_module.bats
+++ b/test/gomod_tidy_nested_module.bats
@@ -55,3 +55,39 @@ PKL
     assert_output --partial "module example.com/svc"
     refute_output --partial "example.com/unused"
 }
+
+@test "gomod_tidy runs on Go changes and stages updated manifests" {
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl" as Builtins
+hooks {
+  ["fix"] {
+    steps {
+      ["gomod_tidy"] = Builtins.gomod_tidy
+    }
+  }
+}
+PKL
+
+    mkdir -p svc
+    printf 'module example.com/svc\n\ngo 1.21\n\nrequire example.com/unused v1.0.0\n' > svc/go.mod
+    printf 'package main\n\nfunc main() {}\n' > svc/main.go
+    git add -A
+    git commit -m "init" --quiet
+
+    printf 'package main\n\nfunc main() { println("changed") }\n' > svc/main.go
+    git add svc/main.go
+
+    PATH="$PROJECT_ROOT/test/builtin_tool_stubs:$PATH"
+    run hk fix --step gomod_tidy
+    assert_success
+
+    run git diff --cached --name-only
+    assert_success
+    assert_line "svc/main.go"
+    assert_line "svc/go.mod"
+
+    run git diff -- svc/go.mod
+    assert_success
+    refute_output
+}


### PR DESCRIPTION
## Summary

- stage `go.mod` and `go.sum` updates produced by `gomod_tidy` when Go source changes
- cover nested-module manifest staging with both Git backends
- leave ShellCheck autofixing to #1237 and the `ls_lint` builtin to #1238

Related to https://github.com/jdx/hk/discussions/1234.

## Test evidence

- `mise run pkl:gen`
- `mise run build`
- `mise run test:bats test/gomod_tidy_nested_module.bats`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Builtin staging behavior only; no auth, runtime, or broad execution changes beyond ensuring Go module manifests are indexed after tidy.
> 
> **Overview**
> **gomod_tidy** now declares `stage = List("go.mod", "go.sum")` so manifest updates from `go mod tidy` are added to the index when the step was triggered by a `.go` change (default staging only followed the step globs and could leave tidied `go.mod`/`go.sum` unstaged).
> 
> A new bats case in `gomod_tidy_nested_module.bats` covers a nested module: after staging only `svc/main.go`, `hk fix --step gomod_tidy` must leave both the Go file and `svc/go.mod` in the cached diff with no leftover unstaged manifest changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc0d59c746e0da870df46744dd33657bb522455. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->