### PR TITLE
security(ci): isolate mbx OIDC permissions

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,13 +1,18 @@
 name: Set up mbx
 description: Select the trusted jdx server or fork-safe GitHub cache backend
 
+inputs:
+  backend:
+    description: Explicit backend for structurally trusted or untrusted callers
+    default: auto
+
 runs:
   using: composite
   steps:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'github' || 'server' }}
+        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/hk
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -1,0 +1,351 @@
+name: ci implementation
+
+on:
+  workflow_call:
+    inputs:
+      trusted:
+        required: true
+        type: boolean
+      mbx-backend:
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MISE_EXPERIMENTAL: true
+  MISE_HTTP_TIMEOUT: 120
+  CARGO_HTTP_MULTIPLEXING: false
+  CARGO_HTTP_TIMEOUT: 120
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  mcp-ui:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+      - run: mise x -- aube ci
+      - run: ./mcp-ui/node_modules/.bin/vitest run --root mcp-ui
+      - run: ./scripts/check_mcp_ui_fresh
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
+          - os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+    runs-on: ${{ !inputs.trusted && matrix.os || matrix.runner }}
+    timeout-minutes: 10
+    steps:
+      - name: Assert OIDC is unavailable to untrusted CI
+        if: ${{ !inputs.trusted }}
+        run: |
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+      - run: mise run build
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hk-${{ matrix.os }}
+          path: target/debug/hk
+  build-windows:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - name: Build
+        run: mbx build --features git2/vendored-libgit2,git2/vendored-openssl
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hk-windows-latest
+          path: target/debug/hk.exe
+  ci-libgit2:
+    needs: build
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
+          - os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+    runs-on: ${{ !inputs.trusted && matrix.os || matrix.runner }}
+    timeout-minutes: 20
+    steps:
+      - run: brew install parallel
+        if: ${{ matrix.os == 'macos-latest' }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          toolchain: nightly
+          override: false
+          cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: hk-${{ matrix.os }}
+          path: target/debug
+      - run: chmod +x target/debug/hk
+      - run: mise x -- aube install
+      - name: mise run test:bats:libgit2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: mise run test:bats:libgit2
+  ci-nolibgit2:
+    needs: build
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
+          - os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+    runs-on: ${{ !inputs.trusted && matrix.os || matrix.runner }}
+    timeout-minutes: 20
+    steps:
+      - run: brew install parallel
+        if: ${{ matrix.os == 'macos-latest' }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          toolchain: nightly
+          override: false
+          cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: hk-${{ matrix.os }}
+          path: target/debug
+      - run: chmod +x target/debug/hk
+      - run: mise x -- aube install
+      - name: mise run test:bats:nolibgit2
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: mise run test:bats:nolibgit2
+  ci-nogit:
+    needs: build
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    # Pinned to github-hosted runners: builtins_tests.bats installs ~50
+    # tools via mise under 16-way parallelism, which surfaces a
+    # mise + namespace-runner incompatibility (many backends report
+    # "does not have an executable named X" on fresh installs, and
+    # asdf:swiftlint binaries SIGILL on namespace's linux image).
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - run: brew install parallel
+        if: ${{ matrix.os == 'macos-latest' }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          toolchain: nightly
+          override: false
+          cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: hk-${{ matrix.os }}
+          path: target/debug
+      - run: chmod +x target/debug/hk
+      - run: mise x -- aube install
+      - name: mise run test:bats:nogit
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: mise run test:bats:nogit
+  ci-other:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            runner: namespace-profile-endev-macos-arm64
+          - os: ubuntu-latest
+            runner: namespace-profile-endev-linux-amd64
+    runs-on: ${{ !inputs.trusted && matrix.os || matrix.runner }}
+    timeout-minutes: 20
+    steps:
+      - run: brew install parallel
+        if: ${{ matrix.os == 'macos-latest' }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+      - run: mise x -- aube install
+      - name: mise run test:cargo
+        run: mise run test:cargo
+      - name: mise run render
+        run: mise run render
+      - name: assert render produces no diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::'mise run render' produced changes. Run it locally and commit."
+            git status
+            git diff HEAD
+            exit 1
+          fi
+      - name: mise run lint
+        run: mise run lint
+  msrv:
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+      - run: mise run msrv
+  ci-windows:
+    needs: build-windows
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: hk-windows-latest
+          path: target/debug
+      - name: Generate builtins metadata
+        run: mise run pkl:gen
+      - name: Run cargo tests
+        run: mbx test --features git2/vendored-libgit2,git2/vendored-openssl -- --skip settings::tests::test_settings
+      - name: Run Pester e2e tests
+        run: |
+          $env:PKL_PATH = "${{ github.workspace }}/pkl"
+          # Run only basic tests that don't require pkl to avoid hangs
+          ./e2e-win/run.ps1 -TestName "*version*"
+          ./e2e-win/run.ps1 -TestName "*help*"
+          # Regression test for discussion #823 (cmd.exe {{files}} quoting)
+          ./e2e-win/run.ps1 -TestName "*{{files}} template*"
+          # Regression test for discussion #1220 (structured argv npm shims)
+          ./e2e-win/run.ps1 -TestName "*structured argv resolves*"
+  final:
+    permissions: {}
+    needs:
+      - build
+      - build-windows
+      - ci-libgit2
+      - ci-nolibgit2
+      - ci-nogit
+      - ci-other
+      - ci-windows
+      - mcp-ui
+      - msrv
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 1
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Check CI job results
+        run: |
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            echo "build failed or was skipped"
+            exit 1
+          fi
+          if [ "${{ needs.build-windows.result }}" != "success" ]; then
+            echo "build-windows failed or was skipped"
+            exit 1
+          fi
+          if [ "${{ needs.ci-libgit2.result }}" != "success" ]; then
+            echo "ci-libgit2 failed or was skipped"
+            exit 1
+          fi
+          if [ "${{ needs.ci-nolibgit2.result }}" != "success" ]; then
+            echo "ci-nolibgit2 failed or was skipped"
+            exit 1
+          fi
+          if [ "${{ needs.ci-nogit.result }}" != "success" ]; then
+            echo "ci-nogit failed or was skipped"
+            exit 1
+          fi
+          if [ "${{ needs.ci-other.result }}" != "success" ]; then
+            echo "ci-other failed or was skipped"
+            exit 1
+          fi
+          if [ "${{ needs.ci-windows.result }}" != "success" ]; then
+            echo "ci-windows failed or was skipped"
+            exit 1
+          fi
+          if [ "${{ needs.mcp-ui.result }}" != "success" ]; then
+            echo "mcp-ui failed or was skipped"
+            exit 1
+          fi
+          if [ "${{ needs.msrv.result }}" != "success" ]; then
+            echo "msrv failed or was skipped"
+            exit 1
+          fi
+          echo "All CI jobs completed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,344 +7,44 @@ on:
     tags: ["*"]
     branches: ["main"]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-env:
-  MISE_EXPERIMENTAL: true
-  MISE_HTTP_TIMEOUT: 120
-  CARGO_HTTP_MULTIPLEXING: false
-  CARGO_HTTP_TIMEOUT: 120
-  CARGO_NET_RETRY: 10
-  CARGO_TERM_COLOR: always
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 permissions: {}
 
 jobs:
-  mcp-ui:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+  trusted:
+    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          cache: false
-      - run: mise x -- aube ci
-      - run: ./mcp-ui/node_modules/.bin/vitest run --root mcp-ui
-      - run: ./scripts/check_mcp_ui_fresh
+      id-token: write
+    uses: ./.github/workflows/ci-impl.yml
+    with:
+      trusted: true
+      mbx-backend: server
 
-  build:
+  untrusted:
+    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
-          - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && matrix.os || matrix.runner }}
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          cache: false
-      - run: mise run build
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: hk-${{ matrix.os }}
-          path: target/debug/hk
-  build-windows:
-    runs-on: windows-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/mbx
-      - name: Build
-        run: mbx build --features git2/vendored-libgit2,git2/vendored-openssl
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: hk-windows-latest
-          path: target/debug/hk.exe
-  ci-libgit2:
-    needs: build
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
-          - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && matrix.os || matrix.runner }}
-    timeout-minutes: 20
-    steps:
-      - run: brew install parallel
-        if: ${{ matrix.os == 'macos-latest' }}
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          cache: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          toolchain: nightly
-          override: false
-          cache: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: hk-${{ matrix.os }}
-          path: target/debug
-      - run: chmod +x target/debug/hk
-      - run: mise x -- aube install
-      - name: mise run test:bats:libgit2
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: mise run test:bats:libgit2
-  ci-nolibgit2:
-    needs: build
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
-          - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && matrix.os || matrix.runner }}
-    timeout-minutes: 20
-    steps:
-      - run: brew install parallel
-        if: ${{ matrix.os == 'macos-latest' }}
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          cache: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          toolchain: nightly
-          override: false
-          cache: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: hk-${{ matrix.os }}
-          path: target/debug
-      - run: chmod +x target/debug/hk
-      - run: mise x -- aube install
-      - name: mise run test:bats:nolibgit2
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: mise run test:bats:nolibgit2
-  ci-nogit:
-    needs: build
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, ubuntu-latest]
-    # Pinned to github-hosted runners: builtins_tests.bats installs ~50
-    # tools via mise under 16-way parallelism, which surfaces a
-    # mise + namespace-runner incompatibility (many backends report
-    # "does not have an executable named X" on fresh installs, and
-    # asdf:swiftlint binaries SIGILL on namespace's linux image).
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
-    steps:
-      - run: brew install parallel
-        if: ${{ matrix.os == 'macos-latest' }}
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          cache: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          toolchain: nightly
-          override: false
-          cache: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: hk-${{ matrix.os }}
-          path: target/debug
-      - run: chmod +x target/debug/hk
-      - run: mise x -- aube install
-      - name: mise run test:bats:nogit
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: mise run test:bats:nogit
-  ci-other:
-    permissions:
-      contents: read
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-latest
-            runner: namespace-profile-endev-macos-arm64
-          - os: ubuntu-latest
-            runner: namespace-profile-endev-linux-amd64
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && matrix.os || matrix.runner }}
-    timeout-minutes: 20
-    steps:
-      - run: brew install parallel
-        if: ${{ matrix.os == 'macos-latest' }}
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          cache: false
-      - run: mise x -- aube install
-      - name: mise run test:cargo
-        run: mise run test:cargo
-      - name: mise run render
-        run: mise run render
-      - name: assert render produces no diff
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::error::'mise run render' produced changes. Run it locally and commit."
-            git status
-            git diff HEAD
-            exit 1
-          fi
-      - name: mise run lint
-        run: mise run lint
-  msrv:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          cache: false
-      - run: mise run msrv
-  ci-windows:
-    needs: build-windows
-    runs-on: windows-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-        with:
-          cache: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: hk-windows-latest
-          path: target/debug
-      - name: Generate builtins metadata
-        run: mise run pkl:gen
-      - name: Run cargo tests
-        run: mbx test --features git2/vendored-libgit2,git2/vendored-openssl -- --skip settings::tests::test_settings
-      - name: Run Pester e2e tests
-        run: |
-          $env:PKL_PATH = "${{ github.workspace }}/pkl"
-          # Run only basic tests that don't require pkl to avoid hangs
-          ./e2e-win/run.ps1 -TestName "*version*"
-          ./e2e-win/run.ps1 -TestName "*help*"
-          # Regression test for discussion #823 (cmd.exe {{files}} quoting)
-          ./e2e-win/run.ps1 -TestName "*{{files}} template*"
-          # Regression test for discussion #1220 (structured argv npm shims)
-          ./e2e-win/run.ps1 -TestName "*structured argv resolves*"
+    uses: ./.github/workflows/ci-impl.yml
+    with:
+      trusted: false
+      mbx-backend: github
+
   final:
