### PR TITLE
fix(step): relativize workspace paths to step directory

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,11 +193,18 @@ hk creates one job per matched workspace, so this runs `go vet ./...` in `packag
 
 File selection happens before hk knows which workspace a job will run in, so `glob` matching, `exclude`, and `stage` pathspecs use only the literal part of `dir` that precedes the first template expression — `sub/{{workspace}}` scopes them to `sub`, and `{{workspace}}` scopes them to nothing. Use `glob` and `workspace_indicator` to select files for a step with a fully templated `dir`.
 
-Literal `dir` values contain no template expression, so they behave exactly as before.
+For commands run with a literal `dir`, `{{workspace}}` and
+`{{workspace_indicator}}` are relative to that directory, just like `{{files}}`.
+For example, a command running in `packages/api` sees `.` and `go.mod` rather
+than `packages/api` and `packages/api/go.mod`.
 
 `stage` patterns are handled separately. Staging runs once per step, after every job, so hk re-resolves a templated `dir` against each matched workspace: `stage = List("generated/**")` stages `packages/a/generated/...` and `packages/b/generated/...`, and leaves a same-named path at the repo root alone. If no workspace matches, the patterns fall back to the repo root and hk warns.
 
-One caveat: `{{workspace}}` is always relative to the repo root, never to a subproject, so a subproject config that sets a templated `dir` resolves to the wrong path. hk reports it as a missing working directory rather than failing obscurely; use a literal `dir` in subprojects for now.
+One caveat: while rendering `dir` itself, `{{workspace}}` is relative to the repo
+root, never to a subproject. A subproject config that sets a templated `dir`
+therefore resolves to the wrong path. hk reports it as a missing working
+directory rather than failing obscurely; use a literal `dir` in subprojects for
+now.
 
 ### Focus checks on failing files
 

--- a/src/step/dir.rs
+++ b/src/step/dir.rs
@@ -21,6 +21,13 @@ use super::Step;
 const TEMPLATE_OPENERS: [&str; 2] = ["{{", "{%"];
 
 impl Step {
+    /// Whether `dir` contains a template expression.
+    pub(crate) fn dir_is_templated(&self) -> bool {
+        self.dir
+            .as_deref()
+            .is_some_and(|dir| template_start(dir).is_some())
+    }
+
     /// The literal directory prefix of `dir`, for selecting files before jobs
     /// (and therefore workspaces) exist.
     ///

--- a/src/step_job.rs
+++ b/src/step_job.rs
@@ -220,6 +220,7 @@ mod tests {
             dir: Some("ui".to_string()),
             ..Default::default()
         });
+        let expected_files = step.shell_type().quote("src/main.ts");
         let job = StepJob::new(step, vec![PathBuf::from("ui/src/main.ts")], RunType::Check)
             .with_workspace_indicator(PathBuf::from("ui/tsconfig.json"));
 
@@ -230,7 +231,7 @@ mod tests {
             tera::render("{{workspace_indicator}}", &tctx).unwrap(),
             "tsconfig.json"
         );
-        assert_eq!(tera::render("{{files}}", &tctx).unwrap(), "src/main.ts");
+        assert_eq!(tera::render("{{files}}", &tctx).unwrap(), expected_files);
     }
 
     #[test]

--- a/src/step_job.rs
+++ b/src/step_job.rs
@@ -84,6 +84,20 @@ impl StepJob {
         // that fails to render strips nothing; the runner renders it again and
         // reports the error before the command runs.
         let dir = self.step.render_dir(&tctx).ok().flatten();
+        // Workspace discovery returns repository-relative paths, but commands
+        // with a literal `dir` run from that directory. Keep workspace template
+        // paths in the same coordinate system as `files`; subproject merging
+        // gives every ordinary step a literal directory, so this also avoids
+        // paths such as `ui/ui/tsconfig.json` from a command run in `ui`.
+        //
+        // A templated `dir` must retain the repository-relative workspace
+        // context because the runner renders it again from this same context.
+        if !self.step.dir_is_templated()
+            && let (Some(workspace_indicator), Some(dir)) = (&self.workspace_indicator, &dir)
+            && let Ok(relative_indicator) = workspace_indicator.strip_prefix(dir)
+        {
+            tctx.with_workspace_indicator(&relative_indicator);
+        }
         let command_files = if let Some(dir) = &dir {
             self.files
                 .iter()
@@ -192,5 +206,53 @@ impl Clone for StepJob {
             progress: self.progress.clone(),
             semaphore: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_templates_are_relative_to_literal_dir() {
+        let step = Arc::new(Step {
+            name: "tsc".to_string(),
+            dir: Some("ui".to_string()),
+            ..Default::default()
+        });
+        let job = StepJob::new(step, vec![PathBuf::from("ui/src/main.ts")], RunType::Check)
+            .with_workspace_indicator(PathBuf::from("ui/tsconfig.json"));
+
+        let tctx = job.tctx(&tera::Context::default());
+
+        assert_eq!(tera::render("{{workspace}}", &tctx).unwrap(), ".");
+        assert_eq!(
+            tera::render("{{workspace_indicator}}", &tctx).unwrap(),
+            "tsconfig.json"
+        );
+        assert_eq!(tera::render("{{files}}", &tctx).unwrap(), "src/main.ts");
+    }
+
+    #[test]
+    fn templated_dir_keeps_repository_relative_workspace_context() {
+        let step = Arc::new(Step {
+            name: "go-vet".to_string(),
+            dir: Some("{{workspace}}".to_string()),
+            ..Default::default()
+        });
+        let job = StepJob::new(
+            step,
+            vec![PathBuf::from("pkgs/api/main.go")],
+            RunType::Check,
+        )
+        .with_workspace_indicator(PathBuf::from("pkgs/api/go.mod"));
+
+        let tctx = job.tctx(&tera::Context::default());
+
+        assert_eq!(tera::render("{{workspace}}", &tctx).unwrap(), "pkgs/api");
+        assert_eq!(
+            tera::render("{{workspace_indicator}}", &tctx).unwrap(),
+            "pkgs/api/go.mod"
+        );
     }
 }

--- a/test/subprojects.bats
+++ b/test/subprojects.bats
@@ -151,3 +151,36 @@ EOF
     run git commit -m "should pass"
     assert_success
 }
+
+@test "subprojects make workspace templates relative to the scoped directory" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+subprojects = List("ui")
+hooks {
+    ["check"] {}
+}
+EOF
+    mkdir -p ui/src
+    cat <<EOF > ui/hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["tsc-paths"] {
+                glob = List("**/*.ts")
+                workspace_indicator = "tsconfig.json"
+                check = "echo workspace={{workspace}} indicator={{workspace_indicator}}; test -f {{workspace_indicator}}; test '{{workspace}}' = '.'"
+            }
+        }
+    }
+}
+EOF
+    echo '{"compilerOptions":{"strict":true}}' > ui/tsconfig.json
+    echo 'const value: number = 1;' > ui/src/main.ts
+    git add .
+    git commit -m "initial commit"
+
+    run hk check --all -v
+    assert_success
+    assert_output --partial "workspace=. indicator=tsconfig.json"
+}


### PR DESCRIPTION
## Summary

- render `{{workspace}}` and `{{workspace_indicator}}` relative to a literal step working directory
- prevent subproject commands such as `tsc -p {{workspace_indicator}}` from resolving duplicated paths like `ui/ui/tsconfig.json`
- preserve repository-relative workspace values used to render templated `dir` settings
- document the command-path semantics and add unit plus Bats regression coverage

Addresses the bug reported in [discussion #1233](https://github.com/jdx/hk/discussions/1233#discussioncomment-18150521).

## Validation

- `mise run test:cargo`
- `mise run test:bats test/subprojects.bats`
- `mise run docs:build`
- `cargo fmt --all -- --check`
- `cargo clippy --bin hk -- -D warnings`
- `git diff --check`

`target/debug/hk check --all` is blocked by the local mise environment lacking a configured ShellCheck version. `cargo clippy --all-targets -- -D warnings` reaches pre-existing test-target warnings outside this change; production-target clippy passes.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes template context for all steps with literal `dir` and workspace indicators, which affects command rendering in subprojects; behavior is narrowly scoped and regression-tested.
> 
> **Overview**
> Fixes incorrect `{{workspace}}` and `{{workspace_indicator}}` paths when a step uses a **literal** `dir` (common in subprojects), where commands run inside that directory but templates still used repo-root paths—e.g. `tsc -p {{workspace_indicator}}` resolving to `ui/ui/tsconfig.json` instead of `tsconfig.json`.
> 
> **`StepJob::tctx`** now detects a non-templated `dir` via new **`dir_is_templated()`**, strips the step directory prefix from the workspace indicator (matching how **`{{files}}`** is already made dir-relative), and leaves **templated** `dir` values on repo-relative workspace paths so `dir` can still render correctly.
> 
> Docs in **`configuration.md`** spell out literal-`dir` vs templated-`dir` semantics. Coverage adds Rust unit tests and a Bats subproject hook case asserting `workspace=.` and `indicator=tsconfig.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe2372ea26bd8e93b3d9638b3af1983df11d03df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected workspace path handling for commands run from literal directories.
  * Ensured templated directories resolve relative to the repository or scoped subproject as expected.
  * Improved workspace detection in subproject hooks.

* **Documentation**
  * Clarified how workspace paths and templated directories are resolved in step configuration.

* **Tests**
  * Added coverage for literal and templated directories, including subproject workspace detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->