### PR TITLE
chore(ci): use default Rust for cache benchmark

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -37,10 +37,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - name: Install pinned Rust toolchain
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
-        with:
-          toolchain: "1.95.0"
       - uses: ./.github/actions/mbx
         with:
           backend: github
@@ -65,10 +61,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - name: Install pinned Rust toolchain
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
-        with:
-          toolchain: "1.95.0"
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:


### PR DESCRIPTION
## Summary

- remove the pinned Rust 1.95.0 setup from Linux cache benchmark jobs
- use the default Rust toolchain provided by the runner, consistent with the macOS and Windows jobs

## Validation

- `mise exec actionlint@latest -- actionlint -shellcheck='' .github/workflows/cache-benchmark.yml`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow tweak with no application or security logic changes; benchmark timings may shift slightly with a different default Rust on `ubuntu-latest`.
> 
> **Overview**
> Linux **cache benchmark** jobs (`mbx_linux` and `rust_cache_linux`) no longer install a **pinned Rust 1.95.0** toolchain via `dtolnay/rust-toolchain`; they rely on the **runner’s default Rust**, matching the macOS and Windows benchmark jobs.
> 
> This trims setup time and avoids an extra toolchain pin in a workflow whose timed step is only `mbx build` / `cargo build` after checkout and cache restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7810c80cac399cf0b4e0b02aec4473e6db0908b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Linux benchmark and cache workflows by using the runner-provided Rust toolchain.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->