+    name: final
+    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
     permissions: {}
-    needs:
-      - build
-      - build-windows
-      - ci-libgit2
-      - ci-nolibgit2
-      - ci-nogit
-      - ci-other
-      - ci-windows
-      - mcp-ui
-      - msrv
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    needs: [trusted, untrusted]
+    runs-on: ubuntu-latest
     timeout-minutes: 1
-    # Run on success or upstream failure but skip when the workflow is cancelled
-    # — `always()` would override `cancel-in-progress` and waste a runner.
-    if: ${{ !cancelled() }}
     steps:
-      - name: Check CI job results
+      - name: Check selected workflow result
+        env:
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
         run: |
-          if [ "${{ needs.build.result }}" != "success" ]; then
-            echo "build failed or was skipped"
-            exit 1
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
+            exit 0
           fi
-          if [ "${{ needs.build-windows.result }}" != "success" ]; then
-            echo "build-windows failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.ci-libgit2.result }}" != "success" ]; then
-            echo "ci-libgit2 failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.ci-nolibgit2.result }}" != "success" ]; then
-            echo "ci-nolibgit2 failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.ci-nogit.result }}" != "success" ]; then
-            echo "ci-nogit failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.ci-other.result }}" != "success" ]; then
-            echo "ci-other failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.ci-windows.result }}" != "success" ]; then
-            echo "ci-windows failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.mcp-ui.result }}" != "success" ]; then
-            echo "mcp-ui failed or was skipped"
-            exit 1
-          fi
-          if [ "${{ needs.msrv.result }}" != "success" ]; then
-            echo "msrv failed or was skipped"
-            exit 1
-          fi
-          echo "All CI jobs completed successfully"
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1

