### PR TITLE
feat(config)!: add shared top-level steps

### DIFF
--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -226,10 +226,19 @@ terminal_progress: Boolean?
 /// Default: true
 walk_ignore: Boolean?
 
+/// Steps declared here are shared by the implicit `check`, `fix`, and `pre-commit`
+/// hooks. Explicit hook steps with the same name override these definitions.
+steps: Mapping<String, Step | Group> = new Mapping<String, Step> {}
+
 /// Hooks define when and how linters are run. See [hooks](https://hk.jdx.dev/hooks) for more information.
 hooks: Mapping<String, Hook> = new Mapping<String, Hook> {}
 
 class Hook {
+  /// Whether this hook should run and be installed.
+  ///
+  /// Set this to false to disable an implicit hook created by top-level `steps`.
+  enabled: Boolean = true
+
   /// Default: `false` (`true` for `fix` hook)
   ///
   /// If true, hk will run the fix command for each step (if it exists) to make modifications.

--- a/src/cli/init/generator.rs
+++ b/src/cli/init/generator.rs
@@ -23,41 +23,33 @@ import "package://github.com/jdx/hk/releases/download/v{version}/hk@{version}#/B
     }
     output.push_str("}\n\n");
 
-    // Generate hooks section
-    output.push_str("hooks {\n");
+    output.push_str("steps = linters\n");
 
