### PR TITLE
chore(ci): compare mbx with rust-cache

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -74,8 +74,8 @@ jobs:
           elapsed=$SECONDS
           echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
 
-  comparison:
-    name: comparison
+  comparison_macos:
+    name: comparison (macOS)
     needs: [mbx, rust-cache]
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -89,7 +89,81 @@ jobs:
           delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           {
-            echo "## Cache build comparison"
+            echo "## macOS cache build comparison"
+            echo
+            echo "| Backend | Build time |"
+            echo "| --- | ---: |"
+            echo "| mbx | ${MBX_SECONDS}s |"
+            echo "| Swatinem/rust-cache | ${RUST_CACHE_SECONDS}s |"
+            echo
+            echo "mbx delta: **${delta}** (positive means mbx was faster)."
+            echo
+            echo "> Treat the first main-branch run as cache seeding. Compare workflow_dispatch runs after it. Build time excludes checkout and cache setup; compare those step durations separately."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  mbx_windows:
+    name: mbx (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    outputs:
+      seconds: ${{ steps.build.outputs.seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: github
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          SECONDS=0
+          mbx build
+          elapsed=$SECONDS
+          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          mbx cache stats
+
+  rust_cache_windows:
+    name: Swatinem rust-cache (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    outputs:
+      seconds: ${{ steps.build.outputs.seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
+        with:
+          shared-key: cache-benchmark-windows-v1
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          SECONDS=0
+          cargo build
+          elapsed=$SECONDS
+          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+
+  comparison_windows:
+    name: comparison (Windows)
+    needs: [mbx_windows, rust_cache_windows]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    env:
+      MBX_SECONDS: ${{ needs.mbx_windows.outputs.seconds }}
+      RUST_CACHE_SECONDS: ${{ needs.rust_cache_windows.outputs.seconds }}
+    steps:
+      - name: Summarize results
+        shell: bash
+        run: |
+          delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          {
+            echo "## Windows cache build comparison"
             echo
             echo "| Backend | Build time |"
             echo "| --- | ---: |"

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -37,6 +37,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: "1.95.0"
       - uses: ./.github/actions/mbx
         with:
           backend: github
@@ -44,9 +48,10 @@ jobs:
         id: build
         shell: bash
         run: |
-          SECONDS=0
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
           mbx build
-          elapsed=$SECONDS
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
           echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
           mbx cache stats
 
@@ -60,6 +65,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: "1.95.0"
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:
@@ -69,9 +78,10 @@ jobs:
         id: build
         shell: bash
         run: |
-          SECONDS=0
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
           cargo build
-          elapsed=$SECONDS
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
           echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
 
   comparison_macos:
@@ -111,17 +121,23 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: "1.95.0"
       - uses: ./.github/actions/mbx
         with:
           backend: github
       - name: Build
         id: build
-        shell: bash
+        shell: pwsh
         run: |
-          SECONDS=0
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
           mbx build
-          elapsed=$SECONDS
-          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $timer.Stop()
+          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "seconds=$elapsed" >> $env:GITHUB_OUTPUT
           mbx cache stats
 
   rust_cache_windows:
@@ -134,6 +150,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: "1.95.0"
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:
@@ -141,12 +161,14 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Build
         id: build
-        shell: bash
+        shell: pwsh
         run: |
-          SECONDS=0
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
           cargo build
-          elapsed=$SECONDS
-          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $timer.Stop()
+          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "seconds=$elapsed" >> $env:GITHUB_OUTPUT
 
   comparison_windows:
     name: comparison (Windows)

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -133,7 +133,7 @@ jobs:
         shell: pwsh
         run: |
           $timer = [System.Diagnostics.Stopwatch]::StartNew()
-          mbx build
+          mbx build --features git2/vendored-libgit2,git2/vendored-openssl
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $timer.Stop()
           $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
@@ -164,7 +164,7 @@ jobs:
         shell: pwsh
         run: |
           $timer = [System.Diagnostics.Stopwatch]::StartNew()
-          cargo build
+          cargo build --features git2/vendored-libgit2,git2/vendored-openssl
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           $timer.Stop()
           $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -1,0 +1,102 @@
+name: cache benchmark
+
+on:
+  pull_request:
+    paths:
+      - .github/actions/mbx/action.yml
+      - .github/workflows/cache-benchmark.yml
+  push:
+    branches: [main]
+    paths:
+      - .github/actions/mbx/action.yml
+      - .github/workflows/cache-benchmark.yml
+      - Cargo.lock
+      - Cargo.toml
+      - "**/*.rs"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cache-benchmark-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+
+jobs:
+  mbx:
+    name: mbx (macOS)
+    runs-on: macos-14
+    timeout-minutes: 20
+    outputs:
+      seconds: ${{ steps.build.outputs.seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: github
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          SECONDS=0
+          mbx build
+          elapsed=$SECONDS
+          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          mbx cache stats
+
+  rust-cache:
+    name: Swatinem rust-cache (macOS)
+    runs-on: macos-14
+    timeout-minutes: 20
+    outputs:
+      seconds: ${{ steps.build.outputs.seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
+        with:
+          shared-key: cache-benchmark-macos-v1
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          SECONDS=0
+          cargo build
+          elapsed=$SECONDS
+          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+
+  comparison:
+    name: comparison
+    needs: [mbx, rust-cache]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    env:
+      MBX_SECONDS: ${{ needs.mbx.outputs.seconds }}
+      RUST_CACHE_SECONDS: ${{ needs.rust-cache.outputs.seconds }}
+    steps:
+      - name: Summarize results
+        shell: bash
+        run: |
+          delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          {
+            echo "## Cache build comparison"
+            echo
+            echo "| Backend | Build time |"
+            echo "| --- | ---: |"
+            echo "| mbx | ${MBX_SECONDS}s |"
+            echo "| Swatinem/rust-cache | ${RUST_CACHE_SECONDS}s |"
+            echo
+            echo "mbx delta: **${delta}** (positive means mbx was faster)."
+            echo
+            echo "> Treat the first main-branch run as cache seeding. Compare workflow_dispatch runs after it. Build time excludes checkout and cache setup; compare those step durations separately."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- add macOS and Windows A/B workflows for mbx and Swatinem/rust-cache
- run equivalent non-incremental builds and publish per-platform build timings
- keep the benchmark off release and tag workflows

## Method
The first main-branch run seeds the dedicated rust-cache keys. Warm comparisons should use later workflow_dispatch runs. Build timing excludes checkout and cache setup; those remain visible as separate step durations.

The Windows mbx path exercises the native-search-directory fix in jdx/mr-boxington#120 once that fix is released and the pinned mbx version is updated.

## Validation
- actionlint -shellcheck= .github/workflows/cache-benchmark.yml
- mise x zizmor@1.29.0 -- zizmor .github/workflows/cache-benchmark.yml

*AI-assisted — Tool: Codex; model: OpenAI/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow addition with read permissions and restricted rust-cache writes; no application or runtime behavior changes.
> 
> **Overview**
> Adds a new **`cache-benchmark`** GitHub Actions workflow that A/B tests **mbx** (via `./.github/actions/mbx` with the GitHub backend) against **Swatinem/rust-cache** on **macOS** and **Windows**.
> 
> Each platform runs parallel jobs that time only the build step (`mbx build` vs `cargo build`, with vendored git2/openssl features on Windows), set **`CARGO_INCREMENTAL: 0`**, and pass build seconds to lightweight **comparison** jobs that write a markdown table and **mbx delta %** to **`GITHUB_STEP_SUMMARY`**. The rust-cache arms use dedicated **`shared-key`** values and **`save-if`** limited to **main** pushes so PRs don’t poison benchmark caches.
> 
> Triggers are scoped: PRs only when the workflow or mbx action change; pushes to **main** also when Rust sources or lockfiles change; plus **`workflow_dispatch`** for warm runs after cache seeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a83bd6825d146f558af8f6ad65d393425d38a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated cache benchmarking for macOS and Windows builds.
  * Benchmarks compare cache performance, build times, and timing differences across platforms.
  * Results are summarized with formatted comparisons and practical interpretation guidance.
  * Added support for running benchmarks on pull requests, main-branch updates, and on demand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->