--- a/.github/workflows/docs-impl.yml
+++ b/.github/workflows/docs-impl.yml
@@ -1,0 +1,65 @@
+name: docs implementation
+
+on:
+  workflow_call:
+    inputs:
+      trusted:
+        required: true
+        type: boolean
+      mbx-backend:
+        required: true
+        type: string
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    if: github.repository == 'jdx/hk'
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    steps:
+      - name: Assert OIDC is unavailable to untrusted docs builds
+        if: ${{ !inputs.trusted }}
+        run: |
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # Not needed if lastUpdated is not enabled
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+      - name: Build with VitePress
+        run: |
+          mise run docs:build
+          touch docs/.vitepress/dist/.nojekyll
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          path: docs/.vitepress/dist
+
+  # Deployment job
+  deploy:
+    if: inputs.trusted && github.repository == 'jdx/hk'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: namespace-profile-endev-linux-amd64
+    name: Deploy
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,71 +1,53 @@
 name: docs
 
 on:
-  # Runs on pushes targeting the `main` branch. Change this to `master` if you're
-  # using the `master` branch as the default branch.
   push:
     branches: [main]
     paths:
       - "docs/**"
       - settings.toml
       - ".github/**"
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions: {}
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 jobs:
-  # Build job
-  build:
-    if: github.repository == 'jdx/hk'
-    runs-on: namespace-profile-endev-linux-amd64
+  trusted:
+    if: ${{ github.actor == 'jdx' }}
     permissions:
       contents: read
       id-token: write
