### PR TITLE
feat(hook)!: make staging contextual

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,8 +48,8 @@ stashing so unstaged work is restored after the hook runs.
 An explicitly configured hook with one of those names keeps its hook-level
 settings and replaces same-named inherited steps; top-level steps still supply
 the remaining step names. Other hook names are custom hooks and must be declared
-explicitly under `hooks` with their own steps and explicit `fix` and `stage`
-settings.
+explicitly under `hooks` with their own steps. Configure `fix` or `stage` only
+when needed; custom hooks are unstaged by default.
 
 ### Config file paths
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,19 @@ hooks {
 
 `pre-commit` applies fixes to staged files while unstaged work is saved. The `check` and `fix` hooks provide the local commands. They are hooks, not individual steps.
 
+### Hook defaults {#hook-defaults}
+
+Top-level `steps` materialize the `check`, `fix`, and `pre-commit` hooks. `check`
+runs checks without fixing or staging. `fix` applies fixes without staging.
+`pre-commit` applies fixes, stages the resulting changes, and defaults to Git
+stashing so unstaged work is restored after the hook runs.
+
+An explicitly configured hook with one of those names keeps its hook-level
+settings and replaces same-named inherited steps; top-level steps still supply
+the remaining step names. Other hook names are custom hooks and must be declared
+explicitly under `hooks` with their own steps and explicit `fix` and `stage`
+settings.
+
 ### Config file paths
 
 Starting in the current directory, hk walks upward. At each directory it checks these paths in order, using the first match:

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -244,7 +244,7 @@ class Hook {
   /// If true, hk will run the fix command for each step (if it exists) to make modifications.
   fix: Boolean?
 
-  /// Default: `true`
+  /// Default: `true` for `pre-commit`; `false` for every other hook.
   ///
   /// If true, hk will automatically stage fixed files after `fix` commands run.
   ///
@@ -751,8 +751,9 @@ open class Step {
 
   /// A list of globs of files to add to the git index after running a fix step.
   ///
-  /// When staging is enabled and the step has a `fix` command, this defaults to the step's
-  /// glob. Set explicitly if your fix modifies different files than those it reads.
+  /// This filters what hk stages; it does not enable staging by itself. When
+  /// staging is enabled and this is unset, hk stages the files processed by
+  /// the step. Set it when a fix modifies different files than those it reads.
   ///
   /// ```pkl
   /// hooks {

--- a/pkl/builtins/aqua_update_checksum.pkl
+++ b/pkl/builtins/aqua_update_checksum.pkl
@@ -59,7 +59,23 @@ const aqua_update_checksum = new Config.Step {
         ]
       }
       """
-    ["fix bad file"] = testMaker.fixPass("{}", good)
+    ["fix bad file"] = new Config.StepTest {
+      run = "fix"
+      tmpdir = true
+      write = new Mapping<String, String> {
+        [testMaker.filename] = "{}"
+        ...testMaker.extra_files
+      }
+      // aqua emits sha256 or sha512 for this registry depending on the platform.
+      after =
+        """
+        jq -e '
+          .checksums[0] |
+          (.algorithm == "sha256" and .checksum == "14BFA633212CF508D45DE47AD17CF666E009BCA351787E28F41D63FFD5B99D8B") or
+          (.algorithm == "sha512" and .checksum == "F5BD5D893B9901B0E0C267651154350D5C0F4A9D1DA0EB82103BF0A2AE28ACB42AFC2F83E32A1B8A2EE2EDE21D905ED71759C7AC08A33AD2129C53F86539FBBF")
+        ' aqua-checksums.json
+        """
+    }
     ["fix good file"] = testMaker.fixPass(good, good)
   }
 }

--- a/settings.toml
+++ b/settings.toml
@@ -406,6 +406,9 @@ sources.pkl = ["stage"]
 docs = """
 When specified, overrides the [hook's `stage` key](https://hk.jdx.dev/configuration#hook-stage-boolean).
 
+Without an override, staging is enabled only for `pre-commit`. Manual `hk fix`
+and every other hook leave changes unstaged.
+
 This is useful when you want to manually review changes made by auto-fixers before including them in your commit.
 """
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1145,12 +1145,11 @@ impl Config {
             return Ok(());
         }
 
-        for (name, fix, stage, stash) in [
-            ("check", Some(false), Some(false), None),
-            ("fix", Some(true), Some(false), None),
+        for (name, fix, stash) in [
+            ("check", Some(false), None),
+            ("fix", Some(true), None),
             (
                 "pre-commit",
-                Some(true),
                 Some(true),
                 Some(crate::hook::StashSetting::Method(
                     crate::git::StashMethod::Git,
@@ -1166,7 +1165,6 @@ impl Config {
             hook.steps = self.steps.clone();
             hook.steps.extend(explicit_steps);
             hook.fix = hook.fix.or(fix);
-            hook.stage = hook.stage.or(stage);
             hook.stash = hook.stash.clone().or(stash);
             hook.init(name)?;
         }
@@ -1406,11 +1404,11 @@ mod tests {
             Some("explicit")
         );
         assert_eq!(check.fix, Some(false));
-        assert_eq!(check.stage, Some(false));
+        assert_eq!(check.stage, None);
         assert_eq!(config.hooks["fix"].fix, Some(true));
-        assert_eq!(config.hooks["fix"].stage, Some(false));
+        assert_eq!(config.hooks["fix"].stage, None);
         assert_eq!(config.hooks["pre-commit"].fix, Some(true));
-        assert_eq!(config.hooks["pre-commit"].stage, Some(true));
+        assert_eq!(config.hooks["pre-commit"].stage, None);
         assert_eq!(
             config.hooks["pre-commit"].stash,
             Some(crate::hook::StashSetting::Method(
@@ -1620,7 +1618,7 @@ mod tests {
 
         let check = &root.hooks["check"];
         assert_eq!(check.fix, Some(false));
-        assert_eq!(check.stage, Some(false));
+        assert_eq!(check.stage, None);
         assert_eq!(check.stash, None);
         assert!(!check.fail_on_fix);
         assert_eq!(check.report, None);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1577,11 +1577,11 @@ mod tests {
             assert!(root.implicit_default_hooks.contains(hook_name));
         }
         assert_eq!(root.hooks["check"].fix, Some(false));
-        assert_eq!(root.hooks["check"].stage, Some(false));
+        assert_eq!(root.hooks["check"].stage, None);
         assert_eq!(root.hooks["fix"].fix, Some(true));
-        assert_eq!(root.hooks["fix"].stage, Some(false));
+        assert_eq!(root.hooks["fix"].stage, None);
         assert_eq!(root.hooks["pre-commit"].fix, Some(true));
-        assert_eq!(root.hooks["pre-commit"].stage, Some(true));
+        assert_eq!(root.hooks["pre-commit"].stage, None);
         assert_eq!(
             root.hooks["pre-commit"].stash,
             Some(crate::hook::StashSetting::Method(

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1154,7 +1154,7 @@ impl Hook {
             .should_stage()
             .or(settings.stage)
             .or(self.stage)
-            .unwrap_or(true);
+            .unwrap_or_else(|| self.name == "pre-commit");
 
         if settings.skip_hooks.contains(&self.name) {
             warn!("{}: skipping hook due to HK_SKIP_HOOK", self.name);

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -394,11 +394,14 @@ impl Step {
     ) -> Result<()> {
         // Build stage pathspecs; if `dir` is set, stage entries are relative to it.
         // Compute "root" variants for patterns that start with "**/" BEFORE prefixing with `dir`.
-        // Determine effective stage: explicit setting wins, otherwise default to <JOB_FILES>
-        // for steps that can modify files when staging is enabled.
-        let effective_stage: Option<&Vec<String>> = if self.stage.is_some() {
+        // A step-level stage setting filters paths; it never enables staging.
+        // When staging is enabled, explicit patterns win and fixers otherwise
+        // default to the files processed by this job.
+        let effective_stage: Option<&Vec<String>> = if !ctx.hook_ctx.should_stage {
+            None
+        } else if self.stage.is_some() {
             self.stage.as_ref()
-        } else if ctx.hook_ctx.should_stage && (self.fix.is_some() || self.check_diff.is_some()) {
+        } else if self.fix.is_some() || self.check_diff.is_some() {
             Some(&DEFAULT_STAGE)
         } else {
             None
@@ -538,7 +541,7 @@ impl Step {
             if !filtered.is_empty() {
                 // Snapshot pre-staging untracked set for classification
                 let pre_untracked: BTreeSet<PathBuf> = status.untracked_files.clone();
-                // Only stage matched files if stage setting is enabled (default: true)
+                // Only stage matched files when staging is enabled for this hook.
                 // Unintended staging caused by stash/apply is handled separately in git.pop_stash().
                 if ctx.hook_ctx.should_stage {
                     ctx.hook_ctx.git.lock().await.add(&filtered)?;

--- a/test/dir_template.bats
+++ b/test/dir_template.bats
@@ -241,7 +241,7 @@ EOF
     echo "y" >> pkgs/b/in.txt
     git add pkgs/a/in.txt pkgs/b/in.txt
 
-    run hk fix
+    run hk fix --stage
     assert_success
 
     run git diff --cached --name-only

--- a/test/fix_preserves_unstaged_newline.bats
+++ b/test/fix_preserves_unstaged_newline.bats
@@ -142,7 +142,7 @@ PKL
     # Worktree adds extra line at end
     printf 'line1\n\nline2\nline3\n' > double.txt
 
-    run hk fix -v
+    run hk fix --stage -v
     assert_success
 
     # Check exact bytes
@@ -178,7 +178,7 @@ PY'
     create_fix_config_with_stash git
     prepare_sample_file
 
-    run hk fix -v
+    run hk fix --stage -v
     assert_success
 
     assert_preserves_newline
@@ -193,7 +193,7 @@ PY'
     create_fix_config_with_stash patch-file
     prepare_sample_file
 
-    run hk fix -v
+    run hk fix --stage -v
     assert_success
 
     assert_preserves_newline
@@ -244,7 +244,7 @@ PKL
     # So it reads "content\n" instead of "content\n\n"
     # This causes incorrect tail detection: thinks "\nExtra\n" is the tail
     # Result: worktree gets corrupted with wrong merge
-    run hk fix -v
+    run hk fix --stage -v
     assert_success
 
     # Use exact newline preservation check

--- a/test/gomod_tidy_nested_module.bats
+++ b/test/gomod_tidy_nested_module.bats
@@ -79,7 +79,7 @@ PKL
     git add svc/main.go
 
     PATH="$PROJECT_ROOT/test/builtin_tool_stubs:$PATH"
-    run hk fix --step gomod_tidy
+    run hk fix --stage --step gomod_tidy
     assert_success
 
     run git diff --cached --name-only

--- a/test/group_inheritance.bats
+++ b/test/group_inheritance.bats
@@ -125,7 +125,7 @@ EOF
 
     echo "dirty" > packages/frontend/dist/assets/output.txt
 
-    run hk run fix
+    run hk run fix --stage
     assert_success
 
     run git diff --name-only --cached

--- a/test/overstaging_prettier.bats
+++ b/test/overstaging_prettier.bats
@@ -38,10 +38,10 @@ PKL
   printf 'two\n' > src/unrelated.ts
   printf 'one\nmore\n' > src/changed.ts
 
-  run hk fix -v
+  run hk fix --stage -v
   assert_success
 
-  # Both files match **/*.ts so both should be staged (explicit stage glob opts into staging untracked)
+  # Both files match **/*.ts, so the step filter stages both when staging is enabled.
   run git status --porcelain
   assert_success
   assert_line --regexp '^[MA]  src/changed\.ts$'
@@ -82,7 +82,7 @@ PKL
   # Now modify the job file
   printf 'one\nmore\n' > src/changed.ts
 
-  run hk fix -v
+  run hk fix --stage -v
   assert_success
 
   # changed.ts should be staged (matches glob), but .md files should not
@@ -126,7 +126,7 @@ PKL
 
   printf 'one\nmore\n' > src/changed.ts
 
-  run hk fix -v
+  run hk fix --stage -v
   assert_success
 
   # Both changed.ts AND created_by_step.ts should be staged
@@ -166,7 +166,7 @@ PKL
   printf 'one\nmore\n' > src/changed.ts
   printf 'two\nmore\n' > src/other.ts
 
-  run hk fix -v
+  run hk fix --stage -v
   assert_success
 
   # Both files match **/*.ts so both should be staged

--- a/test/stage_default.bats
+++ b/test/stage_default.bats
@@ -42,11 +42,11 @@ EOF
     assert_output ' M file.txt'
 }
 
-@test "hook stage=false prevents staging even with default step stage" {
+@test "hook stage=false disables the pre-commit staging default" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
 hooks {
-    ["fix"] {
+    ["pre-commit"] {
         fix = true
         stage = false
         steps {
@@ -64,19 +64,20 @@ EOF
 
     # Modify file to create unstaged changes
     echo "modified" > file.txt
+    git add file.txt
 
-    hk run fix
+    hk run pre-commit
 
     run git status --porcelain
     assert_success
-    assert_output ' M file.txt'
+    assert_output 'MM file.txt'
 }
 
-@test "HK_STAGE=0 prevents staging even with default step stage" {
+@test "HK_STAGE=0 disables the pre-commit staging default" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
 hooks {
-    ["fix"] {
+    ["pre-commit"] {
         fix = true
         steps {
             ["add-newline"] {
@@ -93,12 +94,13 @@ EOF
 
     # Modify file to create unstaged changes
     echo "modified" > file.txt
+    git add file.txt
 
-    HK_STAGE=0 hk run fix
+    HK_STAGE=0 hk run pre-commit
 
     run git status --porcelain
     assert_success
-    assert_output ' M file.txt'
+    assert_output 'MM file.txt'
 }
 
 @test "explicit step stage filters paths when hook staging is enabled" {
@@ -195,11 +197,11 @@ EOF
     assert_output ' M file.txt'
 }
 
-@test "--no-stage CLI flag prevents staging with default step stage" {
+@test "--no-stage disables the pre-commit staging default" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
 hooks {
-    ["fix"] {
+    ["pre-commit"] {
         fix = true
         steps {
             ["add-newline"] {
@@ -216,10 +218,11 @@ EOF
 
     # Modify file to create unstaged changes
     echo "modified" > file.txt
+    git add file.txt
 
-    hk run fix --no-stage
+    hk run pre-commit --no-stage
 
     run git status --porcelain
     assert_success
-    assert_output ' M file.txt'
+    assert_output 'MM file.txt'
 }

--- a/test/stage_default.bats
+++ b/test/stage_default.bats
@@ -13,7 +13,7 @@ teardown() {
     _common_teardown
 }
 
-@test "step with fix but no stage auto-stages fixed files" {
+@test "manual fix hook does not stage by default" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
 hooks {
@@ -39,7 +39,7 @@ EOF
 
     run git status --porcelain
     assert_success
-    assert_output 'M  file.txt'
+    assert_output ' M file.txt'
 }
 
 @test "hook stage=false prevents staging even with default step stage" {
@@ -101,7 +101,40 @@ EOF
     assert_output ' M file.txt'
 }
 
-@test "explicit step stage overrides default" {
+@test "explicit step stage filters paths when hook staging is enabled" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["fix"] {
+        fix = true
+        stage = true
+        steps {
+            ["add-newline"] {
+                glob = "*.txt"
+                fix = #"for f in {{ files }}; do echo >> \$f; done"#
+                stage = List("*.log")
+            }
+        }
+    }
+}
+EOF
+    echo -n "no newline" > file.txt
+    echo "log content" > file.log
+    git add hk.pkl file.txt file.log
+    git commit -m "initial commit"
+
+    echo "modified" > file.txt
+    echo "modified log" > file.log
+
+    hk run fix
+
+    run git status --porcelain
+    assert_success
+    assert_output --partial 'M  file.log'
+    assert_output --partial ' M file.txt'
+}
+
+@test "explicit step stage does not enable hook staging" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"
 hooks {
@@ -122,17 +155,14 @@ EOF
     git add hk.pkl file.txt file.log
     git commit -m "initial commit"
 
-    # Modify both files
     echo "modified" > file.txt
     echo "modified log" > file.log
 
     hk run fix
 
-    # Only .txt was fixed, but stage is set to *.log
-    # So .txt should remain unstaged, .log should be staged
     run git status --porcelain
     assert_success
-    assert_output --partial 'M  file.log'
+    assert_output --partial ' M file.log'
     assert_output --partial ' M file.txt'
 }
 

--- a/test/stage_generated_files.bats
+++ b/test/stage_generated_files.bats
@@ -39,7 +39,7 @@ TS
 export const schema = 'changed'
 TS
 
-    run hk fix -v
+    run hk fix --stage -v
     assert_success
 
     run git status --porcelain -- fooment/schemas/generated.proto config/logging/generated/frontend_schema.ts

--- a/test/stage_job_files.bats
+++ b/test/stage_job_files.bats
@@ -67,7 +67,7 @@ EOF
   # Modify the tracked shell script (with "bad" formatting that check will detect)
   printf 'echo "modified"\nNEEDS_FORMATTING\n' >> src/script.sh
 
-  run hk fix -v
+  run hk fix --stage -v
   assert_success
 
   # src/script.sh should be staged (tracked modified file processed by check_list_files)
@@ -132,7 +132,7 @@ EOF
   printf 'export const baz = 3;\n' >> src/with_todo.ts
   printf 'export const qux = 4;\n' >> src/without_todo.ts
 
-  run hk fix -v
+  run hk fix --stage -v
   assert_success
 
   # Only with_todo.ts should be staged (it had TODO and was processed)
@@ -176,7 +176,7 @@ PKL
   # Modify input
   printf 'export const modified = 2;\n' >> src/input.ts
 
-  run hk fix -v
+  run hk fix --stage -v
   assert_success
 
   # Both input.ts and generated.ts should be staged

--- a/test/stage_root_glob.bats
+++ b/test/stage_root_glob.bats
@@ -37,7 +37,7 @@ EOF
     [[ "$output" == '?? maintainers.yml' ]]
 
     # run fix using hk in PATH (added by test helper)
-    hk fix -v
+    hk fix --stage -v
 
     # file should be staged after hk fix
     run git status --porcelain -- maintainers.yml
@@ -72,7 +72,7 @@ EOF
     assert_success
     [[ "$output" == '?? pkg/maintainers.yml' ]]
 
-    hk fix -v
+    hk fix --stage -v
 
     run git status --porcelain -- pkg/maintainers.yml
     assert_success
@@ -105,7 +105,7 @@ EOF
     assert_success
     [[ "$output" == $'?? a.txt\n?? b.txt' ]]
 
-    hk fix -v
+    hk fix --stage -v
 
     run git status --porcelain -- a.txt b.txt
     assert_success

--- a/test/stage_setting.bats
+++ b/test/stage_setting.bats
@@ -15,6 +15,13 @@ hooks {
             ["trailing-whitespace"] = Builtins.trailing_whitespace
         }
     }
+    ["pre-commit"] {
+        fix = true
+        stash = "none"
+        steps {
+            ["trailing-whitespace"] = Builtins.trailing_whitespace()
+        }
+    }
 }
 EOF
     touch file.txt
@@ -26,10 +33,21 @@ teardown() {
     _common_teardown
 }
 
-@test "stages by default" {
+@test "non-pre-commit hooks do not stage by default" {
     echo "content  " > file.txt
 
     hk run fix
+
+    run git status --porcelain
+    assert_success
+    assert_output ' M file.txt'
+}
+
+@test "pre-commit stages by default" {
+    echo "content  " > file.txt
+    git add file.txt
+
+    hk run pre-commit
 
     run git status --porcelain
     assert_success

--- a/test/stage_setting.bats
+++ b/test/stage_setting.bats
@@ -20,7 +20,7 @@ hooks {
         stage = read?("env:PRE_COMMIT_STAGE")?.toBoolean() ?? null
         stash = "none"
         steps {
-            ["trailing-whitespace"] = Builtins.trailing_whitespace()
+            ["trailing-whitespace"] = Builtins.trailing_whitespace
         }
     }
 }

--- a/test/stage_setting.bats
+++ b/test/stage_setting.bats
@@ -17,6 +17,7 @@ hooks {
     }
     ["pre-commit"] {
         fix = true
+        stage = read?("env:PRE_COMMIT_STAGE")?.toBoolean() ?? null
         stash = "none"
         steps {
             ["trailing-whitespace"] = Builtins.trailing_whitespace()
@@ -56,12 +57,13 @@ teardown() {
 
 @test "disabled in hook config" {
     echo "content  " > file.txt
+    git add file.txt
 
-    FIX_STAGE=false hk run fix
+    PRE_COMMIT_STAGE=false hk run pre-commit
 
     run git status --porcelain
     assert_success
-    assert_output ' M file.txt'
+    assert_output 'MM file.txt'
 }
 
 @test "disabled in config" {
@@ -69,12 +71,13 @@ teardown() {
     git commit -am "disabling stage in config"
 
     echo "content  " > file.txt
+    git add file.txt
 
-    hk run fix
+    hk run pre-commit
 
     run git status --porcelain
     assert_success
-    assert_output ' M file.txt'
+    assert_output 'MM file.txt'
 }
 
 @test "disabled in user config" {
@@ -86,43 +89,47 @@ EOF
     echo ".hkrc.pkl" > .git/info/exclude
 
     echo "content  " > file.txt
+    git add file.txt
 
-    hk run fix
+    hk run pre-commit
 
     run git status --porcelain
     assert_success
-    assert_output ' M file.txt'
+    assert_output 'MM file.txt'
 }
 
 @test "disabled in git config" {
     git config hk.stage false
     echo "content  " > file.txt
+    git add file.txt
 
-    hk run fix
+    hk run pre-commit
 
     run git status --porcelain
     assert_success
-    assert_output ' M file.txt'
+    assert_output 'MM file.txt'
 }
 
 @test "disabled in envvar" {
     echo "content  " > file.txt
+    git add file.txt
 
-    HK_STAGE=0 hk run fix
+    HK_STAGE=0 hk run pre-commit
 
     run git status --porcelain
     assert_success
-    assert_output ' M file.txt'
+    assert_output 'MM file.txt'
 }
 
 @test "disabled on CLI" {
     echo "content  " > file.txt
+    git add file.txt
 
-    hk run -v fix --no-stage
+    hk run -v pre-commit --no-stage
 
     run git status --porcelain
     assert_success
-    assert_output ' M file.txt'
+    assert_output 'MM file.txt'
 }
 
 @test "CLI enable overrides env disable" {


### PR DESCRIPTION
## Summary

- stage fixes by default only for `pre-commit`
- leave manual `hk fix` and other hooks unstaged unless staging is explicitly enabled
- preserve precedence across CLI, settings, hook configuration, and contextual defaults
- treat step-level stage patterns as filters rather than implicit staging switches
- document hook defaults in one canonical configuration section

## v2 stack

- #1253 (1/5) — flat configurable builtin steps
- #1255 (2/5) — shared top-level steps and hook materialization
- #1256 (3/5) — contextual staging defaults
- #1257 (4/5) — remove v1 interfaces and add migration guidance
- #1369 (5/5) — remove the external Pkl runtime fallback

Depends on #1255.

## Verification

- staging-default and staging-setting tests with both Git backends
- Rust test suite
- stack-top slow lint/check suite and Apple Pkl compatibility validation

_AI-generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes default Git index behavior for `hk fix` and non-pre-commit hooks—a breaking workflow change—and alters when step-level stage globs apply, which can surprise users who relied on implicit staging.
> 
> **Overview**
> **Breaking change:** Git staging after fix steps is no longer the default for every hook. Only **`pre-commit`** auto-stages fixed files; **`hk fix`**, **`check`**, and custom hooks leave the index alone unless staging is turned on.
> 
> Runtime resolution is **CLI / `HK_STAGE` / git `hk.stage` → hook `stage` → hook name** (`pre-commit` = on, everything else = off). Default hook materialization no longer sets `stage` on `check` / `fix` / `pre-commit`; that behavior lives in `hook.rs` and step execution.
> 
> **Step `stage` globs** are documented and implemented as **path filters only**—they do not enable staging. When hook staging is off, step patterns are ignored; when on, they limit what gets `git add` (default remains job files for fixers).
> 
> Docs add a **Hook defaults** section; Pkl/schema and `settings.toml` describe the new rules. Integration tests that expected `hk fix` to stage now pass **`--stage`**; `stage_default.bats` / `stage_setting.bats` assert the pre-commit vs manual-fix split. The aqua checksum builtin test accepts **sha256 or sha512** per platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a3332d0e0280b05e68a6c489933f5366b58a0b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->