### PR TITLE
fix(builtins): correct gitleaks scan modes

### DIFF
--- a/pkl/builtins/gitleaks.pkl
+++ b/pkl/builtins/gitleaks.pkl
@@ -10,7 +10,6 @@ import "./test/helpers.pkl"
   }
 }
 gitleaks = new Config.Step {
-  types = List("text")
   // gitleaks dir accepts exactly one path. Passing multiple files makes it silently scan ".".
   // Reference: https://github.com/gitleaks/gitleaks/blob/v8.30.1/cmd/directory.go#L22-L30
   check = new Config.CommandSpec {

--- a/pkl/builtins/gitleaks.pkl
+++ b/pkl/builtins/gitleaks.pkl
@@ -4,17 +4,18 @@ import "./test/helpers.pkl"
 
 @Builtins.meta {
   category = "Secrets"
-  description = "Secret scanner for Git repositories"
+  description = "Secret scanner for repository working trees"
   project_indicators {
     new { file = ".gitleaks.toml" }
   }
 }
 gitleaks = new Config.Step {
   types = List("text")
-  // Reference: https://github.com/gitleaks/gitleaks/blob/v8.30.1/.pre-commit-hooks.yaml#L4
+  // gitleaks dir accepts exactly one path. Passing multiple files makes it silently scan ".".
+  // Reference: https://github.com/gitleaks/gitleaks/blob/v8.30.1/cmd/directory.go#L22-L30
   check = new Config.CommandSpec {
     command = new Config.Command {
-      argv = List("gitleaks", "dir", "--redact", "--verbose", "--no-banner", "{{files}}")
+      argv = List("gitleaks", "dir", "--redact", "--verbose", "--no-banner", ".")
     }
     effect = "read"
   }
@@ -23,5 +24,15 @@ gitleaks = new Config.Step {
     // Reference: https://github.com/gitleaks/gitleaks/blob/v8.30.1/testdata/repos/nogit/api.go#L20
     ["check bad file"] = testMaker.checkFail("awsToken = AKIALALEMEL33243OLIA", 1)
     ["check good file"] = testMaker.checkPass("message = foobar")
+    ["check whole tree beyond selected files"] =
+      (
+        new helpers.TestMaker {
+          filename = "unselected.txt"
+          files = List("selected.txt")
+          extra_files {
+            ["selected.txt"] = "message = foobar"
+          }
+        }
+      ).checkFail("awsToken = AKIALALEMEL33243OLIA", 1)
   }
 }

--- a/pkl/builtins/gitleaks_staged.pkl
+++ b/pkl/builtins/gitleaks_staged.pkl
@@ -1,0 +1,63 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+import "./test/helpers.pkl"
+
+@Builtins.meta {
+  category = "Secrets"
+  description = "Secret scanner for staged Git changes"
+  project_indicators {
+    new { file = ".gitleaks.toml" }
+  }
+}
+gitleaks_staged = new Config.Step {
+  types = List("text")
+  // Reference: https://github.com/gitleaks/gitleaks/blob/v8.30.1/.pre-commit-hooks.yaml#L1-L5
+  check = new Config.CommandSpec {
+    command = new Config.Command {
+      argv =
+        List(
+          "gitleaks",
+          "git",
+          "--pre-commit",
+          "--redact",
+          "--staged",
+          "--verbose",
+          "--no-banner",
+        )
+    }
+    effect = "read"
+  }
+  tests {
+    local const testMaker = new helpers.TestMaker {
+      filename = "foo.txt"
+      before = "git init --quiet && git add foo.txt"
+    }
+    // Reference: https://github.com/gitleaks/gitleaks/blob/v8.30.1/testdata/repos/nogit/api.go#L20
+    ["check bad staged file"] = testMaker.checkFail("awsToken = AKIALALEMEL33243OLIA", 1)
+    ["check good staged file"] = testMaker.checkPass("message = foobar")
+    ["ignore unstaged files"] =
+      (
+        new helpers.TestMaker {
+          filename = "foo.txt"
+          before = "git init --quiet && git add foo.txt"
+          extra_files {
+            ["unstaged.txt"] = "awsToken = AKIALALEMEL33243OLIA"
+          }
+        }
+      ).checkPass("message = foobar")
+    ["check staged content instead of worktree"] = new Config.StepTest {
+      files = List("foo.txt")
+      tmpdir = true
+      write {
+        ["foo.txt"] = "awsToken = AKIALALEMEL33243OLIA"
+      }
+      before = "git init --quiet && git add foo.txt && printf 'message = foobar' > foo.txt"
+      expect = new Config.StepTestExpect {
+        code = 1
+        files {
+          ["foo.txt"] = "message = foobar"
+        }
+      }
+    }
+  }
+}

--- a/pkl/builtins/gitleaks_staged.pkl
+++ b/pkl/builtins/gitleaks_staged.pkl
@@ -5,12 +5,8 @@ import "./test/helpers.pkl"
 @Builtins.meta {
   category = "Secrets"
   description = "Secret scanner for staged Git changes"
-  project_indicators {
-    new { file = ".gitleaks.toml" }
-  }
 }
 gitleaks_staged = new Config.Step {
-  types = List("text")
   // Reference: https://github.com/gitleaks/gitleaks/blob/v8.30.1/.pre-commit-hooks.yaml#L1-L5
   check = new Config.CommandSpec {
     command = new Config.Command {


### PR DESCRIPTION
## Summary

- make `Builtins.gitleaks` explicitly scan the repository working tree instead of changing behavior when `{{files}}` expands to multiple paths
- add `Builtins.gitleaks_staged` for pre-commit hooks using gitleaks’ staged Git diff mode
- cover whole-tree selection, unstaged-file exclusion, and staged-index versus working-tree content

Closes the behavior reported in https://github.com/jdx/hk/discussions/1246.

## Testing

- `mise run build`
- `PATH="$PWD/test/builtin_tool_stubs:$PATH" cargo run --quiet --bin hk -- test --step gitleaks`
- `PATH="$PWD/test/builtin_tool_stubs:$PATH" cargo run --quiet --bin hk -- test --step gitleaks_staged`
- `pkl eval pkl/Builtins.pkl --format json`
- `MISE_SHELLCHECK_VERSION=0.11.0 mise run lint` (all code and format checks passed; docs build stopped because the generated docs environment could not resolve `@vitejs/plugin-vue`)

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default secret-scan scope for `gitleaks` (whole tree vs per-file list) and introduces a new builtin users may wire into hooks; behavior is intentional but affects security-sensitive pre-commit flows.
> 
> **Overview**
> Fixes **gitleaks** so it always scans the repo working tree with `gitleaks dir … .` instead of passing `{{files}}`, which could make gitleaks silently fall back to scanning `.` when multiple paths were expanded. The step no longer declares `types = List("text")`, and metadata now describes a working-tree scanner. A regression test asserts secrets are still found outside the hook’s selected file list.
> 
> Adds **`gitleaks_staged`**, a new builtin that runs `gitleaks git --pre-commit --staged` for pre-commit-style checks on the index only, with tests for bad/good staged content, ignoring unstaged secrets, and scanning staged bytes when the worktree differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7915d56079dc54eb1dc243f8267337dacacff6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->