### PR TITLE
chore(deps): remove rust toolchain pins

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -37,10 +37,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - name: Install pinned Rust toolchain
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
-        with:
-          toolchain: "1.95.0"
       - uses: ./.github/actions/mbx
         with:
           backend: github
@@ -65,10 +61,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - name: Install pinned Rust toolchain
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
-        with:
-          toolchain: "1.95.0"
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:
@@ -121,10 +113,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - name: Install pinned Rust toolchain
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
-        with:
-          toolchain: "1.95.0"
       - uses: ./.github/actions/mbx
         with:
           backend: github
@@ -150,10 +138,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - name: Install pinned Rust toolchain
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
-        with:
-          toolchain: "1.95.0"
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel    = "1.95.0"
-components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

- remove the repository-wide `rust-toolchain.toml` pin
- remove pinned Rust setup from cache benchmark jobs
- rely on the ambient Rust toolchain locally and on GitHub-hosted runners
- avoid ongoing Renovate PRs such as #1232 for these pins

## Validation

- `mise exec -- actionlint -shellcheck= .github/workflows/cache-benchmark.yml`
- `mise exec -- prettier --check .github/workflows/cache-benchmark.yml`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and tooling-only changes with no application runtime impact; cache-benchmark timing may drift if runner Rust versions change.
> 
> **Overview**
> Stops pinning Rust **1.95.0** repo-wide by deleting `rust-toolchain.toml` (including `clippy` / `rustfmt` components), so local and CI no longer follow that file via `rustup`.
> 
> The **cache benchmark** workflow no longer runs `dtolnay/rust-toolchain` on macOS or Windows for the mbx and Swatinem `rust-cache` jobs; those builds use whatever Rust is already on the hosted runner. That should cut Renovate noise on toolchain bumps, at the cost of less fixed compiler versions for benchmark comparisons over time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 339262b2e047ad5bfd89a12d5224f03850a85e68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the project’s fixed Rust toolchain version and bundled development components.
  - Updated automated benchmark builds to use the environment’s configured Rust toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->