### PR TITLE
docs: publish llms.txt index

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -3,24 +3,8 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitepress'
 
-import spec from "../cli/commands.json";
 import pklLang from '../pkl.tmLanguage.json'
-
-interface Command {
-  subcommands: Record<string, Command & { hide?: boolean; full_cmd: string[] }>;
-}
-
-function getCommands(cmd: Command): string[][] {
-  const commands: string[][] = [];
-  for (const [name, sub] of Object.entries(cmd.subcommands)) {
-    if (sub.hide) continue;
-    commands.push(sub.full_cmd);
-    commands.push(...getCommands(sub));
-  }
-  return commands;
-}
-
-const commands = getCommands(spec.cmd);
+import { sidebar } from './sidebar'
 const configDir = dirname(fileURLToPath(import.meta.url));
 const cargoToml = readFileSync(resolve(configDir, '../../Cargo.toml'), 'utf8');
 const versionMatch = cargoToml.match(/^\[package\][\s\S]*?^\s*version\s*=\s*"([^"]+)"/m);
@@ -49,40 +33,7 @@ export default defineConfig({
       { text: 'CLI Reference', link: '/cli/' },
       { text: `v${latestVersion}`, link: 'https://github.com/jdx/hk/releases' },
     ],
-    sidebar: [
-      { text: 'Getting Started', link: '/getting_started' },
-      { text: 'Configuration', link: '/configuration' },
-      {
-        text: 'Guides',
-        items: [
-          { text: 'Built-in Linters', link: '/builtins' },
-          { text: 'Configuration Examples', link: '/reference/examples/' },
-          { text: 'Git Hooks', link: '/hooks' },
-          { text: 'mise Integration', link: '/mise_integration' },
-          { text: 'Coding Agents', link: '/agents' },
-        ]
-      },
-      { text: 'CLI Reference', link: '/cli', items: commands.map(cmd => ({ text: cmd.join(' '), link: `/cli/${cmd.join('/')}` })) },
-      {
-        text: 'Reference',
-        items: [
-          { text: 'Environment Variables', link: '/environment_variables' },
-          { text: 'Pkl Introduction', link: '/pkl_introduction' },
-          { text: 'Logging and Debugging', link: '/logging' },
-          { text: 'Glossary', link: '/glossary' },
-        ]
-      },
-      {
-        text: 'Project',
-        items: [
-          { text: 'Why hk?', link: '/why-hk' },
-          { text: 'Benchmarks', link: '/benchmarks' },
-          { text: 'Contributing', link: '/contributing' },
-          { text: 'About', link: '/about' },
-          { text: 'Sea Shanty', link: '/shanty' },
-        ]
-      },
-    ],
+    sidebar,
     socialLinks: [
       { icon: 'github', link: 'https://github.com/jdx/hk' },
       { icon: 'discord', link: 'https://discord.gg/UBa7pJUN7Z' },

--- a/docs/.vitepress/llms.ts
+++ b/docs/.vitepress/llms.ts
@@ -1,0 +1,148 @@
+// Generates docs/public/llms.txt, served at https://hk.jdx.dev/llms.txt.
+// The page list comes from the VitePress sidebar and descriptions come from
+// each page's lead paragraph so the index stays aligned with the documentation.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { sidebar, type SidebarItem } from './sidebar.ts'
+
+const configDir = dirname(fileURLToPath(import.meta.url))
+const docsDir = resolve(configDir, '..')
+const outFile = resolve(docsDir, 'public/llms.txt')
+const siteUrl = 'https://hk.jdx.dev'
+const maxDescription = 200
+
+function sourceFile(link: string): string {
+  const relative = link.replace(/^\//, '')
+  return resolve(
+    docsDir,
+    relative.endsWith('/') ? `${relative}index.md` : `${relative}.md`,
+  )
+}
+
+function pageUrl(link: string): string {
+  return link.endsWith('/')
+    ? `${siteUrl}${link}`
+    : `${siteUrl}${link}.html`
+}
+
+function plain(markdown: string): string {
+  return markdown
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/\[((?:[^[\]]|\[[^[\]]*\])*)\]\([^)]*\)/g, '$1')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, '$1')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function description(file: string): string | undefined {
+  let markdown: string
+  try {
+    markdown = readFileSync(file, 'utf8')
+  } catch {
+    return undefined
+  }
+
+  markdown = markdown.replace(/^---\n[\s\S]*?\n---\n/, '')
+
+  let seenHeading = false
+  const paragraph: string[] = []
+
+  for (const raw of markdown.split('\n')) {
+    const line = raw.trim()
+
+    if (!seenHeading) {
+      if (line.startsWith('# ')) seenHeading = true
+      continue
+    }
+    if (paragraph.length === 0) {
+      if (
+        line === '' ||
+        line.startsWith('#') ||
+        line.startsWith(':::') ||
+        line.startsWith('```') ||
+        line.startsWith('<') ||
+        line.startsWith('|') ||
+        line.startsWith('- ') ||
+        line.startsWith('* ') ||
+        line.startsWith('**Choices:') ||
+        line.startsWith('**Default:') ||
+        line.startsWith('import ') ||
+        line.startsWith('export ')
+      ) {
+        continue
+      }
+    } else if (
+      line === '' ||
+      line.startsWith('#') ||
+      line.startsWith(':::')
+    ) {
+      break
+    }
+    paragraph.push(line.replace(/^>\s?/, ''))
+  }
+
+  const text = plain(paragraph.join(' ')).replace(/:$/, '.')
+  if (!text) return undefined
+  if (text.length <= maxDescription) return text
+
+  const sentence = text.slice(0, maxDescription).lastIndexOf('. ')
+  if (sentence > maxDescription / 2) return text.slice(0, sentence + 1)
+  const word = text.lastIndexOf(' ', maxDescription)
+  return `${text.slice(0, word > 0 ? word : maxDescription)}…`
+}
+
+interface Entry {
+  text: string
+  link: string
+}
+
+function flatten(items: SidebarItem[], entries: Entry[] = []): Entry[] {
+  for (const item of items) {
+    if (item.link?.startsWith('/')) {
+      entries.push({ text: item.text, link: item.link })
+    }
+    if (item.items) flatten(item.items, entries)
+  }
+  return entries
+}
+
+const missing: string[] = []
+const sections: string[] = []
+
+for (const group of sidebar) {
+  const entries = flatten(group.items ?? [])
+  if (group.link?.startsWith('/')) {
+    entries.unshift({ text: group.text, link: group.link })
+  }
+  if (entries.length === 0) continue
+
+  const lines = entries.map(({ text, link }) => {
+    const summary = description(sourceFile(link))
+    if (!summary) missing.push(link)
+    return summary
+      ? `- [${text}](${pageUrl(link)}): ${summary}`
+      : `- [${text}](${pageUrl(link)})`
+  })
+  sections.push(`## ${group.text}\n\n${lines.join('\n')}`)
+}
+
+const output = `# hk
+
+> Run linters concurrently without letting overlapping fixes race
+
+${sections.join('\n\n')}
+`
+
+writeFileSync(outFile, output)
+
+const pages = output.split('\n').filter((line) => line.startsWith('- ')).length
+console.log(`wrote ${outFile} (${pages} pages, ${output.length} bytes)`)
+if (missing.length > 0) {
+  console.log(`no lead paragraph found for ${missing.length} page(s):`)
+  for (const link of missing) console.log(`  ${link}`)
+}

--- a/docs/.vitepress/llms.ts
+++ b/docs/.vitepress/llms.ts
@@ -14,6 +14,7 @@ const outFile = resolve(docsDir, 'public/llms.txt')
 const siteUrl = 'https://hk.jdx.dev'
 const maxDescription = 200
 
+/** Map a VitePress link to its Markdown source file. */
 function sourceFile(link: string): string {
   const relative = link.replace(/^\//, '')
   return resolve(
@@ -22,23 +23,28 @@ function sourceFile(link: string): string {
   )
 }
 
+/** Convert a VitePress link to its canonical published URL. */
 function pageUrl(link: string): string {
   return link.endsWith('/')
     ? `${siteUrl}${link}`
     : `${siteUrl}${link}.html`
 }
 
+/** Remove Markdown and HTML markup while preserving readable text. */
 function plain(markdown: string): string {
   return markdown
     .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
     .replace(/\[((?:[^[\]]|\[[^[\]]*\])*)\]\([^)]*\)/g, '$1')
     .replace(/`([^`]*)`/g, '$1')
     .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, '$1')
-    .replace(/<[^>]+>/g, '')
+    // HTML tag names are lowercase in the docs. Uppercase angle-bracketed
+    // values such as <SUBCOMMAND> are CLI placeholders and must remain.
+    .replace(/<\/?[a-z][^>]*>|<!--[\s\S]*?-->/g, '')
     .replace(/\s+/g, ' ')
     .trim()
 }
 
+/** Extract and shorten the first prose paragraph after a page's H1. */
 function description(file: string): string | undefined {
   let markdown: string
   try {
@@ -101,6 +107,7 @@ interface Entry {
   link: string
 }
 
+/** Flatten linked sidebar entries while retaining their displayed names. */
 function flatten(items: SidebarItem[], entries: Entry[] = []): Entry[] {
   for (const item of items) {
     if (item.link?.startsWith('/')) {

--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -10,6 +10,7 @@ export interface SidebarItem {
   items?: SidebarItem[]
 }
 
+/** Return every visible command path in depth-first CLI order. */
 function getCommands(cmd: Command): string[][] {
   const commands: string[][] = []
   for (const sub of Object.values(cmd.subcommands)) {

--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -1,0 +1,66 @@
+import spec from '../cli/commands.json' with { type: 'json' }
+
+interface Command {
+  subcommands: Record<string, Command & { hide?: boolean; full_cmd: string[] }>
+}
+
+export interface SidebarItem {
+  text: string
+  link?: string
+  items?: SidebarItem[]
+}
+
+function getCommands(cmd: Command): string[][] {
+  const commands: string[][] = []
+  for (const sub of Object.values(cmd.subcommands)) {
+    if (sub.hide) continue
+    commands.push(sub.full_cmd)
+    commands.push(...getCommands(sub))
+  }
+  return commands
+}
+
+const commands = getCommands(spec.cmd)
+
+// Shared by VitePress and the llms.txt generator so both expose the same pages.
+export const sidebar: SidebarItem[] = [
+  { text: 'Getting Started', link: '/getting_started' },
+  { text: 'Configuration', link: '/configuration' },
+  {
+    text: 'Guides',
+    items: [
+      { text: 'Built-in Linters', link: '/builtins' },
+      { text: 'Configuration Examples', link: '/reference/examples/' },
+      { text: 'Git Hooks', link: '/hooks' },
+      { text: 'mise Integration', link: '/mise_integration' },
+      { text: 'Coding Agents', link: '/agents' },
+    ],
+  },
+  {
+    text: 'CLI Reference',
+    link: '/cli/',
+    items: commands.map((cmd) => ({
+      text: cmd.join(' '),
+      link: `/cli/${cmd.join('/')}`,
+    })),
+  },
+  {
+    text: 'Reference',
+    items: [
+      { text: 'Environment Variables', link: '/environment_variables' },
+      { text: 'Pkl Introduction', link: '/pkl_introduction' },
+      { text: 'Logging and Debugging', link: '/logging' },
+      { text: 'Glossary', link: '/glossary' },
+    ],
+  },
+  {
+    text: 'Project',
+    items: [
+      { text: 'Why hk?', link: '/why-hk' },
+      { text: 'Benchmarks', link: '/benchmarks' },
+      { text: 'Contributing', link: '/contributing' },
+      { text: 'About', link: '/about' },
+      { text: 'Sea Shanty', link: '/shanty' },
+    ],
+  },
+]

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,6 +2,7 @@
   "name": "docs",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "docs:dev": "vitepress dev",
     "docs:build": "vitepress build",

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -20,7 +20,7 @@
 
 ## CLI Reference
 
-- [CLI Reference](https://hk.jdx.dev/cli/): Usage: hk [FLAGS]
+- [CLI Reference](https://hk.jdx.dev/cli/): Usage: hk [FLAGS] <SUBCOMMAND>
 - [agent](https://hk.jdx.dev/cli/agent.html): Generate integration snippets for coding agents
 - [agent hooks](https://hk.jdx.dev/cli/agent/hooks.html): Print a hook configuration for an agent or editor
 - [agent instructions](https://hk.jdx.dev/cli/agent/instructions.html): Print project instructions for a coding agent

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,88 @@
+# hk
+
+> Run linters concurrently without letting overlapping fixes race
+
+## Getting Started
+
+- [Getting Started](https://hk.jdx.dev/getting_started.html): This guide takes you from installing hk to running your first checks. Most projects can be set up in a few minutes.
+
+## Configuration
+
+- [Configuration](https://hk.jdx.dev/configuration.html): hk builds its effective configuration by layering sources from lowest to highest precedence.
+
+## Guides
+
+- [Built-in Linters](https://hk.jdx.dev/builtins.html): hk provides 140+ pre-configured linters and formatters through the Builtins module. They provide the command, file matching, batching, and other hk behavior, while the corresponding tool must be…
+- [Configuration Examples](https://hk.jdx.dev/reference/examples/): This directory contains runnable examples extracted from the public Pkl configurations.
+- [Git Hooks](https://hk.jdx.dev/hooks.html): The following describes the behavior of git hooks that hk supports. Each step provides a "check" and a "fix" command. "check" commands are read-only and can be run in parallel.
+- [mise Integration](https://hk.jdx.dev/mise_integration.html): Most git-hook managers provide features that hk's sister project, mise-en-place, already provides. For this reason, you will want to use mise and hk together if you'd like to use any of the features…
+- [Coding Agents](https://hk.jdx.dev/agents.html): hk gives coding agents a narrow, inspectable way to run project checks and fixes. Agents can use structured CLI output everywhere, or the MCP server for persistent runs, cancellation, paged logs,…
+
+## CLI Reference
+
+- [CLI Reference](https://hk.jdx.dev/cli/): Usage: hk [FLAGS]
+- [agent](https://hk.jdx.dev/cli/agent.html): Generate integration snippets for coding agents
+- [agent hooks](https://hk.jdx.dev/cli/agent/hooks.html): Print a hook configuration for an agent or editor
+- [agent instructions](https://hk.jdx.dev/cli/agent/instructions.html): Print project instructions for a coding agent
+- [agent mcp](https://hk.jdx.dev/cli/agent/mcp.html): Print an MCP server configuration
+- [builtins](https://hk.jdx.dev/cli/builtins.html): Lists all available builtin linters
+- [check](https://hk.jdx.dev/cli/check.html): Checks code
+- [completion](https://hk.jdx.dev/cli/completion.html): Generates shell completion scripts
+- [config](https://hk.jdx.dev/cli/config.html): Configuration introspection and management
+- [config dump](https://hk.jdx.dev/cli/config/dump.html): Print effective runtime settings (JSON format)
+- [config explain](https://hk.jdx.dev/cli/config/explain.html): Explain where a configuration value comes from
+- [config get](https://hk.jdx.dev/cli/config/get.html): Get a specific configuration value
+- [config sources](https://hk.jdx.dev/cli/config/sources.html): Show the configuration source precedence order
+- [fix](https://hk.jdx.dev/cli/fix.html): Fixes code
+- [init](https://hk.jdx.dev/cli/init.html): Generates a new hk.pkl file for a project
+- [install](https://hk.jdx.dev/cli/install.html): Sets up git hooks to run hk.
+- [mcp](https://hk.jdx.dev/cli/mcp.html): Runs an MCP server for coding agents over standard input/output.
+- [migrate](https://hk.jdx.dev/cli/migrate.html): Migrate from other hook managers to hk
+- [migrate pre-commit](https://hk.jdx.dev/cli/migrate/pre-commit.html): Migrate from pre-commit to hk
+- [run](https://hk.jdx.dev/cli/run.html): Run a hook
+- [run commit-msg](https://hk.jdx.dev/cli/run/commit-msg.html)
+- [run post-checkout](https://hk.jdx.dev/cli/run/post-checkout.html)
+- [run post-commit](https://hk.jdx.dev/cli/run/post-commit.html)
+- [run post-merge](https://hk.jdx.dev/cli/run/post-merge.html)
+- [run post-rewrite](https://hk.jdx.dev/cli/run/post-rewrite.html)
+- [run pre-commit](https://hk.jdx.dev/cli/run/pre-commit.html): Run the pre-commit hook
+- [run pre-push](https://hk.jdx.dev/cli/run/pre-push.html)
+- [run pre-rebase](https://hk.jdx.dev/cli/run/pre-rebase.html)
+- [run prepare-commit-msg](https://hk.jdx.dev/cli/run/prepare-commit-msg.html)
+- [sponsors](https://hk.jdx.dev/cli/sponsors.html): Show the companies sponsoring hk and the jdx.dev open source tools
+- [test](https://hk.jdx.dev/cli/test.html): Run step-defined tests
+- [uninstall](https://hk.jdx.dev/cli/uninstall.html): Removes hk hooks from the current git repository
+- [util](https://hk.jdx.dev/cli/util.html): Utility commands for file operations
+- [util check-added-large-files](https://hk.jdx.dev/cli/util/check-added-large-files.html): Check for large files being added to repository
+- [util check-byte-order-marker](https://hk.jdx.dev/cli/util/check-byte-order-marker.html): Check for UTF-8 byte order marker (BOM)
+- [util check-case-conflict](https://hk.jdx.dev/cli/util/check-case-conflict.html): Check for case-insensitive filename conflicts
+- [util check-conventional-commit](https://hk.jdx.dev/cli/util/check-conventional-commit.html): Check for conventional commit message
+- [util check-executables-have-shebangs](https://hk.jdx.dev/cli/util/check-executables-have-shebangs.html): Check that executable files have shebangs
+- [util check-merge-conflict](https://hk.jdx.dev/cli/util/check-merge-conflict.html): Check for merge conflict markers
+- [util check-symlinks](https://hk.jdx.dev/cli/util/check-symlinks.html): Check for broken symlinks
+- [util detect-private-key](https://hk.jdx.dev/cli/util/detect-private-key.html): Detect private keys in files
+- [util end-of-file-fixer](https://hk.jdx.dev/cli/util/end-of-file-fixer.html): Check for and optionally fix missing final newlines
+- [util fix-byte-order-marker](https://hk.jdx.dev/cli/util/fix-byte-order-marker.html): Remove UTF-8 byte order marker (BOM)
+- [util fix-smart-quotes](https://hk.jdx.dev/cli/util/fix-smart-quotes.html): Replace UTF-8 smart quotes
+- [util mixed-line-ending](https://hk.jdx.dev/cli/util/mixed-line-ending.html): Detect and fix mixed line endings
+- [util no-commit-to-branch](https://hk.jdx.dev/cli/util/no-commit-to-branch.html): Prevent commits to specific branches
+- [util python-check-ast](https://hk.jdx.dev/cli/util/python-check-ast.html): Check Python files for valid syntax
+- [util python-debug-statements](https://hk.jdx.dev/cli/util/python-debug-statements.html): Detect Python debug statements
+- [util trailing-whitespace](https://hk.jdx.dev/cli/util/trailing-whitespace.html): Check for and optionally fix trailing whitespace
+- [validate](https://hk.jdx.dev/cli/validate.html): Validate the config file
+- [version](https://hk.jdx.dev/cli/version.html): Print the version of hk
+
+## Reference
+
+- [Environment Variables](https://hk.jdx.dev/environment_variables.html): Environment variables can be used to configure hk.
+- [Pkl Introduction](https://hk.jdx.dev/pkl_introduction.html): hk uses pkl for configuration. As this is a new configuration language, this doc gives an overview of how to write it and work with it for hk configuration.
+- [Logging and Debugging](https://hk.jdx.dev/logging.html): hk provides several ways to control logging output for debugging issues and understanding what's happening during execution.
+- [Glossary](https://hk.jdx.dev/glossary.html): This glossary defines key terms used throughout hk documentation and configuration.
+
+## Project
+
+- [Why hk?](https://hk.jdx.dev/why-hk.html): Tools like pre-commit, prek, and lefthook simply shell out to run linters. That means they can't safely run linters in parallel—if two linters try to modify the same file at the same time, there will…
+- [Benchmarks](https://hk.jdx.dev/benchmarks.html): These benchmarks compare hk, lefthook, pre-commit, and prek running 10 linters on a synthetic project.
+- [Contributing](https://hk.jdx.dev/contributing.html): Thank you for your interest in contributing to hk! This guide will help you get started.
+- [About](https://hk.jdx.dev/about.html): hk is built by @jdx.
+- [Sea Shanty](https://hk.jdx.dev/shanty.html): A sea shanty celebrating the hk git hook manager

--- a/mise-tasks/render/llms
+++ b/mise-tasks/render/llms
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#MISE description="Generate docs/public/llms.txt for coding agents"
+#MISE depends=["render:usage"]
+#MISE sources=["docs/**/*.md", "docs/.vitepress/llms.ts", "docs/.vitepress/sidebar.ts", "docs/cli/commands.json"]
+#MISE outputs=["docs/public/llms.txt"]
+
+set -eu
+
+node docs/.vitepress/llms.ts


### PR DESCRIPTION
## Summary

- generate `docs/public/llms.txt` from the VitePress sidebar and page introductions
- share the sidebar between VitePress and the generator
- integrate generation with `mise run render` and publish it through the existing docs build

Implements the request in Discussion #1271.

## Testing

- `mise run render` (run twice; second run produced no diff)
- `mise run docs:build`
- verified `docs/.vitepress/dist/llms.txt` matches `docs/public/llms.txt`
- `PATH="$PWD/target/debug:$PATH" mise x shellcheck@0.11.0 -- target/debug/hk check --all`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only tooling and static asset generation; no runtime or security-sensitive code paths.
> 
> **Overview**
> Adds a machine-readable **`llms.txt`** index at `https://hk.jdx.dev/llms.txt` so coding agents can discover hk docs with short blurbs per page.
> 
> **Sidebar** is moved from `config.mts` into shared **`sidebar.ts`** (still driven by `commands.json` for CLI pages). VitePress imports that module; a new **`llms.ts`** script walks the same tree, maps links to Markdown, pulls the first prose paragraph after each H1 (with stripping/truncation), and writes **`docs/public/llms.txt`**. Generation is wired as **`mise run render:llms`** (depends on `render:usage`) so it runs with the rest of `render`; the committed file ships via VitePress `public/`. **`docs/package.json`** sets **`"type": "module"`** for the JSON import attribute in `sidebar.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 511f51c2e87720f139165aaefbcc63914a6e8f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a plain-text `llms.txt` documentation index covering guides, configuration, CLI commands, reference material, and project documentation.
  * Added automatic generation of the index with organized sections, page links, and descriptions.
  * Updated the documentation sidebar to dynamically include available CLI commands while excluding hidden subcommands.

* **Chores**
  * Configured the documentation package for modern module support.
  * Added a task for regenerating the documentation index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->