### PR TITLE
fix(ci): target repository when publishing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,6 +336,7 @@ jobs:
       - name: Append jdx.dev sponsor blurb
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           INPUTS_VERSION: ${{ inputs.version }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
@@ -368,6 +369,7 @@ jobs:
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           INPUTS_VERSION: ${{ inputs.version }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |


### PR DESCRIPTION
## Summary

- set `GH_REPO` for release-note enhancement and publication
- allow `gh release edit` to work in jobs without a repository checkout
- prevent releases from remaining drafts after successful artifact and crate publication

## Testing

- `git diff --check`
- `actionlint -shellcheck= .github/workflows/release.yml`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow env changes with no application or security logic impact.
> 
> **Overview**
> **Release workflow** now sets `GH_REPO` to `${{ github.repository }}` on the steps that call `gh release view`, `gh release edit` for sponsor notes, and `gh release edit` to unpublish the draft.
> 
> That pins the GitHub CLI to this repo when a job has no checkout (notably **publish-release**, which only flips `--draft=false`) or when the default inferred repo would be wrong. The intended effect is reliable release body updates and drafts actually publishing after crate/artifact work finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a44b714f8d82755354772120fee9b83d9cca6b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated release and sponsor-blurb updates by ensuring commands target the correct repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->