### PR TITLE
chore(ci): use server cache for dispatched benchmarks

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -17,7 +17,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write
+  id-token: write # Authenticate trusted manual dispatches to the cache server.
 
 concurrency:
   group: cache-benchmark-${{ github.ref }}

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: ${{ github.event_name == 'workflow_dispatch' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: bash
@@ -115,7 +115,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: ${{ github.event_name == 'workflow_dispatch' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: bash
@@ -191,7 +191,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: ${{ github.event_name == 'workflow_dispatch' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: pwsh

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -29,9 +29,6 @@ env:
 jobs:
   mbx_linux:
     name: mbx (Linux)
-    permissions:
-      contents: read
-      id-token: write # Authenticate trusted manual dispatches to the cache server.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
@@ -42,7 +39,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'jdx' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
+          backend: github
       - name: Build
         id: build
         shell: bash
@@ -108,9 +105,6 @@ jobs:
 
   mbx:
     name: mbx (macOS)
-    permissions:
-      contents: read
-      id-token: write # Authenticate trusted manual dispatches to the cache server.
     runs-on: macos-14
     timeout-minutes: 20
     outputs:
@@ -121,7 +115,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'jdx' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
+          backend: github
       - name: Build
         id: build
         shell: bash
@@ -187,9 +181,6 @@ jobs:
 
   mbx_windows:
     name: mbx (Windows)
-    permissions:
-      contents: read
-      id-token: write # Authenticate trusted manual dispatches to the cache server.
     runs-on: windows-latest
     timeout-minutes: 30
     outputs:
@@ -200,7 +191,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'jdx' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
+          backend: github
       - name: Build
         id: build
         shell: pwsh

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ github.event_name == 'workflow_dispatch' && 'server' || 'github' }}
+          backend: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'jdx' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: bash
@@ -121,7 +121,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ github.event_name == 'workflow_dispatch' && 'server' || 'github' }}
+          backend: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'jdx' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: bash
@@ -200,7 +200,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ github.event_name == 'workflow_dispatch' && 'server' || 'github' }}
+          backend: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'jdx' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: pwsh

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -17,7 +17,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write # Authenticate trusted manual dispatches to the cache server.
 
 concurrency:
   group: cache-benchmark-${{ github.ref }}
@@ -30,6 +29,9 @@ env:
 jobs:
   mbx_linux:
     name: mbx (Linux)
+    permissions:
+      contents: read
+      id-token: write # Authenticate trusted manual dispatches to the cache server.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
@@ -106,6 +108,9 @@ jobs:
 
   mbx:
     name: mbx (macOS)
+    permissions:
+      contents: read
+      id-token: write # Authenticate trusted manual dispatches to the cache server.
     runs-on: macos-14
     timeout-minutes: 20
     outputs:
@@ -182,6 +187,9 @@ jobs:
 
   mbx_windows:
     name: mbx (Windows)
+    permissions:
+      contents: read
+      id-token: write # Authenticate trusted manual dispatches to the cache server.
     runs-on: windows-latest
     timeout-minutes: 30
     outputs:

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: cache-benchmark-${{ github.ref }}

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # 1.95.0
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: 1.95.0
       - uses: ./.github/actions/mbx
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # 1.95.0
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: 1.95.0
       - name: Restore Cargo cache

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   mbx:
     name: mbx (${{ matrix.label }})
+    if: github.actor == 'jdx' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
       id-token: write # Authenticate the main-branch dispatch to the cache server.

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -1,0 +1,114 @@
+name: warm cache benchmark
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-cache-benchmark-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+
+jobs:
+  mbx:
+    name: mbx (${{ matrix.label }})
+    permissions:
+      contents: read
+      id-token: write # Authenticate the main-branch dispatch to the cache server.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: Linux
+          - os: macos-14
+            label: macOS
+          - os: windows-latest
+            label: Windows
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # 1.95.0
+        with:
+          toolchain: 1.95.0
+      - uses: ./.github/actions/mbx
+        with:
+          backend: server
+      - name: Build
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          mbx build
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
+          echo "## mbx ${{ matrix.label }}: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+          mbx cache stats
+      - name: Build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          mbx build --features git2/vendored-libgit2,git2/vendored-openssl
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $timer.Stop()
+          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## mbx ${{ matrix.label }}: ${elapsed}s" >> $env:GITHUB_STEP_SUMMARY
+          mbx cache stats
+
+  rust_cache:
+    name: Swatinem rust-cache (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: Linux
+            shared-key: cache-benchmark-linux-v1
+          - os: macos-14
+            label: macOS
+            shared-key: cache-benchmark-macos-v1
+          - os: windows-latest
+            label: Windows
+            shared-key: cache-benchmark-windows-v1
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # 1.95.0
+        with:
+          toolchain: 1.95.0
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          shared-key: ${{ matrix.shared-key }}
+          save-if: false
+      - name: Build
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          cargo build
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
+          echo "## Swatinem/rust-cache ${{ matrix.label }}: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+      - name: Build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          cargo build --features git2/vendored-libgit2,git2/vendored-openssl
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $timer.Stop()
+          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## Swatinem/rust-cache ${{ matrix.label }}: ${elapsed}s" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -37,9 +37,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
-        with:
-          toolchain: 1.95.0
       - uses: ./.github/actions/mbx
         with:
           backend: server
@@ -67,6 +64,7 @@ jobs:
 
   rust_cache:
     name: Swatinem rust-cache (${{ matrix.label }})
+    if: github.actor == 'jdx' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:
@@ -86,9 +84,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
-        with:
-          toolchain: 1.95.0
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   mbx:
     name: mbx (${{ matrix.label }})
-    if: github.actor == 'jdx' && github.ref == 'refs/heads/main'
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
       id-token: write # Authenticate the main-branch dispatch to the cache server.
@@ -64,7 +64,7 @@ jobs:
 
   rust_cache:
     name: Swatinem rust-cache (${{ matrix.label }})
-    if: github.actor == 'jdx' && github.ref == 'refs/heads/main'
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- keep pull request and main-push cache benchmarks on the GitHub backend
- use the trusted mbx server backend for manual dispatches
- allow a seed dispatch followed by a real warm-cache comparison without immutable GitHub cache collisions

## Validation

- `git diff --check`
- `actionlint -shellcheck='' .github/workflows/cache-benchmark.yml`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only, manually dispatched workflow with tight actor/ref guards; no application or runtime behavior changes.
> 
> **Overview**
> Adds a **manual-only** workflow (`warm-cache-benchmark.yml`) for comparing warm-build times on Linux, macOS, and Windows without fighting GitHub Actions cache immutability.
> 
> The **mbx** job uses `./.github/actions/mbx` with `backend: server`, `id-token: write` for cache-server auth, and records elapsed build time plus `mbx cache stats` in the step summary. The **Swatinem rust-cache** job restores with per-OS `shared-key` values and `save-if: false` so benchmarks measure restore-only warm builds. Both jobs are gated to `workflow_dispatch` on `main` by actor `jdx`, use a matrix instead of separate per-OS jobs, and disable `cancel-in-progress` on the concurrency group so seed-then-compare runs can complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d201a4c9b3e0b9da0dab2a760ed22e61a92b5808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an on-demand build benchmarking workflow across Linux, macOS, and Windows.
  * Added comparisons between server-side and Rust-based caching approaches.
  * Build durations are now recorded in workflow summaries for easier performance evaluation.
  * No user-facing product functionality or public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->