### PR TITLE
chore(ci): restore mbx remote cache

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -20,15 +20,18 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+      uses: jdx/mr-boxington-action@cff2f8f0606288b60e7ff0570a06faf5c3ebd3ac
       with:
         version: 1.0.0
         backend: github
+        cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
-    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+    - uses: jdx/mr-boxington-action@cff2f8f0606288b60e7ff0570a06faf5c3ebd3ac
       with:
         version: 1.0.0
+        cache-generation: v2
+        save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main' }}
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -20,14 +20,14 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@cff2f8f0606288b60e7ff0570a06faf5c3ebd3ac
+      uses: jdx/mr-boxington-action@9a406893b83a977c45324a34aed553e3c43f414d
       with:
         version: 1.0.0
         backend: github
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
-    - uses: jdx/mr-boxington-action@cff2f8f0606288b60e7ff0570a06faf5c3ebd3ac
+    - uses: jdx/mr-boxington-action@9a406893b83a977c45324a34aed553e3c43f414d
       with:
         version: 1.0.0
         cache-generation: v2

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -22,14 +22,14 @@ runs:
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@9a406893b83a977c45324a34aed553e3c43f414d
       with:
-        version: 1.0.0
+        version: 1.0.1
         backend: github
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
     - uses: jdx/mr-boxington-action@9a406893b83a977c45324a34aed553e3c43f414d
       with:
-        version: 1.0.0
+        version: 1.0.1
         cache-generation: v2
         save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' }}
         cache-links: ${{ inputs.cache-links }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -31,7 +31,7 @@ runs:
       with:
         version: 1.1.0
         cache-generation: v2
-        save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' }}
+        save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main' }}
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -22,14 +22,14 @@ runs:
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@9a406893b83a977c45324a34aed553e3c43f414d
       with:
-        version: 1.0.1
+        version: 1.1.0
         backend: github
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
     - uses: jdx/mr-boxington-action@9a406893b83a977c45324a34aed553e3c43f414d
       with:
-        version: 1.0.1
+        version: 1.1.0
         cache-generation: v2
         save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' }}
         cache-links: ${{ inputs.cache-links }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,7 +1,13 @@
 name: Set up mbx
-description: Set up mbx with the GitHub Actions cache backend
+description: Select the trusted jdx server or fork-safe GitHub cache backend
 
 inputs:
+  backend:
+    description: Explicit backend for structurally trusted or untrusted callers
+    default: auto
+  mirror-github-cache:
+    description: Mirror a trusted main build into the restore-only cache used by fork PRs
+    default: "false"
   cache-links:
     description: Cache native links; "auto" enables this on Linux
     default: auto
@@ -12,9 +18,20 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+    - name: Restore the fork PR cache mirror
+      if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
         version: 0.7.0
         backend: github
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
+    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+      with:
+        version: 0.7.0
+        cache-links: ${{ inputs.cache-links }}
+        toolchain: ${{ inputs.toolchain }}
+        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
+        server-url: https://cache.mise.jdx.dev
+        namespace: jdx/hk
+        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -31,7 +31,7 @@ runs:
       with:
         version: 1.0.0
         cache-generation: v2
-        save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main' }}
+        save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' }}
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -22,13 +22,13 @@ runs:
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
-        version: 0.7.0
+        version: 1.0.0
         backend: github
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
     - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
-        version: 0.7.0
+        version: 1.0.0
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: github
       - name: Build
         id: build
         shell: bash
@@ -113,6 +115,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
+          backend: github
           # mbx 0.7.0 makes macOS debug links portable, so the benchmark
           # exercises them the way the Linux job already does.
           cache-links: "true"
@@ -190,6 +193,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: github
       - name: Build
         id: build
         shell: pwsh

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -31,6 +31,9 @@ jobs:
     name: mbx (Linux)
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write # Main pushes authenticate to the cache server; its policy keeps other events read-only.
     outputs:
       seconds: ${{ steps.build.outputs.seconds }}
     steps:
@@ -39,7 +42,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: bash
@@ -100,13 +103,16 @@ jobs:
             echo
             echo "mbx delta: **${delta}** (positive means mbx was faster)."
             echo
-            echo "> Treat the first main-branch run as cache seeding. Compare workflow_dispatch runs after it. Build time excludes checkout and cache setup; compare those step durations separately."
+            echo "> The main-branch push seeds both backends. Compare them with the warm cache benchmark dispatched on main. Build time excludes checkout and cache setup; compare those step durations separately."
           } >> "$GITHUB_STEP_SUMMARY"
 
   mbx:
     name: mbx (macOS)
     runs-on: macos-14
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write # Main pushes authenticate to the cache server; its policy keeps other events read-only.
     outputs:
       seconds: ${{ steps.build.outputs.seconds }}
     steps:
@@ -115,7 +121,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
           # mbx 0.7.0 makes macOS debug links portable, so the benchmark
           # exercises them the way the Linux job already does.
           cache-links: "true"
@@ -179,13 +185,16 @@ jobs:
             echo
             echo "mbx delta: **${delta}** (positive means mbx was faster)."
             echo
-            echo "> Treat the first main-branch run as cache seeding. Compare workflow_dispatch runs after it. Build time excludes checkout and cache setup; compare those step durations separately."
+            echo "> The main-branch push seeds both backends. Compare them with the warm cache benchmark dispatched on main. Build time excludes checkout and cache setup; compare those step durations separately."
           } >> "$GITHUB_STEP_SUMMARY"
 
   mbx_windows:
     name: mbx (Windows)
     runs-on: windows-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write # Main pushes authenticate to the cache server; its policy keeps other events read-only.
     outputs:
       seconds: ${{ steps.build.outputs.seconds }}
     steps:
