### PR TITLE
feat(builtins): add golangci_lint_fmt formatter

### DIFF
--- a/pkl/builtins/golangci_lint_fmt.pkl
+++ b/pkl/builtins/golangci_lint_fmt.pkl
@@ -1,0 +1,37 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+import "./test/helpers.pkl"
+
+@Builtins.meta {
+  category = "Go"
+  description = "Go formatter (part of golangci-lint)"
+  project_indicators {
+    new { file = "go.mod" }
+  }
+}
+golangci_lint_fmt = new Config.Step {
+  glob = "**/*.go"
+  // The formatter half of golangci-lint, separate from `run` so a project can
+  // format without paying for the linters. `fmt` takes a `--diff` flag that
+  // `run` has no equivalent for, so unlike `golangci_lint` this can use
+  // check_diff and let hk apply the patch. It also accepts explicit file paths
+  // rather than needing `./...`, so it formats only the files that changed and
+  // needs no workspace resolution.
+  check_diff = new Config.CommandSpec {
+    command = new Config.Command { argv = List("golangci-lint", "fmt", "--diff", "{{files}}") }
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = new Config.Command { argv = List("golangci-lint", "fmt", "{{files}}") }
+    effect = "write"
+  }
+  tests {
+    local const testMaker = new helpers.TestMaker { filename = "test.go" }
+    local const before = "package main\n\nfunc main() {\nprintln(\"hi\")\n}\n"
+    local const after = "package main\n\nfunc main() {\n\tprintln(\"hi\")\n}\n"
+    ["check bad file"] = testMaker.checkFail(before, 1)
+    ["check good file"] = testMaker.checkPass(after)
+    ["fix bad file"] = testMaker.fixPass(before, after)
+    ["fix good file"] = testMaker.fixPass(after, after)
+  }
+}


### PR DESCRIPTION
Adds a builtin for `golangci-lint fmt`, the formatter half of golangci-lint.

## Why a second golangci-lint builtin

`golangci_lint` already exists, but it wraps `golangci-lint run` — the linters. `fmt` is a separate subcommand with its own formatters, so this lets a project format without paying for a full lint run.

The two subcommands also have different capabilities, which changes how each can be modeled:

- **`run` has no `--diff` flag**, so `golangci_lint` can only offer `run --fix=false` / `run --fix`.
- **`fmt` has `-d, --diff`** ("Display diffs instead of rewriting files"), so this builtin can use `check_diff` and let hk apply the patch directly instead of spawning a fixer.

`fmt` also accepts explicit file paths rather than requiring `./...`, so it formats only the files that changed and needs no `workspace_indicator`/`dir` — unlike `golangci_lint`, which has to resolve the module and run `./...`.

```pkl
check_diff = new Config.CommandSpec {
  command = new Config.Command { argv = List("golangci-lint", "fmt", "--diff", "{{files}}") }
  effect = "read"
}
fix = new Config.CommandSpec {
  command = new Config.Command { argv = List("golangci-lint", "fmt", "{{files}}") }
  effect = "write"
}
```

## Verified (golangci-lint 2.13.1)

- `fmt --diff` on an unformatted file → diff on stdout, exit 1; on a clean file → empty, exit 0. `fmt` in place → rewrites, exit 0.
- The diff is gofmt-style (`--- test.go.orig`, no `a/` `b/` prefixes), which hk's `apply_diff_output` already normalizes — same shape as `go_fmt`.
- Works with relative paths from the repo root, including into a nested module, and with no `go.mod` present at all.
- End-to-end `hk fix --all` with a wrapper counting invocations: **one** call (`fmt --diff main.go`), file formatted, fixer never spawned — the `check_diff` fast path engaging as intended.

## Testing

Four builtin tests (check/fix × bad/good) via `hk test --step golangci_lint_fmt`, all passing. Reuses the existing `golangci-lint` tool stub — no new stub needed.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.231.*