### PR TITLE
test: avoid login shell when committing in fixer tail deletion test

### DIFF
--- a/src/cli/migrate/mod.rs
+++ b/src/cli/migrate/mod.rs
@@ -330,11 +330,8 @@ fn parse_as_path_list(pattern: &str) -> Option<Vec<String>> {
     for part in parts {
         let part = part.trim();
 
-        if let Some(glob) = convert_regex_to_glob(part) {
-            globs.push(glob);
-        } else {
-            return None; // Can't convert this part
-        }
+        // A part that can't be converted fails the whole conversion
+        globs.push(convert_regex_to_glob(part)?);
     }
 
     Some(globs)

--- a/src/git.rs
+++ b/src/git.rs
@@ -1191,14 +1191,14 @@ impl Git {
                         && git_cmd_silent([
                             "cat-file",
                             "-e",
-                            &format!("{}^3:{}", &stash_ref, path_str),
+                            &format!("{}^3:{}", stash_ref, path_str),
                         ])
                         .run()
                         .is_ok()
                         && git_cmd_silent([
                             "cat-file",
                             "-e",
-                            &format!("{}^2:{}", &stash_ref, path_str),
+                            &format!("{}^2:{}", stash_ref, path_str),
                         ])
                         .run()
                         .is_err();
@@ -1212,7 +1212,7 @@ impl Git {
                         if let Ok(contents) = git_read_bytes([
                             "cat-file",
                             "-p",
-                            &format!("{}^3:{}", &stash_ref, path_str),
+                            &format!("{}^3:{}", stash_ref, path_str),
                         ]) {
                             if let Err(err) = xx::file::write(&path, &contents) {
                                 warn!(
@@ -1248,7 +1248,7 @@ impl Git {
                     } else {
                         fixer_worktree_paths.contains(&path)
                     };
-                    let work_ref = format!("{}:{}", &stash_ref, path_str);
+                    let work_ref = format!("{}:{}", stash_ref, path_str);
                     let work_size = git_cmd_silent(["cat-file", "-s", &work_ref])
                         .read()
                         .ok()
@@ -1372,12 +1372,12 @@ impl Git {
                     .or_else(|| work_bytes.and_then(|b| String::from_utf8(b).ok()));
                     // Parent ^1 of the stash commit points to the HEAD commit at stash time
                     let base_pre =
-                        git_read_raw(["cat-file", "-p", &format!("{}^1:{}", &stash_ref, path_str)])
+                        git_read_raw(["cat-file", "-p", &format!("{}^1:{}", stash_ref, path_str)])
                             .ok();
                     // Parent ^2 is the index at stash time. Use this to detect whether the path had
                     // any unstaged changes then (worktree vs index).
                     let index_pre =
-                        git_read_raw(["cat-file", "-p", &format!("{}^2:{}", &stash_ref, path_str)])
+                        git_read_raw(["cat-file", "-p", &format!("{}^2:{}", stash_ref, path_str)])
                             .ok();
                     // Fixer content comes from the index when fixes were staged, or from the
                     // isolated post-step worktree when staging was disabled.
@@ -1626,7 +1626,7 @@ impl Git {
 
     pub fn add(&self, pathspecs: &[PathBuf]) -> Result<()> {
         let pathspecs = pathspecs.iter().collect_vec();
-        trace!("adding files: {:?}", &pathspecs);
+        trace!("adding files: {:?}", pathspecs);
         if let Some(repo) = &self.repo {
             let mut index = repo.index().wrap_err("failed to get index")?;
             index

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1112,7 +1112,7 @@ impl Hook {
             .unwrap_or(true);
 
         if settings.skip_hooks.contains(&self.name) {
-            warn!("{}: skipping hook due to HK_SKIP_HOOK", &self.name);
+            warn!("{}: skipping hook due to HK_SKIP_HOOK", self.name);
             crate::structured_output::emit_noop_run(
                 output_format,
                 &self.name,
@@ -1740,7 +1740,7 @@ impl Hook {
             // Process excludes - handle both directory patterns and glob patterns
             debug!(
                 "files.exclude: patterns from settings/CLI: {:?}",
-                &all_excludes
+                all_excludes
             );
             let files_before = files.len();
             let mut expanded_excludes = Vec::new();
@@ -1752,7 +1752,7 @@ impl Hook {
                     expanded_excludes.push(format!("{}/**", exclude));
                 }
             }
-            debug!("files.exclude: expanded patterns: {:?}", &expanded_excludes);
+            debug!("files.exclude: expanded patterns: {:?}", expanded_excludes);
 
             let f = files.iter().collect::<Vec<_>>();
             let exclude_files = glob::get_matches(&expanded_excludes, &f)?

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -434,7 +434,7 @@ impl Step {
         stage_globs.retain(|g| !g.is_empty());
         // Ignore directory-only patterns (ending with '/'); staging should target files
         stage_globs.retain(|g| !g.ends_with('/'));
-        trace!("{}: stage globs: {:?}", self, &stage_globs);
+        trace!("{}: stage globs: {:?}", self, stage_globs);
         let stage_pathspecs: Vec<OsString> =
             stage_globs.iter().cloned().map(OsString::from).collect();
         if !stage_pathspecs.is_empty() || stage_only_job_files {
@@ -520,7 +520,7 @@ impl Step {
 
             trace!(
                 "{}: files to stage after filtering/scoping: {:?}",
-                self, &filtered
+                self, filtered
             );
             if !filtered.is_empty() {
                 // Snapshot pre-staging untracked set for classification

--- a/src/step/output.rs
+++ b/src/step/output.rs
@@ -153,7 +153,7 @@ impl Step {
                 rendered.contains('\n') || rendered.chars().count() > MAX_INLINE_FIX_COMMAND_CHARS;
             if should_use_hk_fix {
                 // Multi-line or overly long commands are clearer through hk.
-                let step_flag = format!("-S {}", &self.name);
+                let step_flag = format!("-S {}", self.name);
                 let cmd = format!(
                     "To fix, run: {}",
                     style::edim(format!("hk fix {}", step_flag))

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -472,7 +472,7 @@ impl Step {
                     }
                     self.collect_failure_hint(ctx, &e.3.combined_output);
                     if job.check_first && matches!(job.run_type, RunType::Check) {
-                        return Err(Error::CheckListFailed {
+                        Err(Error::CheckListFailed {
                             source: eyre::eyre!("{}", err),
                             stdout: e.3.stdout.clone(),
                             stderr: e.3.stderr.clone(),

--- a/test/fixer_tail_deletion_with_middle_unstaged.bats
+++ b/test/fixer_tail_deletion_with_middle_unstaged.bats
@@ -72,7 +72,11 @@ deps:
 
 EOF
 
-    run bash -lc 'git -c commit.gpgsign=false commit -m "redis"'
+    # Not `bash -lc`: a login shell runs macOS path_helper, which reorders PATH
+    # so the commit can resolve a pre-2.54 system git that silently ignores the
+    # config-based hooks (`hook.hk-pre-commit.command`) installed by `hk install`,
+    # skipping the fixer entirely.
+    run git -c commit.gpgsign=false commit -m "redis"
     echo "$output"
     assert_success
 


### PR DESCRIPTION
`test/fixer_tail_deletion_with_middle_unstaged.bats` fails intermittently on the macOS CI jobs — e.g. both `ci-libgit2` and `ci-nolibgit2` (macos) in [this run on `main` at c2066be](https://github.com/jdx/hk/actions/runs/32990218129) and in [PR #1268's run](https://github.com/jdx/hk/actions/runs/33016515705), failing all in-job retries while every Linux job passes.

**Observed failure shape** (from the bats output): the `redis` commit succeeds with *no hk hook output at all* and `1 file changed, 3 insertions(+)` — i.e. the unfixed staged content (redis + two trailing blank lines) is committed and the worktree keeps the blank lines (`5a6,7`). The pre-commit hook never ran; the three-way merge this test guards is never reached.

**Cause (analysis):** the `redis` commit is the only hook-triggering command in the whole suite wrapped in `bash -lc`:

```bash
run bash -lc 'git -c commit.gpgsign=false commit -m "redis"'
```

`hk install` on Git 2.54+ uses config-based hooks (`hook.hk-pre-commit.command`) and leaves `.git/hooks/` untouched. On macOS a login shell runs `path_helper`, which reorders `PATH` so system directories come first — the commit can then resolve the pre-2.54 Apple git, which does not know config-based hooks and silently commits without running any hook. Whether that happens depends on the runner image's git/`PATH` layout, which is why the failure is deterministic within a job (all retries fail) but varies across runs. The PATH-reordering step is inferred from the failure shape rather than reproduced on a runner; the rest (config-based install, missing hook output, unfixed commit) is taken directly from the logs and `src/cli/install.rs`. A "hk missing from PATH" explanation doesn't fit: with git ≥2.54 the hook command would fail and abort the commit loudly, but the commit succeeds silently.

The `bash -lc` wrapper came in with the original regression test (#931) alongside `bash -lc`-wrapped *inspection* commands (`git show`, `git diff`), where the login shell is harmless; for the hook-triggering commit it isn't. This change runs the commit directly, like the test's own `base` commit and every other hook-triggering test, and leaves a comment explaining why a login shell must be avoided here.


## Underlying hk bug this test was accidentally exposing

The flake is gone with this change, but the mechanism it tripped over is a real hazard in hk itself: `hk install` decides between config-based hooks and legacy shims from the git version resolved **at install time** (`use_config_hooks = !legacy && git_at_least(2, 54)`), while whether hooks actually fire depends on the git used **at commit time**. When those differ across the 2.54 boundary (install sees Homebrew git 2.55, a later commit resolves pre-2.54 Apple git — login shells via `path_helper`, GUI clients with bundled git, editors' integrated terminals), the older git ignores the unknown `hook.hk-*.command` keys and commits **silently, with no hook run at all** — the worst failure mode for a hook manager. This test only surfaced it by accident; with the test fixed, nothing exercises that path anymore. A possible direction: when installing config-based hooks, also write a fallback shim guarded to no-op when the executing git is ≥ 2.54 (git prepends its own exec-path for hooks, so the shim's `git` is the invoking one, making the two dispatch paths mutually exclusive), plus a cheap warning when hk runs under a pre-2.54 git in a config-hook repo.

## Stacked on #1278

This branch is rebased on top of #1278 (`style: fix clippy lints for rust 1.98`), which fixes the `mise run lint` failure that Rust 1.98.0's new clippy lints cause on current `main` — otherwise this PR's CI cannot go green. The diff of this PR itself is still only the one bats file; once #1278 merges, this PR reduces to that single commit.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: 2.1.241.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary stashing when path-limited tracked changes are absent.
  - Improved reporting when checking for relevant changes encounters an unexpected Git error.

- **Tests**
  - Improved regression-test reliability by ensuring commits use the intended Git configuration and executable.

- **Refactor**
  - Simplified internal error propagation and path-list conversion logic without changing behavior.

- **Style**
  - Cleaned up redundant references and formatting across Git operations, hook processing, execution tracing, and fix suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->