### PR TITLE
feat(step): recheck applied diffs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -219,6 +219,8 @@ In check mode, hk first runs `check_diff` or `check_list_files` over the complet
 
 This behavior is opt-in because it adds another process invocation and requires `check` to accept file arguments. Enabling it requires `check` and at least one of `check_diff` or `check_list_files`. Paths not present in the original job are ignored, focused commands retain automatic argument-limit batching, and a failure from the file-reporting command remains authoritative if the focused check unexpectedly succeeds.
 
+For partial fixers, set `check_after_diff = true` alongside `check` and `check_diff`. After applying a nonempty diff in fix mode, hk reruns `check` on the original batch so non-fixable findings are not hidden by a successfully applied patch. Complete formatters can leave this disabled to retain the single-command fast path.
+
 ### `<GROUP>`
 
 A group is a collection of steps that are executed in parallel, waiting for previous steps/groups to finish and blocking other steps/groups from starting until it finishes. This is a naive way to ensure the order of execution. It's better to make use of read/write locks and depends.

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -502,6 +502,15 @@ class Step {
 
   /// Default: `false`
   ///
+  /// If true, rerun `check` on the original file batch after successfully
+  /// applying `check_diff` output. Use this for partial fixers whose diff can
+  /// leave non-fixable findings behind.
+  ///
+  /// Requires both `check` and `check_diff`.
+  check_after_diff: Boolean = false
+
+  /// Default: `false`
+  ///
   /// If true, check mode first runs `check_diff` or `check_list_files` to
   /// identify failing files, then runs `check` only on those files. This keeps
   /// detailed diagnostics while avoiding commands and suggestions containing

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -106,6 +106,7 @@ impl Step {
             let step = job.step.clone();
             let mut job = job;
             set.spawn(async move {
+                let original_job_files = job.files.clone();
                 let mut focused_check_failed = false;
                 let mut focused_check_output: Option<(String, String, String)> = None;
                 if let Some(reason) = &job.skip_reason {
@@ -195,11 +196,22 @@ impl Step {
                                     let dir = step.render_dir(&job.tctx(&ctx.hook_ctx.tctx))?;
                                     match step.apply_diff_output(stdout, dir.as_deref()) {
                                         Ok(true) => {
-                                            // Diff applied successfully - no need to run fixer
-                                            debug!("{step}: diff applied successfully, skipping fixer");
-                                            job.run_type = prev_run_type;
+                                            let applied_files = job.files.clone();
+                                            if step.check_after_diff {
+                                                debug!(
+                                                    "{step}: diff applied successfully, rerunning check on original files"
+                                                );
+                                                job.files = original_job_files.clone();
+                                                job.run_type = RunType::Check;
+                                                job.check_first = false;
+                                                step.run(&ctx, &mut job).await?;
+                                            } else {
+                                                debug!(
+                                                    "{step}: diff applied successfully, skipping fixer"
+                                                );
+                                            }
                                             ctx.hook_ctx.inc_completed_jobs(1);
-                                            return Ok(job.files.clone());
+                                            return Ok(applied_files);
                                         }
                                         Ok(false) => {
                                             // Diff application failed - fall through to run fixer
@@ -370,10 +382,10 @@ impl Step {
         // Build stage pathspecs; if `dir` is set, stage entries are relative to it.
         // Compute "root" variants for patterns that start with "**/" BEFORE prefixing with `dir`.
         // Determine effective stage: explicit setting wins, otherwise default to <JOB_FILES>
-        // for steps with fix commands when staging is enabled.
+        // for steps that can modify files when staging is enabled.
         let effective_stage: Option<&Vec<String>> = if self.stage.is_some() {
             self.stage.as_ref()
-        } else if ctx.hook_ctx.should_stage && self.fix.is_some() {
+        } else if ctx.hook_ctx.should_stage && (self.fix.is_some() || self.check_diff.is_some()) {
             Some(&DEFAULT_STAGE)
         } else {
             None

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -63,11 +63,15 @@ impl Step {
             };
 
             // A failed check-first command falls through to the command for the
-            // requested run type. Include both possible commands in plans and
-            // safe-mode preflight even though a successful check-first command
-            // can make the fallback unnecessary at runtime.
+            // requested run type. Include every possible command in plans and
+            // safe-mode preflight even though only one fallback or recheck may
+            // be needed at runtime.
             let fallback = job.check_first.then(|| self.run_cmd(run_type)).flatten();
-            for command in [first, fallback]
+            let recheck =
+                (job.check_first && matches!(run_type, RunType::Fix) && self.check_after_diff)
+                    .then_some(self.check.as_ref())
+                    .flatten();
+            for command in [first, fallback, recheck]
                 .into_iter()
                 .flatten()
                 .filter(|command| !command.is_empty())
@@ -529,6 +533,11 @@ impl Step {
             eyre::bail!(
                 "Step '{name}' with `check_failed_files = true` requires `check` and at least one \
                  of `check_diff` or `check_list_files`."
+            );
+        }
+        if self.check_after_diff && (self.check.is_none() || self.check_diff.is_none()) {
+            eyre::bail!(
+                "Step '{name}' with `check_after_diff = true` requires both `check` and `check_diff`."
             );
         }
         let commands = [

--- a/src/step/types.rs
+++ b/src/step/types.rs
@@ -201,6 +201,10 @@ pub struct Step {
     #[serde_as(as = "Option<PickFirst<(_, DisplayFromStr)>>")]
     pub check_diff: Option<Command>,
 
+    /// Run the regular check after applying check_diff output
+    #[serde(default)]
+    pub check_after_diff: bool,
+
     /// Run a file-listing check first, then check only the failing files
     #[serde(default)]
     pub check_failed_files: bool,

--- a/src/step_job.rs
+++ b/src/step_job.rs
@@ -46,7 +46,7 @@ impl StepJob {
             workspace_indicator: None,
             check_first: *env::HK_CHECK_FIRST
                 && step.check_first
-                && step.fix.is_some()
+                && (step.fix.is_some() || step.check_diff.is_some())
                 && (step.check.is_some()
                     || step.check_diff.is_some()
                     || step.check_list_files.is_some())

--- a/src/step_job.rs
+++ b/src/step_job.rs
@@ -17,6 +17,9 @@ pub struct StepJob {
     pub step: Arc<Step>,
     pub files: Vec<PathBuf>,
     pub run_type: RunType,
+    /// The mode requested by the user, retained while check-first temporarily
+    /// changes `run_type` to select a read-only command.
+    requested_run_type: RunType,
     pub check_first: bool,
     pub skip_reason: Option<SkipReason>,
     pub progress: Option<Arc<ProgressJob>>,
@@ -39,6 +42,7 @@ impl StepJob {
         Self {
             files,
             run_type,
+            requested_run_type: run_type,
             workspace_indicator: None,
             check_first: *env::HK_CHECK_FIRST
                 && step.check_first
@@ -171,7 +175,7 @@ impl StepJob {
     async fn flocks(&self, ctx: &StepContext) -> Flocks {
         if self.step.stomp {
             Default::default()
-        } else if self.run_type == RunType::Fix {
+        } else if self.requested_run_type == RunType::Fix {
             ctx.hook_ctx.file_locks.write_locks(&self.files).await
         } else {
             ctx.hook_ctx.file_locks.read_locks(&self.files).await
@@ -185,6 +189,7 @@ impl Clone for StepJob {
             step: self.step.clone(),
             files: self.files.clone(),
             run_type: self.run_type,
+            requested_run_type: self.requested_run_type,
             check_first: self.check_first,
             skip_reason: self.skip_reason.clone(),
             workspace_indicator: self.workspace_indicator.clone(),

--- a/test/apply_check_diff.bats
+++ b/test/apply_check_diff.bats
@@ -596,7 +596,7 @@ EOF
 
     echo "base" > test.txt
     git add .
-    git commit -m base
+    git commit -m "test: create base fixture"
     echo "old" > test.txt
     git add test.txt
 

--- a/test/apply_check_diff.bats
+++ b/test/apply_check_diff.bats
@@ -424,3 +424,185 @@ EOF
     run cat test.orig
     assert_output "diffed"
 }
+
+@test "check_after_diff rechecks the original batch after applying a partial fix" {
+    cat <<'SCRIPT' > partial-linter.sh
+#!/bin/bash
+mode="$1"
+shift
+failed=0
+for file in "$@"; do
+    content=$(cat "$file")
+    if [[ "$mode" == "--diff" && "$content" == "fixable" ]]; then
+        echo "--- a/$file"
+        echo "+++ b/$file"
+        echo "@@ -1 +1 @@"
+        echo "-fixable"
+        echo "+fixed"
+        failed=1
+    elif [[ "$content" == "unfixable" ]]; then
+        echo "unfixable finding in $file"
+        failed=1
+    fi
+done
+exit "$failed"
+SCRIPT
+    chmod +x partial-linter.sh
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["fix"] {
+        fix = true
+        steps {
+            ["partial"] {
+                glob = List("*.txt")
+                check = "./partial-linter.sh --check {{files}}"
+                check_diff = "./partial-linter.sh --diff {{files}}"
+                check_after_diff = true
+            }
+        }
+    }
+}
+EOF
+
+    echo "fixable" > fixable.txt
+    echo "unfixable" > unfixable.txt
+
+    run hk fix --all
+    assert_failure
+    assert_output --partial "unfixable finding in unfixable.txt"
+
+    run cat fixable.txt
+    assert_output "fixed"
+
+    rm unfixable.txt
+    echo "fixable" > fixable.txt
+
+    run hk fix --all
+    assert_success
+
+    run cat fixable.txt
+    assert_output "fixed"
+}
+
+@test "check_after_diff validates required commands" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["fix"] {
+        fix = true
+        steps {
+            ["partial"] {
+                glob = List("*.txt")
+                check_diff = "./partial-linter.sh --diff {{files}}"
+                check_after_diff = true
+            }
+        }
+    }
+}
+EOF
+    touch test.txt
+
+    run hk validate
+    assert_failure
+    assert_output --partial \
+        "check_after_diff = true\` requires both \`check\` and \`check_diff"
+}
+
+@test "check_diff fix mode serializes writers for the same file" {
+    cat <<'SCRIPT' > formatter.sh
+#!/bin/bash
+file="$1"
+content=$(cat "$file")
+if [[ "$content" == "old" ]]; then
+    sleep 1
+    echo "--- a/$file"
+    echo "+++ b/$file"
+    echo "@@ -1 +1 @@"
+    echo "-old"
+    echo "+new"
+    exit 1
+fi
+SCRIPT
+    chmod +x formatter.sh
+
+    cat <<'SCRIPT' > fixer.sh
+#!/bin/bash
+echo "fixer ran unexpectedly" > "$1"
+SCRIPT
+    chmod +x fixer.sh
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["fix"] {
+        fix = true
+        steps {
+            ["first"] {
+                glob = List("*.txt")
+                check_diff = "./formatter.sh {{files}}"
+                fix = "./fixer.sh {{files}}"
+            }
+            ["second"] {
+                glob = List("*.txt")
+                check_diff = "./formatter.sh {{files}}"
+                fix = "./fixer.sh {{files}}"
+            }
+        }
+    }
+}
+EOF
+
+    echo "old" > test.txt
+
+    run hk fix test.txt
+    assert_success
+
+    run cat test.txt
+    assert_output "new"
+}
+
+@test "check_diff-only step stages an applied patch" {
+    cat <<'SCRIPT' > formatter.sh
+#!/bin/bash
+file="$1"
+if [[ "$(cat "$file")" == "old" ]]; then
+    echo "--- a/$file"
+    echo "+++ b/$file"
+    echo "@@ -1 +1 @@"
+    echo "-old"
+    echo "+new"
+    exit 1
+fi
+SCRIPT
+    chmod +x formatter.sh
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "none"
+        steps {
+            ["fmt"] {
+                glob = List("*.txt")
+                check_diff = "./formatter.sh {{files}}"
+            }
+        }
+    }
+}
+EOF
+
+    echo "base" > test.txt
+    git add .
+    git commit -m base
+    echo "old" > test.txt
+    git add test.txt
+
+    run hk run pre-commit
+    assert_success
+
+    run git show :test.txt
+    assert_output "new"
+}

--- a/test/command_effects.bats
+++ b/test/command_effects.bats
@@ -181,7 +181,7 @@ hooks {
 EOF
     touch input.txt
     git add .
-    git commit -m init
+    git commit -m "test: initialize fixture"
 
     run hk fix --all --safe
     assert_failure

--- a/test/command_effects.bats
+++ b/test/command_effects.bats
@@ -157,6 +157,38 @@ EOF
     assert_file_not_exists fix-ran
 }
 
+@test "safe mode validates checks configured after diff application" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["fix"] {
+        fix = true
+        steps {
+            ["partial"] {
+                check_diff = new CommandSpec {
+                    command = "false"
+                    effect = "read"
+                }
+                check = new CommandSpec {
+                    command = "touch check-ran"
+                    effect = "destructive"
+                }
+                check_after_diff = true
+            }
+        }
+    }
+}
+EOF
+    touch input.txt
+    git add .
+    git commit -m init
+
+    run hk fix --all --safe
+    assert_failure
+    assert_output --partial "partial.check: effect is destructive"
+    assert_file_not_exists check-ran
+}
+
 @test "safe mode ignores check-first commands that no job will use" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"


### PR DESCRIPTION
## Summary

- add an opt-in `check_after_diff` setting for partial fixers
- rerun `check` on the original file batch after a diff applies so non-fixable findings remain visible
- retain fix-mode write locks while `check_diff` runs and stage patches from check-diff-only steps
- include the recheck command in effect planning and safe-mode preflight

This is a prerequisite for #1237. It keeps ShellCheck on hk's `check_diff` path without forcing every complete formatter to pay for a second invocation. The same setting can be adopted by other partial fixers such as rumdl, ryl, ryl_markdown, and zizmor.

## Testing

- `mise run test:cargo`
- `mise run test:bats test/apply_check_diff.bats`
- `mise run test:bats test/command_effects.bats`
- `cargo fmt --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fix-mode execution, git staging, locking, and safe-mode command planning; mistakes could hide failures or race concurrent writers, but behavior is opt-in and covered by new integration tests.
> 
> **Overview**
> Adds an opt-in **`check_after_diff`** step flag (default `false`) for tools whose `check_diff` patch only fixes part of what `check` reports. After a successful diff apply in fix mode, hk can **rerun `check` on the original file batch** so remaining issues (e.g. unfixable lint) still fail the hook instead of being masked by a clean apply.
> 
> Related behavior changes: **`requested_run_type`** keeps fix-mode **write locks** while check-first runs `check_diff`; **check-first** and default **staging** also apply to **`check_diff`-only** steps (no `fix`); command **planning/safe-mode** includes the optional post-diff `check`. Config validation requires both `check` and `check_diff` when the flag is enabled.
> 
> Docs in `configuration.md` describe when to enable it vs leaving complete formatters on the single-command path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fee7ab68c66a5a1dccc9c6a810e24be3f6cb2272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `check_after_diff` to rerun checks after partial fixes are applied.
  - Added validation requiring both `check` and `check_diff` when this option is enabled.
  - Improved staging and file handling for diff-based fixes.

- **Bug Fixes**
  - Checks now rerun reliably against the original files after applying a diff.
  - Safe mode blocks destructive post-diff checks when configuration validation fails.

- **Documentation**
  - Documented the `check_after_diff` setting and recommended usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->