### PR TITLE
fix(builtins): recheck partial diff fixes

### DIFF
--- a/pkl/builtins/pinact_v3.pkl
+++ b/pkl/builtins/pinact_v3.pkl
@@ -9,12 +9,19 @@ import "./test/helpers.pkl"
 }
 const pinact_v3 = (pinact.pinact) {
   // pinact v3 calls this flag `verify`; v4 renamed it to `verify-comment`.
+  check = new Config.CommandSpec {
+    command = new Config.Command {
+      argv = List("pinact", "run", "--verify", "--check", "{{files}}")
+    }
+    effect = "read"
+  }
   check_diff = new Config.CommandSpec {
     command = new Config.Command {
       argv = List("pinact", "run", "--verify", "--check", "{{files}}")
     }
     effect = "read"
   }
+  check_after_diff = true
   fix = new Config.CommandSpec {
     command = new Config.Command { argv = List("pinact", "run", "--verify", "{{files}}") }
     effect = "write"

--- a/pkl/builtins/rumdl.pkl
+++ b/pkl/builtins/rumdl.pkl
@@ -8,10 +8,15 @@ import "./test/helpers.pkl"
 }
 rumdl = new Config.Step {
   glob = List("**/*.md", "**/*.markdown")
+  check = new Config.CommandSpec {
+    command = new Config.Command { argv = List("rumdl", "check", "{{files}}") }
+    effect = "read"
+  }
   check_diff = new Config.CommandSpec {
     command = new Config.Command { argv = List("rumdl", "check", "--diff", "{{files}}") }
     effect = "read"
   }
+  check_after_diff = true
   fix = new Config.CommandSpec {
     command = new Config.Command { argv = List("rumdl", "check", "--fix", "{{files}}") }
     effect = "write"

--- a/pkl/builtins/ryl.pkl
+++ b/pkl/builtins/ryl.pkl
@@ -19,10 +19,15 @@ import "./test/helpers.pkl"
 }
 ryl = new Config.Step {
   types = List("yaml")
+  check = new Config.CommandSpec {
+    command = new Config.Command { argv = List("ryl", "{{files}}") }
+    effect = "read"
+  }
   check_diff = new Config.CommandSpec {
     command = new Config.Command { argv = List("ryl", "--diff", "{{files}}") }
     effect = "read"
   }
+  check_after_diff = true
   check_list_files = new Config.CommandSpec {
     command = new Config.Command { argv = List("ryl", "--list-files", "{{files}}") }
     effect = "read"

--- a/pkl/builtins/ryl_markdown.pkl
+++ b/pkl/builtins/ryl_markdown.pkl
@@ -19,10 +19,15 @@ import "./test/helpers.pkl"
 }
 ryl_markdown = new Config.Step {
   types = List("markdown")
+  check = new Config.CommandSpec {
+    command = new Config.Command { argv = List("ryl", "--markdown", "{{files}}") }
+    effect = "read"
+  }
   check_diff = new Config.CommandSpec {
     command = new Config.Command { argv = List("ryl", "--diff", "--markdown", "{{files}}") }
     effect = "read"
   }
+  check_after_diff = true
   check_list_files = new Config.CommandSpec {
     command = new Config.Command { argv = List("ryl", "--list-files", "--markdown", "{{files}}") }
     effect = "read"

--- a/pkl/builtins/zizmor.pkl
+++ b/pkl/builtins/zizmor.pkl
@@ -18,10 +18,15 @@ zizmor = new Config.Step {
       "**/action.yml",
       "**/action.yaml",
     )
+  check = new Config.CommandSpec {
+    command = new Config.Command { argv = List("zizmor", "--no-progress", "{{files}}") }
+    effect = "read"
+  }
   check_diff = new Config.CommandSpec {
     command = new Config.Command { argv = List("zizmor", "--no-progress", "{{files}}") }
     effect = "read"
   }
+  check_after_diff = true
   fix = new Config.CommandSpec {
     command = new Config.Command { argv = List("zizmor", "--no-progress", "--fix", "{{files}}") }
     effect = "write"


### PR DESCRIPTION
## Summary

- enable `check_after_diff` for the five builtins with demonstrated partial-fix cases
- add regular check commands so remaining violations are reported after hk applies each generated patch
- cover rumdl, ryl, ryl_markdown, zizmor, and legacy pinact_v3

These builtins already have `fixFail` tests showing that their fixers can modify a file while leaving violations behind. Before #1243, the production `check_diff` fast path could apply the available patch and return success without surfacing those remaining violations.

## Testing

- pinned-tool `hk test` suites for rumdl, ryl, ryl_markdown, zizmor, and pinact_v3
- `mise run test:bats test/builtin_effects.bats`
- `pkl format --diff-name-only` on all changed builtins
- `mise run pkl:gen`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Builtin Pkl config only; tightens lint/check behavior for five tools with no changes to core runtime, auth, or data handling.
> 
> **Overview**
> **Fixes false passes when builtins apply a partial fix via the `check_diff` path** by turning on `check_after_diff` and defining a full-file `check` command for **rumdl**, **ryl**, **ryl_markdown**, **zizmor**, and **pinact_v3**.
> 
> After hk applies a nonempty diff in fix mode, it reruns the normal `check` on the batch so tools that can fix some issues but not all (already covered by existing `fixFail` tests) still fail with remaining violations instead of succeeding once the patch applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feb5417f9db5fa2df817e86802cc4c33d51d40ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->