### PR TITLE
feat(step): allow configured command failures

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -23,6 +23,27 @@ hk hooks perform the following assuming `fix = true`:
 
 If `fix = false`, hk will just run the `check` steps and won't need to deal with read/write locks as nothing should be making modifications. Steps with [`check_failed_files = true`](/configuration#focus-checks-on-failing-files) first use `check_diff` or `check_list_files` to identify affected paths, then run the detailed `check` command only on that focused set.
 
+### Allowing a step to fail
+
+Set `allow_failure = true` on a step to run it and report a non-zero command
+exit without failing the hook. This is narrower than bypassing the hook or
+skipping the step: all other steps retain their normal blocking behavior, and
+errors from hk itself are still fatal.
+
+The setting can be an expression using `env(name)` when the policy should be
+conditional on an environment variable:
+
+```pkl
+["cargo-check"] {
+    check = "cargo check"
+    allow_failure = "env('KNOWN_BROKEN') == 'true'"
+}
+```
+
+`KNOWN_BROKEN=true git commit` will therefore show a failed `cargo-check` but
+allow the commit, while an ordinary `git commit` remains blocked by the same
+failure.
+
 ## `pre-commit`
 
 Runs when `git commit` is run before `git commit` creates the commit.

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -696,6 +696,23 @@ class Step {
   /// ```
   depends: (String | List<String>) = List()
 
+  /// Default: `false`
+  ///
+  /// If true, a non-zero exit from this step's command is reported but does not
+  /// cause the hook to fail. The step still runs, its output is preserved, and
+  /// dependent steps may continue. Errors produced by hk itself remain fatal.
+  ///
+  /// A string value is evaluated as an expression when the command fails. The
+  /// expression can use `env(name)` to read an environment variable:
+  ///
+  /// ```pkl
+  /// ["cargo-check"] {
+  ///     check = "cargo check"
+  ///     allow_failure = "env('KNOWN_BROKEN') == 'true'"
+  /// }
+  /// ```
+  allow_failure: (Boolean | String) = false
+
   /// If set, use this shell instead of the default `sh -o errexit -c`.
   ///
   /// ```pkl

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,4 +10,19 @@ pub enum Error {
         stderr: String,
         combined: String,
     },
+
+    #[error("{step}: file-listing check failed but focused check succeeded")]
+    FocusedCheckMismatch { step: String },
+}
+
+pub fn is_command_failure(error: &eyre::Report) -> bool {
+    error.chain().any(|error| {
+        matches!(
+            error.downcast_ref::<Error>(),
+            Some(Error::CheckListFailed { .. } | Error::FocusedCheckMismatch { .. })
+        ) || matches!(
+            error.downcast_ref::<ensembler::Error>(),
+            Some(ensembler::Error::ScriptFailed(_))
+        )
+    })
 }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -332,6 +332,8 @@ pub struct HookContext {
     /// `step_contexts` are shift_remove'd as soon as each step finishes, so
     /// status info is not available to the end-of-run summary.
     pub failed_steps: std::sync::Mutex<HashSet<String>>,
+    /// Failed steps whose command failure was explicitly allowed.
+    pub allowed_failure_steps: std::sync::Mutex<HashSet<String>>,
     /// Steps that reached a terminal successful state. Timing alone is not a
     /// completion signal because an in-flight command can be aborted.
     pub finished_steps: std::sync::Mutex<HashSet<String>>,
@@ -393,6 +395,7 @@ impl HookContext {
             diagnostic_output_by_step: StdMutex::new(IndexMap::new()),
             command_effects_by_step: StdMutex::new(IndexMap::new()),
             failed_steps: StdMutex::new(HashSet::new()),
+            allowed_failure_steps: StdMutex::new(HashSet::new()),
             finished_steps: StdMutex::new(HashSet::new()),
             cancelled_steps: StdMutex::new(HashSet::new()),
             fix_suggestions: StdMutex::new(Vec::new()),
@@ -515,6 +518,13 @@ impl HookContext {
 
     pub fn mark_step_failed(&self, step_name: &str) {
         self.failed_steps
+            .lock()
+            .unwrap()
+            .insert(step_name.to_string());
+    }
+
+    pub fn mark_step_failure_allowed(&self, step_name: &str) {
+        self.allowed_failure_steps
             .lock()
             .unwrap()
             .insert(step_name.to_string());

--- a/src/step/execution.rs
+++ b/src/step/execution.rs
@@ -23,12 +23,25 @@ use std::sync::{Arc, LazyLock};
 use tokio::sync::OwnedSemaphorePermit;
 
 use super::expr_env::eval_condition;
-use super::types::{CheckFirstCmd, RunType, Step};
+use super::types::{AllowFailure, CheckFirstCmd, RunType, Step};
 
 /// Default stage pattern for steps with fix commands when staging is enabled.
 static DEFAULT_STAGE: LazyLock<Vec<String>> = LazyLock::new(|| vec!["<JOB_FILES>".to_string()]);
 
 impl Step {
+    pub(crate) fn failure_is_allowed(&self, ctx: &expr::Context) -> Result<bool> {
+        match &self.allow_failure {
+            AllowFailure::Bool(allow) => Ok(*allow),
+            AllowFailure::Expression(expression) => {
+                let value = eval_condition(expression, ctx)?;
+                match value {
+                    expr::Value::Bool(allow) => Ok(allow),
+                    _ => eyre::bail!("{self}: allow_failure expression must evaluate to a boolean"),
+                }
+            }
+        }
+    }
+
     /// Execute all jobs for this step.
     ///
     /// This is the main orchestration function that:
@@ -297,13 +310,13 @@ impl Step {
                     {
                         step.save_output_summary(&ctx, job, stdout, stderr, combined, true);
                     }
-                    let err = eyre::eyre!(
-                        "{step}: file-listing check failed but focused check succeeded"
-                    );
+                    let err = Error::FocusedCheckMismatch {
+                        step: step.to_string(),
+                    };
                     if let Some(job) = &mut last_job {
                         job.status_errored(&ctx, format!("{err}")).await?;
                     }
-                    return Err(err);
+                    return Err(err.into());
                 }
                 Ok(files_to_return.into_iter().collect())
             });

--- a/src/step/expr_env.rs
+++ b/src/step/expr_env.rs
@@ -24,7 +24,14 @@ pub static EXPR_ENV: LazyLock<expr::Environment> = LazyLock::new(|| {
     });
 
     env.add_function("env", |c| {
-        let name = c.args[0].as_string().unwrap();
+        if c.args.len() != 1 {
+            return Err(expr::Error::ExprError(
+                "env() expects exactly one string argument".to_string(),
+            ));
+        }
+        let name = c.args[0].as_string().ok_or_else(|| {
+            expr::Error::ExprError("env() expects exactly one string argument".to_string())
+        })?;
         Ok(expr::Value::String(std::env::var(name).unwrap_or_default()))
     });
 
@@ -149,5 +156,18 @@ mod tests {
             eval_condition("'ITWORKS\n' == 'ITWORKS\\n'", &EXPR_CTX).unwrap(),
             expr::Value::Bool(true)
         );
+    }
+
+    #[test]
+    fn env_rejects_missing_and_non_string_arguments() {
+        for expression in ["env()", "env(123)", "env('ONE', 'TWO')"] {
+            let error = eval_condition(expression, &EXPR_CTX).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("env() expects exactly one string argument"),
+                "unexpected error for {expression}: {error}"
+            );
+        }
     }
 }