@@ -194,7 +203,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
       - name: Build
         id: build
         shell: pwsh
@@ -257,5 +266,5 @@ jobs:
             echo
             echo "mbx delta: **${delta}** (positive means mbx was faster)."
             echo
-            echo "> Treat the first main-branch run as cache seeding. Compare workflow_dispatch runs after it. Build time excludes checkout and cache setup; compare those step durations separately."
+            echo "> The main-branch push seeds both backends. Compare them with the warm cache benchmark dispatched on main. Build time excludes checkout and cache setup; compare those step durations separately."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -6,6 +6,9 @@ on:
       trusted:
         required: true
         type: boolean
+      mbx-backend:
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -58,6 +61,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
@@ -74,6 +80,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
+          mirror-github-cache: "true"
       - name: Build
         run: mbx build --features git2/vendored-libgit2,git2/vendored-openssl
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -219,6 +228,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
@@ -245,6 +256,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
@@ -258,6 +271,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: true
+      mbx-backend: server
 
   untrusted:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
@@ -26,6 +27,7 @@ jobs:
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: false
+      mbx-backend: github
 
   final:
     name: final

--- a/.github/workflows/docs-impl.yml
+++ b/.github/workflows/docs-impl.yml
@@ -6,6 +6,9 @@ on:
       trusted:
         required: true
         type: boolean
+      mbx-backend:
+        required: true
+        type: string
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,6 +36,8 @@ jobs:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ jobs:
     uses: ./.github/workflows/docs-impl.yml
     with:
       trusted: true
+      mbx-backend: server
 
   untrusted:
     if: ${{ github.actor != 'jdx' }}
@@ -29,6 +30,7 @@ jobs:
     uses: ./.github/workflows/docs-impl.yml
     with:
       trusted: false
+      mbx-backend: github
 
   docs:
     name: docs

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -27,10 +27,13 @@ jobs:
         include:
           - os: ubuntu-latest
             label: Linux
+            cache-links: auto
           - os: macos-14
             label: macOS
+            cache-links: "true"
           - os: windows-latest
             label: Windows
+            cache-links: auto
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -40,6 +43,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
+          cache-links: ${{ matrix.cache-links }}
       - name: Build
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -1,0 +1,110 @@
+name: warm cache benchmark
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-cache-benchmark-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+
+jobs:
+  mbx:
+    name: mbx (${{ matrix.label }})
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      id-token: write # Authenticate the main-branch dispatch to the cache server.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: Linux
+          - os: macos-14
+            label: macOS
+          - os: windows-latest
+            label: Windows
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: server
+      - name: Build
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          mbx build
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
+          echo "## mbx ${{ matrix.label }}: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+          mbx cache stats
+      - name: Build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          mbx build --features git2/vendored-libgit2,git2/vendored-openssl
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $timer.Stop()
+          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## mbx ${{ matrix.label }}: ${elapsed}s" >> $env:GITHUB_STEP_SUMMARY
+          mbx cache stats
+
+  rust_cache:
+    name: Swatinem rust-cache (${{ matrix.label }})
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: Linux
+            shared-key: cache-benchmark-linux-v1
+          - os: macos-14
+            label: macOS
+            shared-key: cache-benchmark-macos-v1
+          - os: windows-latest
+            label: Windows
+            shared-key: cache-benchmark-windows-v1
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          shared-key: ${{ matrix.shared-key }}
+          save-if: false
+      - name: Build
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          cargo build
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
+          echo "## Swatinem/rust-cache ${{ matrix.label }}: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+      - name: Build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          cargo build --features git2/vendored-libgit2,git2/vendored-openssl
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $timer.Stop()
+          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## Swatinem/rust-cache ${{ matrix.label }}: ${elapsed}s" >> $env:GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- restore trusted hk CI to the mbx server backend
- keep fork PRs on the GitHub Actions backend and restore the main-branch mirror
- keep cache benchmark jobs pinned to the GitHub backend for a fair rust-cache comparison
- restore the dispatched warm-cache benchmark

## Validation
- `actionlint -shellcheck=` on every changed workflow
- restored files match the tree immediately before the server-cache removal

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable cache backends for trusted and untrusted builds.
  * Added optional cache mirroring to improve cache availability for fork-based builds.
  * Added a manually triggered workflow to benchmark warm-cache performance across Linux, macOS, and Windows.
  * Added cache performance comparisons, build durations, and cache statistics to workflow summaries.

* **Bug Fixes**
  * Improved automatic cache selection so builds use the appropriate backend based on their trust context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI cache trust boundaries and OIDC access to an external cache server; misconfiguration could affect build speed or cache isolation for fork PRs, but application/runtime code is untouched.
> 
> **Overview**
> Restores **trusted** CI/docs builds to the remote **mbx server** cache (`cache.mise.jdx.dev` via OIDC) while keeping **untrusted/fork** paths on the **GitHub Actions** cache backend.
> 
> The **`.github/actions/mbx`** composite action now picks `server` vs `github` (or an explicit `backend` input), bumps **mr-boxington** to **1.1.0** with `cache-generation: v2`, and can **mirror** a main-branch trusted build into the GitHub cache used by fork PRs (`mirror-github-cache`). **CI** and **docs** entry workflows pass `mbx-backend: server` or `github` into their impl workflows; build jobs enable mirroring where appropriate.
> 
> **Cache benchmark** jobs gain `id-token: write` and pin mbx to server on main pushes (GitHub otherwise) so comparisons stay fair; summaries now point reviewers at a new **`warm-cache-benchmark`** `workflow_dispatch` on main for post-seed timing across Linux/macOS/Windows (mbx vs Swatinem/rust-cache).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6878a6f893797f3981cbd2ba829e6dbd50592550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->