### PR TITLE
ci: seed mbx cache for fork PRs

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -5,10 +5,19 @@ inputs:
   backend:
     description: Explicit backend for structurally trusted or untrusted callers
     default: auto
+  mirror-github-cache:
+    description: Mirror a trusted main build into the restore-only cache used by fork PRs
+    default: "false"
 
 runs:
   using: composite
   steps:
+    - name: Restore the fork PR cache mirror
+      if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
+      with:
+        version: 0.4.0
+        backend: github
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -63,6 +63,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.mbx-backend }}
+          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
@@ -81,6 +82,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.mbx-backend }}
+          mirror-github-cache: "true"
       - name: Build
         run: mbx build --features git2/vendored-libgit2,git2/vendored-openssl
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## Summary

- restore the fork-facing GitHub Actions mbx cache in one canonical CI job per supported OS
- keep the trusted server backend active for compilation, then save the updated local store under the exact key format fork PRs restore
- restrict mirror writes to jdx pushes on main; fork and other untrusted PR runs remain restore-only and OIDC-free

## Validation

- actionlint
- high-severity zizmor audit
- git diff check
- confirmed release workflows do not enable the mirror

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to GitHub Actions cache wiring with explicit guards on who can write the mirror; no application or auth logic is modified.
> 
> **Overview**
> Adds a **`mirror-github-cache`** input to the **`mbx`** composite action and turns it on only in the **`build`** and **`build-windows`** jobs in **`ci-impl.yml`**.
> 
> When mirroring is enabled, an extra **`mr-boxington-action`** step runs first with **`backend: github`** so the same restore-only GitHub Actions cache key fork PRs use can be populated. That step is gated to **`jdx`** pushes on **`main`**; untrusted or fork runs still do not write the mirror. The existing mbx setup step continues to choose the trusted server backend or GitHub backend for the actual compile cache as before.
> 
> Other CI jobs that call **`mbx`** keep the default (**`mirror-github-cache: false`**), so mirror seeding stays limited to the canonical per-OS build jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0333318577c36978024a596747a916d0e0b05c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build cache mirroring for supported main-branch builds.
  * Enabled cache mirroring in standard Linux and Windows build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->