### PR TITLE
fix(stash): skip empty pathspec stashes

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -883,7 +883,6 @@ impl Git {
         // an empty patch. Avoid invoking Git in that destructive case.
         if let Some(ref ts) = tracked_subset
             && !ts.is_empty()
-            && (!*env::HK_STASH_UNTRACKED || status.untracked_files.is_empty())
         {
             let diff_status = Command::new("git")
                 .args([

--- a/src/git.rs
+++ b/src/git.rs
@@ -876,6 +876,37 @@ impl Git {
                 return Ok(None);
             }
         }
+        // A path-limited stash decides what to reset from the HEAD-to-worktree diff,
+        // even though the paths above were selected from the index-to-worktree diff.
+        // If the former is empty (for example after `git update-index --chmod`), Git
+        // creates a stash entry and resets the index before failing to reverse-apply
+        // an empty patch. Avoid invoking Git in that destructive case.
+        if let Some(ref ts) = tracked_subset
+            && !ts.is_empty()
+            && (!*env::HK_STASH_UNTRACKED || status.untracked_files.is_empty())
+        {
+            let diff_status = Command::new("git")
+                .args([
+                    "diff",
+                    "--quiet",
+                    "--no-ext-diff",
+                    "--ignore-submodules",
+                    "HEAD",
+                    "--",
+                ])
+                .args(ts)
+                .status()
+                .wrap_err("failed to check whether stash pathspec has changes")?;
+            match diff_status.code() {
+                Some(0) => return Ok(None),
+                Some(1) => {}
+                code => {
+                    return Err(eyre!(
+                        "git diff failed while checking stash pathspec with exit code {code:?}"
+                    ));
+                }
+            }
+        }
         if let Some(repo) = &mut self.repo {
             let sig = repo.signature()?;
             let mut flags = git2::StashFlags::default();

--- a/test/stash_empty_pathspec.bats
+++ b/test/stash_empty_pathspec.bats
@@ -68,3 +68,25 @@ PKL
     assert_success
     assert_output ""
 }
+
+@test "untracked files do not bypass the empty stash guard" {
+    create_precommit
+
+    git update-index --chmod=+x a.sh
+    printf 'untracked\n' > unrelated.txt
+
+    run git -c commit.gpgsign=false commit -m "make a.sh executable"
+    assert_success
+
+    run git ls-tree HEAD -- a.sh
+    assert_success
+    assert_output --partial "100755"
+
+    run cat unrelated.txt
+    assert_success
+    assert_output "untracked"
+
+    run git stash list
+    assert_success
+    assert_output ""
+}

--- a/test/stash_empty_pathspec.bats
+++ b/test/stash_empty_pathspec.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+    export HK_SUMMARY_TEXT=1
+}
+
+teardown() {
+    _common_teardown
+}
+
+create_precommit() {
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    fix = true
+    stage = true
+    stash = "git"
+    steps {
+      ["noop"] { glob = List("**/*.sh"); check = "true" }
+    }
+  }
+}
+PKL
+    printf 'echo hi\n' > a.sh
+    git add -A
+    git -c commit.gpgsign=false commit -m init
+    hk install
+}
+
+@test "pre-commit preserves a staged mode change when the stash patch is empty" {
+    create_precommit
+
+    git update-index --chmod=+x a.sh
+    run git -c commit.gpgsign=false commit -m "make a.sh executable"
+    assert_success
+
+    run git ls-tree HEAD -- a.sh
+    assert_success
+    assert_output --partial "100755"
+
+    run git stash list
+    assert_success
+    assert_output ""
+}
+
+@test "pre-commit preserves staged content when the worktree matches HEAD" {
+    create_precommit
+
+    printf 'echo staged\n' > a.sh
+    git add a.sh
+    printf 'echo hi\n' > a.sh
+
+    run git -c commit.gpgsign=false commit -m "change a.sh"
+    assert_success
+
+    run git show HEAD:a.sh
+    assert_success
+    assert_output "echo staged"
+
+    run cat a.sh
+    assert_success
+    assert_output "echo hi"
+
+    run git stash list
+    assert_success
+    assert_output ""
+}


### PR DESCRIPTION
## Summary

- preflight path-limited stashes against the HEAD-to-worktree diff Git uses to reset paths
- skip `git stash push` when that patch is empty, before Git can reset the index and leave an orphaned stash
- cover both mode-only index changes and staged content whose worktree was restored to HEAD

Addresses the failure reported in https://github.com/jdx/hk/discussions/1281.

## Testing

- `mise run test:bats test/stash_empty_pathspec.bats`
- `mise run test:bats test/pre_commit_partial_staged.bats`
- `mise run test:cargo` (284 tests)
- `cargo fmt --check --manifest-path Cargo.toml`
- `mise run build`

`hk check --all` was also attempted. Its actionlint step could not run because this environment has no configured shellcheck shim; cargo-fmt completed successfully before that environment failure.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-commit stash gating around index and staged state; incorrect diff handling could still skip needed stashes or leave edge cases, though behavior is narrowly scoped and covered by new BATS tests.
> 
> **Overview**
> Fixes pre-commit **git stash** runs that could **reset the index** and leave an orphaned stash when the pathspec had index changes but **no HEAD→worktree diff** (e.g. `git update-index --chmod`, or staged content with the worktree restored to HEAD).
> 
> Before `git stash push` with pathspecs, **`push_stash`** now runs `git diff --quiet HEAD -- <paths>`. Exit **0** means skip stashing (`Ok(None)`); **1** proceeds as before. Untracked-only cases still use the existing full-stash path when `HK_STASH_UNTRACKED` is set.
> 
> Adds **`test/stash_empty_pathspec.bats`** for mode-only staged commits, staged-vs-HEAD worktree mismatch, and untracked files alongside an empty stash patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 768ad30dd960af1bcdafca642a357d4e1084b5d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty Git stash operations from altering or losing staged changes.
  * Ensured staged file mode and content changes are preserved during commits.
  * Avoided leaving unnecessary stash entries after successful commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->