--- a/src/step/expr_env.rs
+++ b/src/step/expr_env.rs
@@ -13,6 +13,7 @@ pub static EXPR_CTX: LazyLock<expr::Context> = LazyLock::new(expr::Context::defa
 ///
 /// Currently provides:
 /// - `exec(command)` - Execute a shell command and return its stdout
+/// - `env(name)` - Return an environment variable, or an empty string when unset
 pub static EXPR_ENV: LazyLock<expr::Environment> = LazyLock::new(|| {
     let mut env = expr::Environment::new();
 
@@ -20,6 +21,11 @@ pub static EXPR_ENV: LazyLock<expr::Environment> = LazyLock::new(|| {
         let out = xx::process::sh(c.args[0].as_string().unwrap())
             .map_err(|e| expr::Error::ExprError(e.to_string()))?;
         Ok(expr::Value::String(out))
+    });
+
+    env.add_function("env", |c| {
+        let name = c.args[0].as_string().unwrap();
+        Ok(expr::Value::String(std::env::var(name).unwrap_or_default()))
     });
 
     env

--- a/src/step/types.rs
+++ b/src/step/types.rs
@@ -185,6 +185,10 @@ pub struct Step {
     #[serde(default)]
     pub depends: Vec<String>,
 
+    /// Report command failures without failing the hook, optionally based on an expression
+    #[serde(default)]
+    pub allow_failure: AllowFailure,
+
     /// Custom shell to use (default: `sh -o errexit -c`)
     #[serde_as(as = "Option<PickFirst<(_, DisplayFromStr)>>")]
     pub shell: Option<Script>,
@@ -283,6 +287,19 @@ pub struct Step {
 
     /// Tool name included in normalized diagnostics (defaults to step name).
     pub diagnostic_tool: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum AllowFailure {
+    Bool(bool),
+    Expression(String),
+}
+
+impl Default for AllowFailure {
+    fn default() -> Self {
+        Self::Bool(false)
+    }
 }
 
 impl fmt::Display for Step {

--- a/src/step_group.rs
+++ b/src/step_group.rs
@@ -195,6 +195,9 @@ impl StepGroup {
                         Ok(failure_allowed) => failure_allowed,
                         Err(err) => {
                             step_ctx.status_errored(&err.to_string());
+                            if !fail_fast {
+                                step_ctx.depends.mark_done(&step.name)?;
+                            }
                             hook_ctx
                                 .step_contexts
                                 .lock()

--- a/src/step_group.rs
+++ b/src/step_group.rs
@@ -186,10 +186,30 @@ impl StepGroup {
                 let hook_ctx = ctx.hook_ctx.clone();
                 async move {
                     let result = step.clone().run_all_jobs(step_ctx.clone(), semaphore).await;
+                    let failure_allowed = match match &result {
+                        Err(err) if crate::error::is_command_failure(err) => {
+                            step.failure_is_allowed(&hook_ctx.expr_ctx())
+                        }
+                        _ => Ok(false),
+                    } {
+                        Ok(failure_allowed) => failure_allowed,
+                        Err(err) => {
+                            step_ctx.status_errored(&err.to_string());
+                            hook_ctx
+                                .step_contexts
+                                .lock()
+                                .unwrap()
+                                .shift_remove(&step.name);
+                            return Err(err);
+                        }
+                    };
+                    if failure_allowed {
+                        hook_ctx.mark_step_failure_allowed(&step.name);
+                    }
                     if let Err(err) = &result {
                         step_ctx.status_errored(&err.to_string());
                     }
-                    if !fail_fast && result.is_err() {
+                    if (!fail_fast || failure_allowed) && result.is_err() {
                         step_ctx.depends.mark_done(&step.name)?;
                     }
                     hook_ctx
@@ -197,7 +217,7 @@ impl StepGroup {
                         .lock()
                         .unwrap()
                         .shift_remove(&step.name);
-                    result
+                    if failure_allowed { Ok(()) } else { result }
                 }
             });
         }

--- a/src/structured_output.rs
+++ b/src/structured_output.rs
@@ -52,6 +52,8 @@ struct RunResult {
 struct StepResult {
     name: String,
     status: &'static str,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    failure_allowed: bool,
     duration_ms: u128,
     effects: Vec<ExecutedEffect>,
     diagnostics: Vec<Diagnostic>,
@@ -168,6 +170,7 @@ pub fn emit_run(
     sarif_path: Option<&Path>,
 ) -> Result<()> {
     let failed = ctx.failed_steps.lock().unwrap();
+    let allowed_failures = ctx.allowed_failure_steps.lock().unwrap();
     let finished = ctx.finished_steps.lock().unwrap();
     let cancelled = ctx.cancelled_steps.lock().unwrap();
     let run_was_cancelled = !cancelled.is_empty();
@@ -227,6 +230,7 @@ pub fn emit_run(
             steps.push(StepResult {
                 name: name.clone(),
                 status,
+                failure_allowed: allowed_failures.contains(name),
                 duration_ms: timings.get(name).copied().unwrap_or(0),
                 effects: executed_effects
                     .get(name)
@@ -250,6 +254,7 @@ pub fn emit_run(
     drop(cancelled);
     drop(finished);
     drop(failed);
+    drop(allowed_failures);
 
     let result = RunResult {
         schema_version: 1,
@@ -301,6 +306,7 @@ pub fn emit_noop_run(
             .map(|(name, skip_reason)| StepResult {
                 name,
                 status: "skipped",
+                failure_allowed: false,
                 duration_ms: 0,
                 effects: vec![],
                 diagnostics: vec![],

--- a/test/allow_failure.bats
+++ b/test/allow_failure.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "allow_failure reports command failure without failing hook" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+fail_fast = true
+hooks {
+    ["check"] {
+        steps {
+            ["allowed"] {
+                check = "echo ALLOWED_FAILURE >&2; exit 1"
+                allow_failure = true
+                exclusive = true
+            }
+            ["required"] {
+                check = "echo REQUIRED_RAN"
+            }
+        }
+    }
+}
+EOF
+
+    run hk check --all
+    assert_success
+    assert_output --partial "ALLOWED_FAILURE"
+    assert_output --partial "REQUIRED_RAN"
+}
+
+@test "allow_failure defaults to false" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["blocking"] {
+                check = "echo BLOCKING_FAILURE >&2; exit 1"
+            }
+        }
+    }
+}
+EOF
+
+    run hk check --all
+    assert_failure
+    assert_output --partial "BLOCKING_FAILURE"
+}
+
+@test "allow_failure can be controlled by environment" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["conditional"] {
+                check = "echo CONDITIONAL_FAILURE >&2; exit 1"
+                allow_failure = "env('KNOWN_BROKEN') == 'true'"
+            }
+        }
+    }
+}
+EOF
+
+    run hk check --all
+    assert_failure
+
+    export KNOWN_BROKEN=true
+    run hk check --all
+    assert_success
+    assert_output --partial "CONDITIONAL_FAILURE"
+}
+
+@test "allow_failure does not hide hk execution errors" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["broken-template"] {
+                check = "echo {{ missing_template_value }}"
+                allow_failure = true
+            }
+        }
+    }
+}
+EOF
+
+    run hk check --all
+    assert_failure
+    assert_output --partial "failed to render command template"
+}
+
+@test "structured output identifies an allowed failing step" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["allowed"] {
+                check = "echo JSON_FAILURE >&2; exit 1"
+                allow_failure = true
+            }
+        }
+    }
+}
+EOF
+
+    run bash -c "hk --format json check --all 2>machine-errors.log"
+    assert_success
+    json="$output"
+    run jq -e '.status == "passed" and .steps[0].status == "failed" and .steps[0].failure_allowed == true' <<<"$json"
+    assert_success
+}

--- a/test/allow_failure.bats
+++ b/test/allow_failure.bats
@@ -98,6 +98,48 @@ EOF
     assert_output --partial "failed to render command template"
 }
 
+@test "invalid allow_failure expression releases dependents" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+fail_fast = false
+hooks {
+    ["check"] {
+        steps {
+            ["invalid-policy"] {
+                check = "exit 1"
+                allow_failure = "env('KNOWN_BROKEN')"
+            }
+            ["dependent"] {
+                depends = List("invalid-policy")
+                check = "echo DEPENDENT_RAN"
+            }
+        }
+    }
+}
+EOF
+
+    run bash -c '
+        hk check --all &
+        hk_pid=$!
+        (
+            for _ in {1..100}; do
+                kill -0 "$hk_pid" 2>/dev/null || exit 0
+                sleep 0.1
+            done
+            kill "$hk_pid" 2>/dev/null
+        ) &
+        watchdog_pid=$!
+        wait "$hk_pid"
+        exit_code=$?
+        kill "$watchdog_pid" 2>/dev/null
+        wait "$watchdog_pid" 2>/dev/null
+        exit "$exit_code"
+    '
+    assert_failure
+    assert_output --partial "allow_failure expression must evaluate to a boolean"
+    assert_output --partial "DEPENDENT_RAN"
+}
+
 @test "structured output identifies an allowed failing step" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"