-    for hook in hooks {
-        match hook.as_str() {
-            "pre-commit" => {
-                output.push_str(
-                    r#"    ["pre-commit"] {
-        fix = true
-        stash = "git"
-        steps = linters
+    let implicit_hooks = ["pre-commit", "check", "fix"];
+    let disabled_hooks = implicit_hooks
+        .iter()
+        .filter(|name| !hooks.iter().any(|hook| hook == **name))
+        .collect::<Vec<_>>();
+    let explicit_hooks = hooks
+        .iter()
+        .filter(|hook| !implicit_hooks.contains(&hook.as_str()))
+        .collect::<Vec<_>>();
+
+    if disabled_hooks.is_empty() && explicit_hooks.is_empty() {
+        return output;
     }
-"#,
-                );
-            }
+
+    output.push_str("\nhooks {\n");
+    for hook in disabled_hooks {
+        output.push_str(&format!(
+            "    [\"{hook}\"] {{\n        enabled = false\n    }}\n"
+        ));
+    }
+    for hook in explicit_hooks {
+        match hook.as_str() {
             "pre-push" => {
                 output.push_str(
                     r#"    ["pre-push"] {
-        steps = linters
-    }
-"#,
-                );
-            }
-            "fix" => {
-                output.push_str(
-                    r#"    ["fix"] {
-        fix = true
-        steps = linters
-    }
-"#,
-                );
-            }
-            "check" => {
-                output.push_str(
-                    r#"    ["check"] {
         steps = linters
     }
 "#,
@@ -79,7 +71,7 @@ pub fn generate_default_template(version: &str) -> String {
 import "package://github.com/jdx/hk/releases/download/v{version}/hk@{version}#/Builtins.pkl"
 // Using a coding agent? See https://hk.jdx.dev/agents
 
-local linters = new Mapping {{
+steps {{
     // Add linters here. Examples:
     // ["prettier"] = Builtins.prettier
     // ["eslint"] = Builtins.eslint
@@ -90,21 +82,6 @@ local linters = new Mapping {{
     //     glob = "**/*.py"
     //     check = "mypy {{{{ files }}}}"
     // }}
-}}
-
-hooks {{
-    ["pre-commit"] {{
-        fix = true
-        stash = "git"
-        steps = linters
-    }}
-    ["fix"] {{
-        fix = true
-        steps = linters
-    }}
-    ["check"] {{
-        steps = linters
-    }}
 }}
 "#
     )
@@ -121,18 +98,24 @@ mod tests {
         let pkl = generate_pkl(&[], &hooks, "1.34.0");
         assert!(pkl.contains("amends"));
         assert!(pkl.contains("hooks"));
+        assert!(pkl.contains("[\"pre-commit\"]"));
+        assert!(pkl.contains("enabled = false"));
     }
 
     #[test]
     fn test_generate_pkl_with_builtins() {
         let prettier = BUILTINS_META.iter().find(|b| b.name == "prettier").unwrap();
         let builtins = vec![prettier];
-        let hooks = vec!["pre-commit".to_string(), "check".to_string()];
+        let hooks = vec![
+            "pre-commit".to_string(),
+            "check".to_string(),
+            "fix".to_string(),
+        ];
         let pkl = generate_pkl(&builtins, &hooks, "1.34.0");
 
         assert!(pkl.contains("Builtins.prettier"));
-        assert!(pkl.contains("[\"pre-commit\"]"));
-        assert!(pkl.contains("[\"check\"]"));
+        assert!(pkl.contains("steps = linters"));
+        assert!(!pkl.contains("hooks {"));
     }
 
     #[test]

--- a/src/cli/init/generator.rs
+++ b/src/cli/init/generator.rs
@@ -46,16 +46,13 @@ import "package://github.com/jdx/hk/releases/download/v{version}/hk@{version}#/B
         ));
     }
     for hook in explicit_hooks {
-        match hook.as_str() {
-            "pre-push" => {
-                output.push_str(
-                    r#"    ["pre-push"] {
+        if hook == "pre-push" {
+            output.push_str(
+                r#"    ["pre-push"] {
         steps = linters
     }
 "#,
-                );
-            }
-            _ => {}
+            );
         }
     }
 

--- a/src/cli/init/generator.rs
+++ b/src/cli/init/generator.rs
@@ -25,7 +25,7 @@ import "package://github.com/jdx/hk/releases/download/v{version}/hk@{version}#/B
 
     output.push_str("steps = linters\n");
 
-    let implicit_hooks = ["pre-commit", "check", "fix"];
+    let implicit_hooks = ["pre-commit"];
     let disabled_hooks = implicit_hooks
         .iter()
         .filter(|name| !hooks.iter().any(|hook| hook == **name))
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn test_generate_pkl_empty() {
-        let hooks = vec!["check".to_string()];
+        let hooks = vec![];
         let pkl = generate_pkl(&[], &hooks, "1.34.0");
         assert!(pkl.contains("amends"));
         assert!(pkl.contains("hooks"));
@@ -103,11 +103,7 @@ mod tests {
     fn test_generate_pkl_with_builtins() {
         let prettier = BUILTINS_META.iter().find(|b| b.name == "prettier").unwrap();
         let builtins = vec![prettier];
-        let hooks = vec![
-            "pre-commit".to_string(),
-            "check".to_string(),
-            "fix".to_string(),
-        ];
+        let hooks = vec!["pre-commit".to_string()];
         let pkl = generate_pkl(&builtins, &hooks, "1.34.0");
 
         assert!(pkl.contains("Builtins.prettier"));
@@ -118,7 +114,7 @@ mod tests {
     #[test]
     fn test_generate_pkl_with_builtin_options() {
         let gitleaks = BUILTINS_META.iter().find(|b| b.name == "gitleaks").unwrap();
-        let pkl = generate_pkl(&[gitleaks], &["check".to_string()], "1.34.0");
+        let pkl = generate_pkl(&[gitleaks], &["pre-commit".to_string()], "1.34.0");
 
         assert!(pkl.contains("Builtins.gitleaks"));
     }

--- a/src/cli/init/mod.rs
+++ b/src/cli/init/mod.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use crate::{Result, env};
 
 /// Default hooks to configure when none are specified
-pub(crate) const DEFAULT_HOOKS: &[&str] = &["pre-commit", "check", "fix"];
+pub(crate) const DEFAULT_HOOKS: &[&str] = &["pre-commit"];
 
 /// Generate a new hk.pkl file for a project
 #[derive(Debug, usage_rs::Args)]

--- a/src/cli/init/picker.rs
+++ b/src/cli/init/picker.rs
@@ -56,8 +56,6 @@ pub fn pick_builtins(detected: &[Detection]) -> Result<Vec<&'static BuiltinMeta>
 pub fn pick_hooks() -> Result<Vec<String>> {
     let hooks = vec![
         ("pre-commit", "Run linters before committing"),
-        ("check", "Manual check command (hk check)"),
-        ("fix", "Manual fix command (hk fix)"),
         ("pre-push", "Run linters before pushing"),
     ];
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -167,10 +167,7 @@ fn global_hook_command(use_mise: bool) -> Result<OsString> {
 
 fn global_hook_events() -> Result<Vec<String>> {
     if Config::project_config_exists() {
-        let events = hook_events(&Config::get()?);
-        if !events.is_empty() {
-            return Ok(events);
-        }
+        return Ok(hook_events(&Config::get()?));
     }
     Ok(CORE_GLOBAL_EVENTS
         .iter()

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -181,9 +181,9 @@ fn global_hook_events() -> Result<Vec<String>> {
 fn hook_events(config: &Config) -> Vec<String> {
     config
         .hooks
-        .keys()
-        .filter(|h| h.as_str() != "check" && h.as_str() != "fix")
-        .cloned()
+        .iter()
+        .filter(|(name, hook)| hook.enabled && name.as_str() != "check" && name.as_str() != "fix")
+        .map(|(name, _)| name.clone())
         .collect()
 }
 
@@ -615,6 +615,23 @@ mod tests {
             hook_run_args("pre-commit", false),
             OsString::from(r#" run pre-commit --from-hook"#)
         );
+    }
+
+    #[test]
+    fn disabled_hooks_are_not_installable_events() {
+        let mut config = Config::default();
+        config.hooks.insert(
+            "pre-commit".to_string(),
+            crate::hook::Hook {
+                enabled: false,
+                ..Default::default()
+            },
+        );
+        config
+            .hooks
+            .insert("pre-push".to_string(), crate::hook::Hook::default());
+
+        assert_eq!(hook_events(&config), vec!["pre-push"]);
     }
 
     #[cfg(unix)]

--- a/src/cli/migrate/mod.rs
+++ b/src/cli/migrate/mod.rs
@@ -39,6 +39,8 @@ pub struct HkConfig {
     pub header_comments: Vec<String>,
     /// Named step collections (e.g., "linters", "local_hooks", "custom_steps")
     pub step_collections: IndexMap<String, IndexMap<String, HkStep>>,
+    /// Steps shared by the implicit check, fix, and pre-commit hooks.
+    pub steps: IndexMap<String, HkStep>,
     /// Hook configurations
     pub hooks: IndexMap<String, HkHook>,
 }
@@ -150,6 +152,14 @@ impl HkConfig {
 
             output.push_str(&format!("local {} = new Mapping {{\n", name));
             for (id, step) in steps {
+                output.push_str(&self.format_step(id, step, 1));
+            }
+            output.push_str("}\n\n");
+        }
+
+        if !self.steps.is_empty() {
+            output.push_str("steps {\n");
+            for (id, step) in &self.steps {
                 output.push_str(&self.format_step(id, step, 1));
             }
             output.push_str("}\n\n");

--- a/src/cli/migrate/mod.rs
+++ b/src/cli/migrate/mod.rs
@@ -39,6 +39,8 @@ pub struct HkConfig {
     pub header_comments: Vec<String>,
     /// Named step collections (e.g., "linters", "local_hooks", "custom_steps")
     pub step_collections: IndexMap<String, IndexMap<String, HkStep>>,
+    /// Top-level steps that reference their canonical generated collection.
+    pub step_references: IndexMap<String, String>,
     /// Steps shared by the implicit check, fix, and pre-commit hooks.
     pub steps: IndexMap<String, HkStep>,
     /// Hook configurations
@@ -157,8 +159,11 @@ impl HkConfig {
             output.push_str("}\n\n");
         }
 
-        if !self.steps.is_empty() {
+        if !self.step_references.is_empty() || !self.steps.is_empty() {
             output.push_str("steps {\n");
+            for (id, collection) in &self.step_references {
+                output.push_str(&format!("    [\"{}\"] = {}[\"{}\"]\n", id, collection, id));
+            }
             for (id, step) in &self.steps {
                 output.push_str(&self.format_step(id, step, 1));
             }

--- a/src/cli/migrate/pre_commit.rs
+++ b/src/cli/migrate/pre_commit.rs
@@ -336,14 +336,30 @@ impl PreCommit {
                 .insert("manual_steps".to_string(), manual_steps);
         }
 
+        // Pre-commit steps are the shared v2 defaults. The implicit check and
+        // fix hooks inherit them, while their explicit definitions below add
+        // any manual or non-pre-commit steps.
+        if let Some(pre_commit_steps) = steps_by_stage.get("pre-commit") {
+            for (id, collection) in pre_commit_steps {
+                if let Some(step) = hk_config
+                    .step_collections
+                    .get(collection)
+                    .and_then(|steps| steps.get(id))
+                {
+                    hk_config.steps.insert(id.clone(), step.clone());
+                }
+            }
+        }
+
         // Generate hooks
         let has_steps = !hk_config.step_collections.is_empty();
 
         // Create hooks for each stage (except manual, which goes to check/fix)
         let mut stages_used = HashSet::new();
         for stage in steps_by_stage.keys() {
-            // Skip manual stage - those steps will be added to check/fix hooks
-            if stage == "manual" {
+            // Manual steps are added to check/fix, and pre-commit is implicit
+            // from the shared top-level steps.
+            if stage == "manual" || stage == "pre-commit" {
                 continue;
             }
 

--- a/src/cli/migrate/pre_commit.rs
+++ b/src/cli/migrate/pre_commit.rs
@@ -341,13 +341,9 @@ impl PreCommit {
         // any manual or non-pre-commit steps.
         if let Some(pre_commit_steps) = steps_by_stage.get("pre-commit") {
             for (id, collection) in pre_commit_steps {
-                if let Some(step) = hk_config
-                    .step_collections
-                    .get(collection)
-                    .and_then(|steps| steps.get(id))
-                {
-                    hk_config.steps.insert(id.clone(), step.clone());
-                }
+                hk_config
+                    .step_references
+                    .insert(id.clone(), collection.clone());
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1078,6 +1078,9 @@ pub struct Config {
     pub min_hk_version: Option<String>,
     #[serde(default)]
     pub steps: IndexMap<String, crate::hook::StepOrGroup>,
+    #[serde(skip)]
+    #[serde(default)]
+    default_hooks_materialized: bool,
     #[serde(default)]
     pub hooks: IndexMap<String, Hook>,
     /// Preferred default branch to compare against (e.g. "main"). If not set, hk will detect it.
@@ -1113,7 +1116,7 @@ impl std::fmt::Display for Config {
 
 impl Config {
     fn materialize_default_hooks(&mut self) -> Result<()> {
-        if self.steps.is_empty() {
+        if self.default_hooks_materialized || self.steps.is_empty() {
             return Ok(());
         }
 
@@ -1138,6 +1141,7 @@ impl Config {
             hook.stash = hook.stash.clone().or(stash);
             hook.init(name)?;
         }
+        self.default_hooks_materialized = true;
         Ok(())
     }
 
@@ -1517,6 +1521,41 @@ mod tests {
             };
             assert_eq!(lint.dir.as_deref(), Some("packages/web"));
         }
+    }
+
+    #[test]
+    fn rematerializing_does_not_apply_root_hook_env_to_subproject_steps() {
+        let mut root = Config::default();
+        root.steps.insert(
+            "root".to_string(),
+            StepOrGroup::Step(Box::new(step("root"))),
+        );
+        let mut root_check = hook("check");
+        root_check
+            .env
+            .insert("ROOT_ONLY".to_string(), "root".to_string());
+        root.hooks.insert("check".to_string(), root_check);
+        root.materialize_default_hooks().unwrap();
+
+        let mut sub = Config::default();
+        sub.env
+            .insert("SUB_ONLY".to_string(), "subproject".to_string());
+        sub.steps.insert(
+            "lint".to_string(),
+            StepOrGroup::Step(Box::new(step("lint"))),
+        );
+        root.merge_subproject("packages/web", None, sub).unwrap();
+
+        root.materialize_default_hooks().unwrap();
+
+        let StepOrGroup::Step(lint) = &root.hooks["check"].steps["packages/web:lint"] else {
+            panic!("expected step");
+        };
+        assert_eq!(
+            lint.env.get("SUB_ONLY").map(String::as_str),
+            Some("subproject")
+        );
+        assert!(!lint.env.contains_key("ROOT_ONLY"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,7 +152,7 @@ impl Config {
         let paths = Self::project_config_search_paths();
         if let Some(path) = Self::find_project_config(&paths) {
             let mut config = Self::load_config_cached(path)?;
-            config.apply_implicit_root_dir();
+            config.apply_implicit_root_dir()?;
             return Ok(config);
         }
         debug!("No config file found, using default");
@@ -171,9 +171,10 @@ impl Config {
     /// this config (before `load_subprojects` merges anything else in) a
     /// default `dir` for the offset from the work tree root to this config's
     /// own directory, the same way a subproject's steps get scoped to it.
-    fn apply_implicit_root_dir(&mut self) {
+    fn apply_implicit_root_dir(&mut self) -> Result<()> {
+        self.materialize_default_hooks()?;
         let Some(subdir) = Self::implicit_root_dir(&self.path) else {
-            return;
+            return Ok(());
         };
         for hook in self.hooks.values_mut() {
             for step_or_group in hook.steps.values_mut() {
@@ -190,6 +191,7 @@ impl Config {
                 }
             }
         }
+        Ok(())
     }
 
     /// The path from the git work tree root to the directory containing
@@ -729,6 +731,7 @@ impl Config {
         root_offset: Option<&str>,
         mut sub: Config,
     ) -> Result<()> {
+        sub.materialize_default_hooks()?;
         if sub.subprojects.as_ref().is_some_and(|s| !s.is_empty()) {
             warn!(
                 "subprojects: nested `subprojects` in {} is ignored (only one level is supported)",
@@ -1384,6 +1387,32 @@ mod tests {
     }
 
     #[test]
+    fn implicit_root_dir_scopes_materialized_top_level_steps() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        let project_dir = tmp.path().join("packages/web");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let mut config = Config {
+            path: project_dir.join("hk.pkl"),
+            ..Default::default()
+        };
+        config.steps.insert(
+            "lint".to_string(),
+            StepOrGroup::Step(Box::new(step("lint"))),
+        );
+
+        config.apply_implicit_root_dir().unwrap();
+
+        for hook_name in ["check", "fix", "pre-commit"] {
+            let StepOrGroup::Step(lint) = &config.hooks[hook_name].steps["lint"] else {
+                panic!("expected step");
+            };
+            assert_eq!(lint.dir.as_deref(), Some("packages/web"));
+        }
+    }
+
+    #[test]
     fn hkrc_top_level_steps_are_additive_and_project_wins() {
         let mut project = Config::default();
         project.steps.insert(
@@ -1469,6 +1498,25 @@ mod tests {
         assert_eq!(fmt.dir.as_deref(), Some("packages/web/nested"));
         // step env wins over subproject config env
         assert_eq!(fmt.env.get("FOO").map(String::as_str), Some("from-step"));
+    }
+
+    #[test]
+    fn merge_subproject_materializes_top_level_steps() {
+        let mut root = Config::default();
+        let mut sub = Config::default();
+        sub.steps.insert(
+            "lint".to_string(),
+            StepOrGroup::Step(Box::new(step("lint"))),
+        );
+
+        root.merge_subproject("packages/web", None, sub).unwrap();
+
+        for hook_name in ["check", "fix", "pre-commit"] {
+            let StepOrGroup::Step(lint) = &root.hooks[hook_name].steps["packages/web:lint"] else {
+                panic!("expected step");
+            };
+            assert_eq!(lint.dir.as_deref(), Some("packages/web"));
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -763,6 +763,9 @@ impl Config {
                     sub.path.display()
                 );
             }
+            if sub_hook_is_implicit && !self.hooks.contains_key(&hook_name) {
+                self.implicit_default_hooks.insert(hook_name.clone());
+            }
             let root_hook = self.hooks.entry(hook_name.clone()).or_insert_with(|| {
                 let mut hook = Hook {
                     name: hook_name.clone(),
@@ -1573,6 +1576,7 @@ mod tests {
                 panic!("expected step");
             };
             assert_eq!(lint.dir.as_deref(), Some("packages/web"));
+            assert!(root.implicit_default_hooks.contains(hook_name));
         }
         assert_eq!(root.hooks["check"].fix, Some(false));
         assert_eq!(root.hooks["check"].stage, Some(false));

--- a/src/config.rs
+++ b/src/config.rs
@@ -529,6 +529,9 @@ impl Config {
         // Hooks: additive, project wins on same-named step collision
         for (hook_name, hkrc_hook) in hkrc.hooks {
             if let Some(project_hook) = self.hooks.get_mut(&hook_name) {
+                if !hkrc_hook.enabled {
+                    continue;
+                }
                 for (step_name, hkrc_step) in hkrc_hook.steps {
                     project_hook.steps.entry(step_name).or_insert(hkrc_step);
                 }
@@ -747,13 +750,19 @@ impl Config {
             if !sub_hook.enabled {
                 continue;
             }
+            if sub_hook.fix.is_some()
+                || sub_hook.stash.is_some()
+                || sub_hook.stage.is_some()
+                || sub_hook.fail_on_fix
+                || sub_hook.report.is_some()
+            {
+                debug!(
+                    "subprojects: ignoring hook-level settings for '{hook_name}' in {}",
+                    sub.path.display()
+                );
+            }
             let root_hook = self.hooks.entry(hook_name.clone()).or_insert_with(|| Hook {
                 name: hook_name.clone(),
-                fix: sub_hook.fix,
-                stash: sub_hook.stash.clone(),
-                stage: sub_hook.stage,
-                fail_on_fix: sub_hook.fail_on_fix,
-                report: sub_hook.report.clone(),
                 ..Default::default()
             });
             // Names of the subproject hook's steps and groups, for rewriting
@@ -1460,6 +1469,33 @@ mod tests {
     }
 
     #[test]
+    fn hkrc_disabled_hook_does_not_add_steps_to_enabled_project_hook() {
+        let mut project = Config::default();
+        let mut project_check = hook("check");
+        project_check.steps.insert(
+            "project".to_string(),
+            StepOrGroup::Step(Box::new(step("project"))),
+        );
+        project.hooks.insert("check".to_string(), project_check);
+
+        let mut user = Config::default();
+        let mut user_check = hook("check");
+        user_check.enabled = false;
+        user_check.steps.insert(
+            "user".to_string(),
+            StepOrGroup::Step(Box::new(step("user"))),
+        );
+        user.hooks.insert("check".to_string(), user_check);
+
+        project.merge_from_hkrc(user);
+
+        let check = &project.hooks["check"];
+        assert!(check.enabled);
+        assert!(check.steps.contains_key("project"));
+        assert!(!check.steps.contains_key("user"));
+    }
+
+    #[test]
     fn merge_subproject_scopes_flat_steps() {
         let mut root = Config::default();
         let mut sub = Config::default();
@@ -1521,6 +1557,43 @@ mod tests {
             };
             assert_eq!(lint.dir.as_deref(), Some("packages/web"));
         }
+    }
+
+    #[test]
+    fn subproject_hook_settings_are_ignored_before_root_hook_materialization() {
+        let mut root = Config::default();
+        root.steps.insert(
+            "root".to_string(),
+            StepOrGroup::Step(Box::new(step("root"))),
+        );
+
+        let mut sub = Config::default();
+        sub.path = PathBuf::from("packages/web/hk.pkl");
+        let mut sub_check = hook("check");
+        sub_check.fix = Some(true);
+        sub_check.stage = Some(true);
+        sub_check.stash = Some(crate::hook::StashSetting::Method(
+            crate::git::StashMethod::Git,
+        ));
+        sub_check.fail_on_fix = true;
+        sub_check.report = Some("echo report".parse().unwrap());
+        sub_check.steps.insert(
+            "sub".to_string(),
+            StepOrGroup::Step(Box::new(step("sub"))),
+        );
+        sub.hooks.insert("check".to_string(), sub_check);
+
+        root.merge_subproject("packages/web", None, sub).unwrap();
+        root.materialize_default_hooks().unwrap();
+
+        let check = &root.hooks["check"];
+        assert_eq!(check.fix, Some(false));
+        assert_eq!(check.stage, Some(false));
+        assert_eq!(check.stash, None);
+        assert!(!check.fail_on_fix);
+        assert_eq!(check.report, None);
+        assert!(check.steps.contains_key("root"));
+        assert!(check.steps.contains_key("packages/web:sub"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -750,20 +750,30 @@ impl Config {
             if !sub_hook.enabled {
                 continue;
             }
-            if sub_hook.fix.is_some()
-                || sub_hook.stash.is_some()
-                || sub_hook.stage.is_some()
-                || sub_hook.fail_on_fix
-                || sub_hook.report.is_some()
+            let sub_hook_is_implicit = sub.implicit_default_hooks.contains(&hook_name);
+            if !sub_hook_is_implicit
+                && (sub_hook.fix.is_some()
+                    || sub_hook.stash.is_some()
+                    || sub_hook.stage.is_some()
+                    || sub_hook.fail_on_fix
+                    || sub_hook.report.is_some())
             {
                 debug!(
                     "subprojects: ignoring hook-level settings for '{hook_name}' in {}",
                     sub.path.display()
                 );
             }
-            let root_hook = self.hooks.entry(hook_name.clone()).or_insert_with(|| Hook {
-                name: hook_name.clone(),
-                ..Default::default()
+            let root_hook = self.hooks.entry(hook_name.clone()).or_insert_with(|| {
+                let mut hook = Hook {
+                    name: hook_name.clone(),
+                    ..Default::default()
+                };
+                if sub_hook_is_implicit {
+                    hook.fix = sub_hook.fix;
+                    hook.stage = sub_hook.stage;
+                    hook.stash = sub_hook.stash.clone();
+                }
+                hook
             });
             // Names of the subproject hook's steps and groups, for rewriting
             // `depends` references to their scoped names.
@@ -1090,6 +1100,9 @@ pub struct Config {
     #[serde(skip)]
     #[serde(default)]
     default_hooks_materialized: bool,
+    #[serde(skip)]
+    #[serde(default)]
+    implicit_default_hooks: IndexSet<String>,
     #[serde(default)]
     pub hooks: IndexMap<String, Hook>,
     /// Preferred default branch to compare against (e.g. "main"). If not set, hk will detect it.
@@ -1141,7 +1154,11 @@ impl Config {
                 )),
             ),
         ] {
+            let is_implicit = !self.hooks.contains_key(name);
             let hook = self.hooks.entry(name.to_string()).or_default();
+            if is_implicit {
+                self.implicit_default_hooks.insert(name.to_string());
+            }
             let explicit_steps = std::mem::take(&mut hook.steps);
             hook.steps = self.steps.clone();
             hook.steps.extend(explicit_steps);
@@ -1557,6 +1574,18 @@ mod tests {
             };
             assert_eq!(lint.dir.as_deref(), Some("packages/web"));
         }
+        assert_eq!(root.hooks["check"].fix, Some(false));
+        assert_eq!(root.hooks["check"].stage, Some(false));
+        assert_eq!(root.hooks["fix"].fix, Some(true));
+        assert_eq!(root.hooks["fix"].stage, Some(false));
+        assert_eq!(root.hooks["pre-commit"].fix, Some(true));
+        assert_eq!(root.hooks["pre-commit"].stage, Some(true));
+        assert_eq!(
+            root.hooks["pre-commit"].stash,
+            Some(crate::hook::StashSetting::Method(
+                crate::git::StashMethod::Git
+            ))
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ impl Config {
         let mut config = Self::load_project_config()?;
         config.load_subprojects()?;
         config.apply_hkrc()?;
+        config.materialize_default_hooks()?;
         config.validate()?;
         Ok(config)
     }
@@ -516,6 +517,11 @@ impl Config {
         self.stash_backup_count = self.stash_backup_count.or(hkrc.stash_backup_count);
         self.terminal_progress = self.terminal_progress.or(hkrc.terminal_progress);
         self.walk_ignore = self.walk_ignore.or(hkrc.walk_ignore);
+
+        // Top-level steps are additive, with project definitions winning.
+        for (step_name, hkrc_step) in hkrc.steps {
+            self.steps.entry(step_name).or_insert(hkrc_step);
+        }
 
         // Hooks: additive, project wins on same-named step collision
         for (hook_name, hkrc_hook) in hkrc.hooks {
@@ -1064,6 +1070,8 @@ fn failed_pkl_config_error(path: &Path, code: Option<&str>, stderr: &str) -> eyr
 pub struct Config {
     pub min_hk_version: Option<String>,
     #[serde(default)]
+    pub steps: IndexMap<String, crate::hook::StepOrGroup>,
+    #[serde(default)]
     pub hooks: IndexMap<String, Hook>,
     /// Preferred default branch to compare against (e.g. "main"). If not set, hk will detect it.
     pub default_branch: Option<String>,
@@ -1097,6 +1105,35 @@ impl std::fmt::Display for Config {
 }
 
 impl Config {
+    fn materialize_default_hooks(&mut self) -> Result<()> {
+        if self.steps.is_empty() {
+            return Ok(());
+        }
+
+        for (name, fix, stage, stash) in [
+            ("check", Some(false), Some(false), None),
+            ("fix", Some(true), Some(false), None),
+            (
+                "pre-commit",
+                Some(true),
+                Some(true),
+                Some(crate::hook::StashSetting::Method(
+                    crate::git::StashMethod::Git,
+                )),
+            ),
+        ] {
+            let hook = self.hooks.entry(name.to_string()).or_default();
+            let explicit_steps = std::mem::take(&mut hook.steps);
+            hook.steps = self.steps.clone();
+            hook.steps.extend(explicit_steps);
+            hook.fix = hook.fix.or(fix);
+            hook.stage = hook.stage.or(stage);
+            hook.stash = hook.stash.clone().or(stash);
+            hook.init(name)?;
+        }
+        Ok(())
+    }
+
     pub fn validate(&self) -> Result<()> {
         for (hook_name, hook) in &self.hooks {
             for (step_name, step_or_group) in &hook.steps {
@@ -1295,6 +1332,84 @@ mod tests {
             name: name.to_string(),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn top_level_steps_create_default_hooks_with_explicit_overrides() {
+        let mut config = Config::default();
+        config.steps.insert(
+            "shared".to_string(),
+            StepOrGroup::Step(Box::new(step("shared"))),
+        );
+        let mut check = hook("check");
+        check.steps.insert(
+            "shared".to_string(),
+            StepOrGroup::Step(Box::new(Step {
+                env: IndexMap::from([("SOURCE".to_string(), "explicit".to_string())]),
+                ..Default::default()
+            })),
+        );
+        config.hooks.insert("check".to_string(), check);
+
+        config.materialize_default_hooks().unwrap();
+
+        assert_eq!(
+            config.hooks.keys().collect::<Vec<_>>(),
+            ["check", "fix", "pre-commit"]
+        );
+        let check = config.hooks.get("check").unwrap();
+        let StepOrGroup::Step(shared) = check.steps.get("shared").unwrap() else {
+            panic!("expected step");
+        };
+        assert_eq!(
+            shared.env.get("SOURCE").map(String::as_str),
+            Some("explicit")
+        );
+        assert_eq!(check.fix, Some(false));
+        assert_eq!(check.stage, Some(false));
+        assert_eq!(config.hooks["fix"].fix, Some(true));
+        assert_eq!(config.hooks["fix"].stage, Some(false));
+        assert_eq!(config.hooks["pre-commit"].fix, Some(true));
+        assert_eq!(config.hooks["pre-commit"].stage, Some(true));
+        assert_eq!(
+            config.hooks["pre-commit"].stash,
+            Some(crate::hook::StashSetting::Method(
+                crate::git::StashMethod::Git
+            ))
+        );
+    }
+
+    #[test]
+    fn hkrc_top_level_steps_are_additive_and_project_wins() {
+        let mut project = Config::default();
+        project.steps.insert(
+            "shared".to_string(),
+            StepOrGroup::Step(Box::new(Step {
+                env: IndexMap::from([("SOURCE".to_string(), "project".to_string())]),
+                ..Default::default()
+            })),
+        );
+        let mut user = Config::default();
+        user.steps.insert(
+            "shared".to_string(),
+            StepOrGroup::Step(Box::new(step("user"))),
+        );
+        user.steps.insert(
+            "user-only".to_string(),
+            StepOrGroup::Step(Box::new(step("user-only"))),
+        );
+
+        project.merge_from_hkrc(user);
+        project.materialize_default_hooks().unwrap();
+
+        let StepOrGroup::Step(shared) = &project.hooks["check"].steps["shared"] else {
+            panic!("expected step");
+        };
+        assert_eq!(
+            shared.env.get("SOURCE").map(String::as_str),
+            Some("project")
+        );
+        assert!(project.hooks["check"].steps.contains_key("user-only"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -741,6 +741,9 @@ impl Config {
         };
         let sub_env = std::mem::take(&mut sub.env);
         for (hook_name, sub_hook) in std::mem::take(&mut sub.hooks) {
+            if !sub_hook.enabled {
+                continue;
+            }
             let root_hook = self.hooks.entry(hook_name.clone()).or_insert_with(|| Hook {
                 name: hook_name.clone(),
                 fix: sub_hook.fix,
@@ -1563,6 +1566,23 @@ mod tests {
 
         let err = root.merge_subproject("sub", None, sub).unwrap_err();
         assert!(err.to_string().contains("duplicate step name 'sub:lint'"));
+    }
+
+    #[test]
+    fn merge_subproject_ignores_disabled_hooks() {
+        let mut root = Config::default();
+        let mut sub = Config::default();
+        let mut disabled = hook("pre-commit");
+        disabled.enabled = false;
+        disabled.steps.insert(
+            "lint".to_string(),
+            StepOrGroup::Step(Box::new(step("lint"))),
+        );
+        sub.hooks.insert("pre-commit".to_string(), disabled);
+
+        root.merge_subproject("sub", sub).unwrap();
+
+        assert!(!root.hooks.contains_key("pre-commit"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,8 +23,8 @@ impl Config {
     fn load() -> Result<Self> {
         let mut config = Self::load_project_config()?;
         config.load_subprojects()?;
-        config.apply_hkrc()?;
         config.materialize_default_hooks()?;
+        config.apply_hkrc()?;
         config.validate()?;
         Ok(config)
     }
@@ -482,6 +482,7 @@ impl Config {
                 let mut hkrc_config: Config = serde_json::from_value(json_value)
                     .wrap_err("failed to parse hkrc as Config")?;
                 hkrc_config.init(&path, true)?;
+                hkrc_config.materialize_default_hooks()?;
                 self.merge_from_hkrc(hkrc_config);
             }
         }
@@ -1398,9 +1399,19 @@ mod tests {
             "user-only".to_string(),
             StepOrGroup::Step(Box::new(step("user-only"))),
         );
+        let mut user_check = hook("check");
+        user_check.steps.insert(
+            "shared".to_string(),
+            StepOrGroup::Step(Box::new(Step {
+                env: IndexMap::from([("SOURCE".to_string(), "user-hook".to_string())]),
+                ..Default::default()
+            })),
+        );
+        user.hooks.insert("check".to_string(), user_check);
 
-        project.merge_from_hkrc(user);
         project.materialize_default_hooks().unwrap();
+        user.materialize_default_hooks().unwrap();
+        project.merge_from_hkrc(user);
 
         let StepOrGroup::Step(shared) = &project.hooks["check"].steps["shared"] else {
             panic!("expected step");

--- a/src/config.rs
+++ b/src/config.rs
@@ -1577,10 +1577,9 @@ mod tests {
         ));
         sub_check.fail_on_fix = true;
         sub_check.report = Some("echo report".parse().unwrap());
-        sub_check.steps.insert(
-            "sub".to_string(),
-            StepOrGroup::Step(Box::new(step("sub"))),
-        );
+        sub_check
+            .steps
+            .insert("sub".to_string(), StepOrGroup::Step(Box::new(step("sub"))));
         sub.hooks.insert("check".to_string(), sub_check);
 
         root.merge_subproject("packages/web", None, sub).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1580,7 +1580,7 @@ mod tests {
         );
         sub.hooks.insert("pre-commit".to_string(), disabled);
 
-        root.merge_subproject("sub", sub).unwrap();
+        root.merge_subproject("sub", None, sub).unwrap();
 
         assert!(!root.hooks.contains_key("pre-commit"));
     }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -96,7 +96,7 @@ impl SkipReason {
 }
 
 #[serde_as]
-#[derive(Debug, Clone, Default, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(debug_assertions, serde(deny_unknown_fields))]
 pub struct Hook {
@@ -104,6 +104,8 @@ pub struct Hook {
     pub name: String,
     #[serde(default)]
     pub steps: IndexMap<String, StepOrGroup>,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
     pub fix: Option<bool>,
     pub stash: Option<StashSetting>,
     pub stage: Option<bool>,
@@ -113,6 +115,26 @@ pub struct Hook {
     pub env: IndexMap<String, String>,
     #[serde_as(as = "Option<PickFirst<(_, DisplayFromStr)>>")]
     pub report: Option<Script>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for Hook {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            steps: IndexMap::new(),
+            enabled: true,
+            fix: None,
+            stash: None,
+            stage: None,
+            fail_on_fix: false,
+            env: IndexMap::new(),
+            report: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]

--- a/src/hook_options.rs
+++ b/src/hook_options.rs
@@ -234,9 +234,7 @@ impl HookOptions {
         match config.hooks.get(name) {
             Some(hook) => {
                 if !hook.enabled {
-                    warn!(
-                        "hook '{name}' is disabled by hooks[\"{name}\"].enabled = false"
-                    );
+                    warn!("hook '{name}' is disabled by hooks[\"{name}\"].enabled = false");
                     crate::structured_output::emit_noop_run(
                         Settings::cli_output_format(),
                         name,

--- a/src/hook_options.rs
+++ b/src/hook_options.rs
@@ -234,7 +234,9 @@ impl HookOptions {
         match config.hooks.get(name) {
             Some(hook) => {
                 if !hook.enabled {
-                    log::debug!("hook '{name}' is disabled, skipping");
+                    warn!(
+                        "hook '{name}' is disabled by hooks[\"{name}\"].enabled = false"
+                    );
                     crate::structured_output::emit_noop_run(
                         Settings::cli_output_format(),
                         name,

--- a/src/hook_options.rs
+++ b/src/hook_options.rs
@@ -233,6 +233,19 @@ impl HookOptions {
         }
         match config.hooks.get(name) {
             Some(hook) => {
+                if !hook.enabled {
+                    log::debug!("hook '{name}' is disabled, skipping");
+                    crate::structured_output::emit_noop_run(
+                        Settings::cli_output_format(),
+                        name,
+                        chrono::Utc::now().to_rfc3339(),
+                        0,
+                        vec![],
+                        "hook disabled by configuration",
+                        self.sarif.as_deref(),
+                    )?;
+                    return Ok(());
+                }
                 if self.stats {
                     hook.stats(self, name).await?;
                 } else if self.plan || self.why.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ extern crate log;
 #[macro_use]
 mod output;
 
-use std::{panic, thread, time::Duration};
+use std::{ffi::OsString, panic, thread, time::Duration};
 
 pub use eyre::Result;
 
@@ -49,6 +49,12 @@ use tokio::signal;
 use tokio::signal::unix::SignalKind;
 
 fn main() -> Result<()> {
+    if is_bare_builtins_invocation(std::env::args_os().skip(1)) {
+        for builtin in builtins::BUILTINS {
+            println!("{builtin}");
+        }
+        return Ok(());
+    }
     let worker_threads = runtime_worker_threads(
         thread::available_parallelism()
             .map(|n| n.get())
@@ -59,6 +65,10 @@ fn main() -> Result<()> {
         .worker_threads(worker_threads)
         .build()?
         .block_on(async_main())
+}
+
+fn is_bare_builtins_invocation(mut args: impl Iterator<Item = OsString>) -> bool {
+    args.next().is_some_and(|arg| arg == "builtins") && args.next().is_none()
 }
 
 async fn async_main() -> Result<()> {
@@ -132,7 +142,18 @@ fn handle_panic() {
 
 #[cfg(test)]
 mod tests {
-    use super::runtime_worker_threads;
+    use super::{is_bare_builtins_invocation, runtime_worker_threads};
+    use std::ffi::OsString;
+
+    #[test]
+    fn bare_builtins_can_skip_runtime_and_command_tree_setup() {
+        assert!(is_bare_builtins_invocation(
+            ["builtins"].into_iter().map(OsString::from)
+        ));
+        assert!(!is_bare_builtins_invocation(
+            ["builtins", "--quiet"].into_iter().map(OsString::from)
+        ));
+    }
 
     #[test]
     fn runtime_workers_are_bounded() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,12 @@ extern crate log;
 #[macro_use]
 mod output;
 
-use std::{ffi::OsString, panic, thread, time::Duration};
+use std::{
+    ffi::OsString,
+    io::{self, Write},
+    panic, thread,
+    time::Duration,
+};
 
 pub use eyre::Result;
 
@@ -50,10 +55,7 @@ use tokio::signal::unix::SignalKind;
 
 fn main() -> Result<()> {
     if is_bare_builtins_invocation(std::env::args_os().skip(1)) {
-        for builtin in builtins::BUILTINS {
-            println!("{builtin}");
-        }
-        return Ok(());
+        return write_builtins(io::stdout().lock());
     }
     let worker_threads = runtime_worker_threads(
         thread::available_parallelism()
@@ -69,6 +71,18 @@ fn main() -> Result<()> {
 
 fn is_bare_builtins_invocation(mut args: impl Iterator<Item = OsString>) -> bool {
     args.next().is_some_and(|arg| arg == "builtins") && args.next().is_none()
+}
+
+fn write_builtins(mut writer: impl Write) -> Result<()> {
+    for builtin in builtins::BUILTINS {
+        if let Err(err) = writeln!(writer, "{builtin}") {
+            if err.kind() == io::ErrorKind::BrokenPipe {
+                return Ok(());
+            }
+            return Err(err.into());
+        }
+    }
+    Ok(())
 }
 
 async fn async_main() -> Result<()> {
@@ -142,8 +156,9 @@ fn handle_panic() {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_bare_builtins_invocation, runtime_worker_threads};
+    use super::{is_bare_builtins_invocation, runtime_worker_threads, write_builtins};
     use std::ffi::OsString;
+    use std::io::{self, Write};
 
     #[test]
     fn bare_builtins_can_skip_runtime_and_command_tree_setup() {
@@ -153,6 +168,24 @@ mod tests {
         assert!(!is_bare_builtins_invocation(
             ["builtins", "--quiet"].into_iter().map(OsString::from)
         ));
+    }
+
+    struct FailingWriter(io::ErrorKind);
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::from(self.0))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn bare_builtins_treats_broken_pipe_as_success() {
+        write_builtins(FailingWriter(io::ErrorKind::BrokenPipe)).unwrap();
+        assert!(write_builtins(FailingWriter(io::ErrorKind::Other)).is_err());
     }
 
     #[test]

--- a/test/config_completeness.bats
+++ b/test/config_completeness.bats
@@ -11,8 +11,9 @@ teardown() {
 
 @test "Ensure settings.toml and Config.pkl match" {
     # Checks to see if the root properties in Config.pkl are all defined in settings.toml.
-    # Excludes structural config that isn't a setting: hooks, output, min_hk_version, and subprojects
+    # Excludes structural config that isn't a setting: hooks, steps, output,
+    # min_hk_version, and subprojects.
     diff -u --label "settings.toml" --label "Config.pkl" \
         <(taplo get -f $PROJECT_ROOT/settings.toml -o json | jq -r 'to_entries | map(select(.value.sources | has("pkl"))) | .[].key' | sort)\
-        <(pkl eval $PKL_PATH/Config.pkl --format json -x "import (\"file:$PROJECT_ROOT/scripts/reflect.pkl\").render(module)" | jq -r '.moduleClass.properties | keys[] | select(. != "hooks" and . != "output" and . != "min_hk_version" and . != "subprojects")' | sort)
+        <(pkl eval $PKL_PATH/Config.pkl --format json -x "import (\"file:$PROJECT_ROOT/scripts/reflect.pkl\").render(module)" | jq -r '.moduleClass.properties | keys[] | select(. != "hooks" and . != "steps" and . != "output" and . != "min_hk_version" and . != "subprojects")' | sort)
 }

--- a/test/init_creates_hk_pkl.bats
+++ b/test/init_creates_hk_pkl.bats
@@ -11,7 +11,7 @@ teardown() {
 
 @test "hk init creates hk.pkl" {
     hk init
-    assert_file_contains hk.pkl "linters ="
+    assert_file_contains hk.pkl "steps {"
 }
 
 @test "hk init detects package.json" {
@@ -85,7 +85,7 @@ teardown() {
     # Check that old content is gone and new content is present
     run grep "old content" hk.pkl
     assert_failure
-    assert_file_contains hk.pkl "hooks"
+    assert_file_contains hk.pkl "steps {"
 }
 
 @test "hk init warns if hk.pkl exists without --force" {

--- a/test/install_global.bats
+++ b/test/install_global.bats
@@ -71,6 +71,25 @@ EOF
     assert_failure
 }
 
+@test "hk install --global does not restore explicitly disabled project hooks" {
+    require_git_2_54
+
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-commit"] {
+        enabled = false
+    }
+}
+EOF
+
+    run hk install --global
+    assert_success
+
+    run git config --global --get hook.hk-pre-commit.command
+    assert_failure
+}
+
 @test "hk install --global --mise writes home-relative mise with explicit hk tool" {
     require_git_2_54
 

--- a/test/migrate_precommit.bats
+++ b/test/migrate_precommit.bats
@@ -29,8 +29,8 @@ PRECOMMIT
     run cat hk.pkl
     assert_output --partial "Builtins.prettier"
     assert_output --partial "Builtins.eslint"
-    assert_output --partial 'hooks {'
-    assert_output --partial '["pre-commit"]'
+    assert_output --partial 'steps {'
+    refute_output --partial '["pre-commit"]'
 
     run hk validate
     assert_success
@@ -159,10 +159,11 @@ PRECOMMIT
     run hk migrate pre-commit --hk-pkl-root "$PKL_PATH"
     assert_success
 
-    # Verify both stages are created
+    # Pre-commit is implicit from top-level steps; other stages stay explicit.
     run cat hk.pkl
     assert_output --partial '["pre-push"]'
-    assert_output --partial '["pre-commit"]'
+    assert_output --partial 'steps {'
+    refute_output --partial '["pre-commit"]'
 }
 
 @test "migrate precommit - local repo" {
@@ -422,8 +423,9 @@ PRECOMMIT
     assert_success
 
     run cat hk.pkl
-    # Should have pre-commit, check, and fix hooks
-    assert_output --partial '["pre-commit"]'
+    # Pre-commit is implicit from top-level steps; check and fix add the full set.
+    assert_output --partial 'steps {'
+    refute_output --partial '["pre-commit"]'
     assert_output --partial '["check"]'
     assert_output --partial '["fix"]'
 }
@@ -459,8 +461,9 @@ PRECOMMIT
     # rather than specific hooks
     assert_output --regexp 'Builtins\.(yamllint|check_merge_conflict|mixed_line_ending|trailing_whitespace|detect_private_key|newlines|python_debug_statements|check_executables_have_shebangs)'
 
-    # Verify it has both pre-commit and pre-push stages (Airflow uses default_stages)
-    assert_output --partial '["pre-commit"]'
+    # Pre-commit is implicit from top-level steps; pre-push remains explicit.
+    assert_output --partial 'steps {'
+    refute_output --partial '["pre-commit"]'
     assert_output --partial '["pre-push"]'
 
     # Verify it has local hooks section

--- a/test/migrate_precommit.bats
+++ b/test/migrate_precommit.bats
@@ -30,6 +30,8 @@ PRECOMMIT
     assert_output --partial "Builtins.prettier"
     assert_output --partial "Builtins.eslint"
     assert_output --partial 'steps {'
+    assert_output --partial '["prettier"] = linters["prettier"]'
+    assert_output --partial '["eslint"] = linters["eslint"]'
     refute_output --partial '["pre-commit"]'
 
     run hk validate

--- a/test/standalone_subdir.bats
+++ b/test/standalone_subdir.bats
@@ -12,14 +12,10 @@ teardown() {
     mkdir -p sub
     cat <<EOF > sub/hk.pkl
 amends "$PKL_PATH/Config.pkl"
-hooks {
-    ["check"] {
-        steps {
-            ["list"] {
-                glob = "*.txt"
-                check = "for f in {{files}}; do echo checked \$f; done"
-            }
-        }
+steps {
+    ["list"] {
+        glob = "*.txt"
+        check = "for f in {{files}}; do echo checked \$f; done"
     }
 }
 EOF

--- a/test/subprojects.bats
+++ b/test/subprojects.bats
@@ -22,27 +22,19 @@ amends "$PKL_PATH/Config.pkl"
 env {
     ["GREETING"] = "hello-from-sub"
 }
-hooks {
-    ["check"] {
-        steps {
-            ["greet"] {
-                glob = "*.txt"
-                check = "echo GREETING=\$GREETING; for f in {{files}}; do echo checked \$f; done; exit 1"
-            }
-        }
+steps {
+    ["greet"] {
+        glob = "*.txt"
+        check = "echo GREETING=\$GREETING; for f in {{files}}; do echo checked \$f; done; exit 1"
     }
 }
 EOF
     cat <<EOF > packages/a/hk.pkl
 amends "$PKL_PATH/Config.pkl"
-hooks {
-    ["check"] {
-        steps {
-            ["pkga"] {
-                glob = "*.txt"
-                check = "echo pkga saw {{files}}; exit 1"
-            }
-        }
+steps {
+    ["pkga"] {
+        glob = "*.txt"
+        check = "echo pkga saw {{files}}; exit 1"
     }
 }
 EOF

--- a/test/top_level_steps.bats
+++ b/test/top_level_steps.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+teardown() {
+    _common_teardown
+}
+
+write_config() {
+    cat > hk.pkl <<EOF
+amends "$PKL_PATH/Config.pkl"
+
+steps {
+    ["shared"] {
+        check = "echo inherited"
+        fix = "echo fixed"
+    }
+}
+EOF
+}
+
+@test "top-level steps create check fix and pre-commit hooks" {
+    write_config
+
+    run hk check --all
+    assert_success
+    assert_output --partial "inherited"
+
+    run hk fix --all
+    assert_success
+    assert_output --partial "fixed"
+
+    run hk run pre-commit --all --no-stage
+    assert_success
+    assert_output --partial "fixed"
+
+    run hk run pre-push --all
+    assert_failure
+}
+
+@test "explicit hook steps override inherited steps" {
+    write_config
+    cat >> hk.pkl <<'EOF'
+hooks {
+    ["check"] {
+        steps {
+            ["shared"] {
+                check = "echo explicit"
+            }
+        }
+    }
+}
+EOF
+
+    run hk check --all
+    assert_success
+    assert_output --partial "explicit"
+    refute_output --partial "inherited"
+}
+
+@test "disabled implicit hook is a successful no-op" {
+    write_config
+    cat >> hk.pkl <<'EOF'
+hooks {
+    ["check"] {
+        enabled = false
+    }
+}
+EOF
+
+    run hk check --all
+    assert_success
+    refute_output --partial "inherited"
+}

--- a/test/top_level_steps.bats
+++ b/test/top_level_steps.bats
@@ -72,5 +72,18 @@ EOF
 
     run hk check --all
     assert_success
+    assert_output --partial 'hook '\''check'\'' is disabled by hooks["check"].enabled = false'
     refute_output --partial "inherited"
+}
+
+@test "every builtin is accepted in the top-level steps mapping" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+import "$PKL_PATH/Builtins.pkl"
+
+steps = Builtins.all
+EOF
+
+    run hk validate
+    assert_success
 }


### PR DESCRIPTION
## Summary

- add a top-level `steps` map shared by the implicit `check`, `fix`, and `pre-commit` hooks
- let explicit same-name hook steps replace shared steps
- add hook `enabled` control for execution and installation
- merge only subproject steps, preserve implicit hook identity at the root, and ignore explicit subproject hook-level settings with a debug message
- keep disabled global hooks from donating steps
- generate concise v2 configs from `hk init` and `hk migrate pre-commit`

## Defaults

- `check`: check mode, no staging
- `fix`: fix mode, no staging
- `pre-commit`: fix mode, staging enabled, Git stash
- no implicit `pre-push`

## v2 stack

- #1253 (1/5) — flat configurable builtin steps
- #1255 (2/5) — shared top-level steps and hook materialization
- #1256 (3/5) — contextual staging defaults
- #1257 (4/5) — remove v1 interfaces and add migration guidance
- #1369 (5/5) — remove the external Pkl runtime fallback

Depends on #1253.

## Verification

- config, init, migration, top-level-step, and subproject regression tests
- Rust test suite
- stack-top slow lint/check suite and Apple Pkl compatibility validation

_AI-generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core config materialization, hook install/run behavior, and monorepo merge semantics; regressions would affect every project's hooks, though coverage is extensive.
> 
> **Overview**
> Introduces **top-level `steps`** in `Config.pkl` and config loading so one step map is shared by the implicit **`check`**, **`fix`**, and **`pre-commit`** hooks (with sensible defaults: pre-commit fix + git stash + staging). Same-named steps under an explicit hook **override** the shared definition.
> 
> Adds **`hooks[].enabled`** so disabled hooks are skipped at run time (successful no-op with a warning), omitted from **`hk install`**, and ignored when merging hkrc/subproject hooks. **`hk init`** and **`migrate pre-commit`** now emit shorter v2 configs (`steps = linters` / `steps { … }`) instead of repeating check/fix/pre-commit blocks; init defaults to pre-commit only.
> 
> Subproject merge **materializes** top-level steps, merges mostly steps (not arbitrary hook-level settings from explicit subproject hooks), and tracks implicit vs explicit hooks. Also adds a fast path for bare **`hk builtins`** that skips the async runtime, and updates tests/docs parity for `steps` in settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddfd6ce65b9c724e9c03f7d66162406258038553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->