### PR TITLE
docs: disable code ligatures

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -18,6 +18,15 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap');
 
+/* Preserve command syntax exactly instead of rendering operators as ligatures. */
+code,
+kbd,
+pre,
+samp {
+  font-variant-ligatures: none;
+  font-feature-settings: 'liga' 0, 'calt' 0;
+}
+
 /* Custom properties - Dark mode only */
 :root {
   /* Brand colors - Electric Blue */


### PR DESCRIPTION
## Summary

- disable font ligatures for code-like elements
- preserve CLI syntax such as `<--target` exactly as written

Addresses discussion #1263.

## Verification

- `mise run docs:build`
- `git diff --check`

`hk check --all` could not complete because the local `shellcheck` mise shim has no active version; hk aborted the remaining checks after actionlint failed for that environment issue.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only CSS presentation change with no runtime, auth, or data impact.
> 
> **Overview**
> The docs VitePress theme now turns off monospace ligatures for **`code`**, **`kbd`**, **`pre`**, and **`samp`** via `font-variant-ligatures: none` and disabled `liga`/`calt` features.
> 
> That keeps JetBrains Mono from merging sequences like `<--` into ligature glyphs, so CLI examples (e.g. `<--target`) read exactly as written in the source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6279cbbdfb90af2b9d116104734021407d18fd88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved command and code text rendering by disabling font ligatures and contextual alternates in code blocks and keyboard-style elements.
  * Preserved the exact appearance of command syntax for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->