### PR TITLE
chore(sponsors): replace 37signals with omacom foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See docs: https://hk.jdx.dev/
 
 ## Sponsors
 
-hk is sponsored by [entire.io](https://entire.io) and [37signals](https://37signals.com).
+hk is sponsored by [entire.io](https://entire.io) and [Omacom Foundation](https://omarchy.org/patrons/).
 
 [View all sponsors](https://jdx.dev/sponsors.html).
 

--- a/src/cli/sponsors.rs
+++ b/src/cli/sponsors.rs
@@ -8,7 +8,7 @@ pub struct Sponsors;
 impl Sponsors {
     pub async fn run(&self) -> Result<()> {
         println!(
-            "hk and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+            "hk and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  Omacom Foundation - https://omarchy.org/patrons/\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- replace 37signals with the Omacom Foundation in the README
- update the `hk sponsors` output and foundation link

## Verification
- `cargo fmt --all --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*