### PR TITLE
chore: automate generated cli versions

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -7877,7 +7877,7 @@
     "sources": {},
     "files": []
   },
-  "version": "1.56.0",
+  "version": "1.56.1",
   "usage": "",
   "complete": {
     "directory": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage:** `hk [FLAGS] <SUBCOMMAND>`
 
-**Version:** 1.56.0
+**Version:** 1.56.1
 
 - **Usage:** `hk [FLAGS] <SUBCOMMAND>`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name hk
 bin hk
-version "1.56.0"
+version "1.56.1"
 unknown_flags error
 subcommand_required #true
 flagset hook-options {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,3 @@
-use crate::version as version_lib;
 use std::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -30,13 +29,7 @@ mod validate;
 mod version;
 
 #[derive(usage_rs::Cli)]
-#[usage(
-    name = "hk",
-    version = version_lib::version(),
-    version_spec = "1.56.0",
-    unknown_flags = "error",
-    completion
-)]
+#[usage(name = "hk", version, unknown_flags = "error", completion)]
 struct Cli {
     /// Run as if hk was started in this directory
     #[usage(long, global, value_name = "DIRECTORY", value_hint = ValueHint::DirPath)]


### PR DESCRIPTION
## Summary

- derive the portable CLI usage version from `CARGO_PKG_VERSION`
- let the existing release-plz render step update `hk.usage.kdl` and generated CLI docs after `cargo set-version`
- synchronize the currently stale generated artifacts with version 1.56.1

## Verification

- `mise run render:usage`
- `cargo test cli::` (164 passed)
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release and documentation tooling only; no change to hook execution or security-sensitive logic beyond consistent version strings in generated CLI artifacts.
> 
> **Overview**
> Stops hardcoding a separate **`version_spec`** on the root `Cli` usage derive and relies on the bare **`version`** attribute so portable CLI metadata (including **`hk usage`** output) stays tied to **`CARGO_PKG_VERSION`**, matching how **`hk version`** already reports the crate version.
> 
> Regenerates **`hk.usage.kdl`**, **`docs/cli/index.md`**, and **`docs/cli/commands.json`** so they show **1.56.1** instead of the stale **1.56.0**, aligning generated docs with the current **`Cargo.toml`** version after release-plz’s existing **`mise run render`** step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 061f07a5ee005104dd43cdcbdaae12df3a043b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented CLI version to 1.56.1 across the command reference and usage metadata.
* **Chores**
  * Refined CLI version metadata handling without changing user-facing commands or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->