-      # actions/configure-pages needs pages permission to enable Pages on the repo.
       pages: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0 # Not needed if lastUpdated is not enabled
-          persist-credentials: false
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-      - name: Setup Pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
-      - name: Build with VitePress
-        run: |
-          mise run docs:build
-          touch docs/.vitepress/dist/.nojekyll
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
-        with:
-          path: docs/.vitepress/dist
+    uses: ./.github/workflows/docs-impl.yml
+    with:
+      trusted: true
+      mbx-backend: server
 
-  # Deployment job
-  deploy:
-    if: github.repository == 'jdx/hk'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  untrusted:
+    if: ${{ github.actor != 'jdx' }}
     permissions:
-      pages: write # to deploy to Pages
-      id-token: write # to verify the deployment originates from an appropriate source
-    needs: build
-    runs-on: namespace-profile-endev-linux-amd64
-    name: Deploy
+      contents: read
+    uses: ./.github/workflows/docs-impl.yml
+    with:
+      trusted: false
+      mbx-backend: github
+
+  docs:
+    name: docs
+    if: ${{ always() && !cancelled() && needs.trusted.result != 'cancelled' && needs.untrusted.result != 'cancelled' }}
+    permissions: {}
+    needs: [trusted, untrusted]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+      - name: Check selected workflow result
+        env:
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
+        run: |
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
+            exit 0
+          fi
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1


### PR DESCRIPTION
## Summary

- cap untrusted CI and docs builds at `contents: read`, so they cannot mint GitHub OIDC tokens
- pass explicit trust and mbx backend inputs into reusable workflows
- keep trusted `jdx` runs on Namespace/server and all other actors on GitHub-hosted/GitHub cache
- keep Pages deployment exclusive to the trusted caller
- preserve the existing artifacts and fan-in checks

Validated first with both trusted and forced-untrusted runs in jdx/tak#61. This follows up #1254.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions trust boundaries and OIDC scope for CI and Pages; mistakes in the `if` conditions could break fork PR CI or weaken isolation, but the diff is defensive hardening.
> 
> **Overview**
> **Splits CI and docs into structurally trusted vs untrusted reusable workflows** so only the trusted caller job can grant `id-token: write`; untrusted paths are capped at `contents: read` and cannot mint OIDC tokens for the mbx server cache.
> 
> The main `ci.yml` and `docs.yml` entrypoints now dispatch to new `ci-impl.yml` / `docs-impl.yml` callables with explicit `trusted` and `mbx-backend` inputs. Trusted `jdx` runs (same-repo PRs included) use Namespace runners and `mbx-backend: server`; everyone else uses GitHub-hosted runners and GitHub cache. Untrusted builds **assert** OIDC env vars are empty, and **GitHub Pages deploy runs only when `inputs.trusted`**.
> 
> The **mbx composite action** gains a `backend` input (default `auto`) so callers can pin `server` or `github` instead of inferring only from inline expressions. Top-level **final** jobs now pass when exactly one of `trusted` / `untrusted` succeeds and the other is skipped, instead of fanning in every CI subjob at the root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50957c4ea13c8e5c13f7e021ecfa551724c57434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->