### PR DESCRIPTION
## Summary

- add per-step `allow_failure` configuration for reporting non-zero command exits without failing the hook
- support conditional policies with expressions such as `env('KNOWN_BROKEN') == 'true'`
- keep hk execution/configuration errors blocking and expose allowed failures in structured output
- document the behavior and cover fail-fast, environment, safety, and JSON output cases

Closes the feature request discussed in #1289.

## Testing

- `mise run test:cargo`
- `mise run test:bats test/allow_failure.bats`
- `mise run test:bats test/structured_output.bats`
- `mise run test:bats test/depends.bats`
- `mise run test:bats test/fail_fast_config.bats`
- `cargo fmt --check`
- `pkl format --diff-name-only pkl/Config.pkl`

`hk check --all` could not complete because the local mise shims have no selected `hk`/`shellcheck` versions; the equivalent built repository binary reached the same missing `shellcheck` shim.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Unable to generate summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ada49d782c634d799c74356788cad14a0e155448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Steps can allow command failures without failing the overall hook.
  * Failure allowance supports conditional expressions, including environment variables.
  * Structured output identifies steps whose failures were allowed.
* **Bug Fixes**
  * Improved reporting for focused-check and file-listing mismatches.
  * Invalid conditional expressions now report configuration errors instead of causing hangs.
* **Documentation**
  * Added guidance and configuration examples for allowing step failures.
* **Tests**
  * Added coverage for allowed failures, conditional behavior, error handling, and JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->