### PR TITLE
ci: benchmark mbx against rust-cache on Linux

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -27,6 +27,90 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  mbx_linux:
+    name: mbx (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      seconds: ${{ steps.build.outputs.seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: "1.95.0"
+      - uses: ./.github/actions/mbx
+        with:
+          backend: github
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          mbx build
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
+          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          mbx cache stats
+
+  rust_cache_linux:
+    name: Swatinem rust-cache (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      seconds: ${{ steps.build.outputs.seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: "1.95.0"
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
+        with:
+          shared-key: cache-benchmark-linux-v1
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          cargo build
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
+          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+
+  comparison_linux:
+    name: comparison (Linux)
+    needs: [mbx_linux, rust_cache_linux]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    env:
+      MBX_SECONDS: ${{ needs.mbx_linux.outputs.seconds }}
+      RUST_CACHE_SECONDS: ${{ needs.rust_cache_linux.outputs.seconds }}
+    steps:
+      - name: Summarize results
+        shell: bash
+        run: |
+          delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          {
+            echo "## Linux cache build comparison"
+            echo
+            echo "| Backend | Build time |"
+            echo "| --- | ---: |"
+            echo "| mbx | ${MBX_SECONDS}s |"
+            echo "| Swatinem/rust-cache | ${RUST_CACHE_SECONDS}s |"
+            echo
+            echo "mbx delta: **${delta}** (positive means mbx was faster)."
+            echo
+            echo "> Treat the first main-branch run as cache seeding. Compare workflow_dispatch runs after it. Build time excludes checkout and cache setup; compare those step durations separately."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   mbx:
     name: mbx (macOS)
     runs-on: macos-14


### PR DESCRIPTION
## Summary
- add Linux mbx and Swatinem/rust-cache build jobs to the cache benchmark
- use the same pinned toolchain and build command for both Linux arms
- publish a Linux timing comparison alongside macOS and Windows

Pull-request runs are restore-only and may reuse caches seeded on `main`, matching the existing macOS and Windows arms. The first main-branch run seeds the dedicated Linux caches; controlled warm measurements should use later workflow dispatches.

## Validation
- `git diff --check`
- `actionlint -shellcheck= .github/workflows/cache-benchmark.yml`
- `mise x zizmor@1.29.0 -- zizmor .github/workflows/cache-benchmark.yml`