### PR TITLE
style: fix clippy lints for rust 1.98

### DIFF
--- a/src/cli/migrate/mod.rs
+++ b/src/cli/migrate/mod.rs
@@ -330,11 +330,8 @@ fn parse_as_path_list(pattern: &str) -> Option<Vec<String>> {
     for part in parts {
         let part = part.trim();
 
-        if let Some(glob) = convert_regex_to_glob(part) {
-            globs.push(glob);
-        } else {
-            return None; // Can't convert this part
-        }
+        // A part that can't be converted fails the whole conversion
+        globs.push(convert_regex_to_glob(part)?);
     }
 
     Some(globs)

--- a/src/git.rs
+++ b/src/git.rs
@@ -1191,14 +1191,14 @@ impl Git {
                         && git_cmd_silent([
                             "cat-file",
                             "-e",
-                            &format!("{}^3:{}", &stash_ref, path_str),
+                            &format!("{}^3:{}", stash_ref, path_str),
                         ])
                         .run()
                         .is_ok()
                         && git_cmd_silent([
                             "cat-file",
                             "-e",
-                            &format!("{}^2:{}", &stash_ref, path_str),
+                            &format!("{}^2:{}", stash_ref, path_str),
                         ])
                         .run()
                         .is_err();
@@ -1212,7 +1212,7 @@ impl Git {
                         if let Ok(contents) = git_read_bytes([
                             "cat-file",
                             "-p",
-                            &format!("{}^3:{}", &stash_ref, path_str),
+                            &format!("{}^3:{}", stash_ref, path_str),
                         ]) {
                             if let Err(err) = xx::file::write(&path, &contents) {
                                 warn!(
@@ -1248,7 +1248,7 @@ impl Git {
                     } else {
                         fixer_worktree_paths.contains(&path)
                     };
-                    let work_ref = format!("{}:{}", &stash_ref, path_str);
+                    let work_ref = format!("{}:{}", stash_ref, path_str);
                     let work_size = git_cmd_silent(["cat-file", "-s", &work_ref])
                         .read()
                         .ok()
@@ -1372,12 +1372,12 @@ impl Git {
                     .or_else(|| work_bytes.and_then(|b| String::from_utf8(b).ok()));
                     // Parent ^1 of the stash commit points to the HEAD commit at stash time
                     let base_pre =
-                        git_read_raw(["cat-file", "-p", &format!("{}^1:{}", &stash_ref, path_str)])
+                        git_read_raw(["cat-file", "-p", &format!("{}^1:{}", stash_ref, path_str)])
                             .ok();
                     // Parent ^2 is the index at stash time. Use this to detect whether the path had
                     // any unstaged changes then (worktree vs index).
                     let index_pre =
-                        git_read_raw(["cat-file", "-p", &format!("{}^2:{}", &stash_ref, path_str)])
+                        git_read_raw(["cat-file", "-p", &format!("{}^2:{}", stash_ref, path_str)])
                             .ok();
                     // Fixer content comes from the index when fixes were staged, or from the
                     // isolated post-step worktree when staging was disabled.
@@ -1626,7 +1626,7 @@ impl Git {
 
     pub fn add(&self, pathspecs: &[PathBuf]) -> Result<()> {
         let pathspecs = pathspecs.iter().collect_vec();
-        trace!("adding files: {:?}", &pathspecs);
+        trace!("adding files: {:?}", pathspecs);
         if let Some(repo) = &self.repo {
             let mut index = repo.index().wrap_err("failed to get index")?;
             index

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1112,7 +1112,7 @@ impl Hook {
             .unwrap_or(true);
 
         if settings.skip_hooks.contains(&self.name) {
-            warn!("{}: skipping hook due to HK_SKIP_HOOK", &self.name);
+            warn!("{}: skipping hook due to HK_SKIP_HOOK", self.name);
             crate::structured_output::emit_noop_run(
                 output_format,
                 &self.name,
@@ -1740,7 +1740,7 @@ impl Hook {
             // Process excludes - handle both directory patterns and glob patterns
             debug!(
                 "files.exclude: patterns from settings/CLI: {:?}",
-                &all_excludes
+                all_excludes
             );
             let files_before = files.len();
             let mut expanded_excludes = Vec::new();
@@ -1752,7 +1752,7 @@ impl Hook {
                     expanded_excludes.push(format!("{}/**", exclude));
                 }
             }
-            debug!("files.exclude: expanded patterns: {:?}", &expanded_excludes);
+            debug!("files.exclude: expanded patterns: {:?}", expanded_excludes);
 
             let f = files.iter().collect::<Vec<_>>();
             let exclude_files = glob::get_matches(&expanded_excludes, &f)?

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -434,7 +434,7 @@ impl Step {
         stage_globs.retain(|g| !g.is_empty());
         // Ignore directory-only patterns (ending with '/'); staging should target files
         stage_globs.retain(|g| !g.ends_with('/'));
-        trace!("{}: stage globs: {:?}", self, &stage_globs);
+        trace!("{}: stage globs: {:?}", self, stage_globs);
         let stage_pathspecs: Vec<OsString> =
             stage_globs.iter().cloned().map(OsString::from).collect();
         if !stage_pathspecs.is_empty() || stage_only_job_files {
@@ -520,7 +520,7 @@ impl Step {
 
             trace!(
                 "{}: files to stage after filtering/scoping: {:?}",
-                self, &filtered
+                self, filtered
             );
             if !filtered.is_empty() {
                 // Snapshot pre-staging untracked set for classification

--- a/src/step/output.rs
+++ b/src/step/output.rs
@@ -153,7 +153,7 @@ impl Step {
                 rendered.contains('\n') || rendered.chars().count() > MAX_INLINE_FIX_COMMAND_CHARS;
             if should_use_hk_fix {
                 // Multi-line or overly long commands are clearer through hk.
-                let step_flag = format!("-S {}", &self.name);
+                let step_flag = format!("-S {}", self.name);
                 let cmd = format!(
                     "To fix, run: {}",
                     style::edim(format!("hk fix {}", step_flag))

--- a/src/step/runner.rs
+++ b/src/step/runner.rs
@@ -472,7 +472,7 @@ impl Step {
                     }
                     self.collect_failure_hint(ctx, &e.3.combined_output);
                     if job.check_first && matches!(job.run_type, RunType::Check) {
-                        return Err(Error::CheckListFailed {
+                        Err(Error::CheckListFailed {
                             source: eyre::eyre!("{}", err),
                             stdout: e.3.stdout.clone(),
                             stderr: e.3.stderr.clone(),


### PR DESCRIPTION
Rust 1.98.0 introduces clippy lints that fail `mise run lint` (`-D warnings`) on current `main`, blocking CI for every open PR as well as the `renovate/rust-1.x` update branch. This fixes all 15 errors:

- `useless_borrows_in_formatting` (13×): redundant `&` on `format!`/`trace!`/`debug!`/`warn!` arguments in `src/git.rs`, `src/hook.rs`, `src/step/execution.rs`, `src/step/output.rs`
- `question_mark` (1×): `if let Some … else return None` → `?` in `src/cli/migrate/mod.rs`
- `needless_return_with_question_mark` (1×): `return Err(…)?` → `Err(…)?` in `src/step/runner.rs`

All changes are mechanical applications of clippy's own suggestions; no behavior change.

Verified locally with rustc 1.98.0 using the same invocation as the repo's `cargo-clippy` step (`clippy --manifest-path Cargo.toml --quiet -- -D warnings`): exit 0. Tests are left to CI — the rewrites are semantically identical.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: 2.1.241.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Path-limited stash operations now skip creating an empty stash when there are no changes to save.
  * Errors encountered while checking for changes continue to be reported appropriately.

* **Refactor**
  * Simplified internal control flow, error handling, and diagnostic formatting.
  * Removed unnecessary references from internal operations.
  * No other user-visible behavior has changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->