### PR TITLE
chore: release v1.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,77 @@
 # Changelog
 
+## [1.58.0](https://github.com/jdx/hk/compare/v1.57.0..v1.58.0) - 2026-09-05
+
+### 🚀 Features
+
+- **(builtins)** add droast dockerfile linter by [@illesnagy1](https://github.com/illesnagy1) in [#1302](https://github.com/jdx/hk/pull/1302)
+
+### 🐛 Bug Fixes
+
+- **(builtins)** match root action metadata files in pinact globs by [@risu729](https://github.com/risu729) in [#1321](https://github.com/jdx/hk/pull/1321)
+- **(ci)** target repository when publishing releases by [@jdx](https://github.com/jdx) in [#1292](https://github.com/jdx/hk/pull/1292)
+- **(ci)** generate pkl builtins for release binaries by [@sahidvelji](https://github.com/sahidvelji) in [#1299](https://github.com/jdx/hk/pull/1299)
+- **(config)** load scalar settings from pkl by [@jdx](https://github.com/jdx) in [#1307](https://github.com/jdx/hk/pull/1307)
+- **(config)** scope a standalone-loaded subproject to its own directory by [@thespags](https://github.com/thespags) in [#1290](https://github.com/jdx/hk/pull/1290)
+- **(hook)** honor the check and fix settings when selecting run type by [@jdx](https://github.com/jdx) in [#1318](https://github.com/jdx/hk/pull/1318)
+
+### 📚 Documentation
+
+- clarify lefthook stash management by [@jdx](https://github.com/jdx) in [#1297](https://github.com/jdx/hk/pull/1297)
+- fix prose and factual errors in docs and CLI help by [@jdx](https://github.com/jdx) in [#1316](https://github.com/jdx/hk/pull/1316)
+
+### ⚡ Performance
+
+- **(ci)** reuse appliance-local mbx cache by [@jdx](https://github.com/jdx) in [#1317](https://github.com/jdx/hk/pull/1317)
+
+### 🎨 Styling
+
+- fix clippy lints for rust 1.98 by [@risu729](https://github.com/risu729) in [#1278](https://github.com/jdx/hk/pull/1278)
+
+### 🧪 Testing
+
+- run the hook-triggering commit outside a login shell by [@sahidvelji](https://github.com/sahidvelji) in [#1301](https://github.com/jdx/hk/pull/1301)
+
+### 🛡️ Security
+
+- **(deps)** update anthropics/claude-code-action action to v1.0.205 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1304](https://github.com/jdx/hk/pull/1304)
+- add open graph share image by [@jdx](https://github.com/jdx) in [#1324](https://github.com/jdx/hk/pull/1324)
+- complete social and search metadata by [@jdx](https://github.com/jdx) in [#1327](https://github.com/jdx/hk/pull/1327)
+- enforce conventional commits by [@jdx](https://github.com/jdx) in [#1331](https://github.com/jdx/hk/pull/1331)
+
+### 🔍 Other Changes
+
+- **(ci)** restore mbx remote cache by [@jdx](https://github.com/jdx) in [#1288](https://github.com/jdx/hk/pull/1288)
+- **(ci)** use runner-provided rust by [@jdx](https://github.com/jdx) in [#1310](https://github.com/jdx/hk/pull/1310)
+- **(ci)** update mbx to 1.3.2 by [@jdx](https://github.com/jdx) in [#1309](https://github.com/jdx/hk/pull/1309)
+- **(ci)** update mbx to 1.4.0 by [@jdx](https://github.com/jdx) in [#1312](https://github.com/jdx/hk/pull/1312)
+- **(ci)** retry JavaScript dependency installation by [@jdx](https://github.com/jdx) in [#1314](https://github.com/jdx/hk/pull/1314)
+- **(ci)** update performance runner image by [@jdx](https://github.com/jdx) in [#1320](https://github.com/jdx/hk/pull/1320)
+- **(perf)** move benchmarks to dedicated runner by [@jdx](https://github.com/jdx) in [#1298](https://github.com/jdx/hk/pull/1298)
+- **(release)** improve sponsor message by [@jdx](https://github.com/jdx) in [#1306](https://github.com/jdx/hk/pull/1306)
+- **(release)** publish a signed packslip with each release by [@jdx](https://github.com/jdx) in [#1329](https://github.com/jdx/hk/pull/1329)
+- **(release)** bump packslip action to v1.0.0 by [@jdx](https://github.com/jdx) in [#1332](https://github.com/jdx/hk/pull/1332)
+- adopt mr-boxington 1.1 cargo shim by [@jdx](https://github.com/jdx) in [#1295](https://github.com/jdx/hk/pull/1295)
+- update mr-boxington to 1.3.0 by [@jdx](https://github.com/jdx) in [#1300](https://github.com/jdx/hk/pull/1300)
+- route mbx caching by runner provider by [@jdx](https://github.com/jdx) in [#1319](https://github.com/jdx/hk/pull/1319)
+- reseed remote build cache by [@jdx](https://github.com/jdx) in [41cda8a](https://github.com/jdx/hk/commit/41cda8ae31e0a22e4a18077cf75fcb8a05954568)
+- document remote cache seeding by [@jdx](https://github.com/jdx) in [7a44fe4](https://github.com/jdx/hk/commit/7a44fe49969e91f21ccbde14ca2d76d580127635)
+- clarify cache seed authorization by [@jdx](https://github.com/jdx) in [d860a75](https://github.com/jdx/hk/commit/d860a759c8d1cb07b42378605678e6ef72ceb634)
+- bump mbx to 1.6.0 by [@jdx](https://github.com/jdx) in [#1322](https://github.com/jdx/hk/pull/1322)
+- configure Entire search by [@jdx](https://github.com/jdx) in [#1326](https://github.com/jdx/hk/pull/1326)
+- adopt mbx 1.8.1 and benchmark its GitHub target cache by [@jdx](https://github.com/jdx) in [#1328](https://github.com/jdx/hk/pull/1328)
+- use mr-boxington-action directly and retire the cache server from CI by [@jdx](https://github.com/jdx) in [#1330](https://github.com/jdx/hk/pull/1330)
+
+### 📦️ Dependency Updates
+
+- update jdx/mise-action action to v4.3.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1305](https://github.com/jdx/hk/pull/1305)
+- update anthropics/claude-code-action action to v1.0.206 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1313](https://github.com/jdx/hk/pull/1313)
+
+### New Contributors
+
+- @thespags made their first contribution in [#1290](https://github.com/jdx/hk/pull/1290)
+- @illesnagy1 made their first contribution in [#1302](https://github.com/jdx/hk/pull/1302)
+
 ## [1.57.0](https://github.com/jdx/hk/compare/v1.56.1..v1.57.0) - 2026-08-30
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.57.0"
+version = "1.58.0"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "hk"
 repository = "https://github.com/jdx/hk"
 resolver = "3"
 rust-version = "1.91.0"
-version = "1.57.0"
+version = "1.58.0"
 
 [[bin]]
 name = "generate-docs"

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The generated `hk.pkl` uses hk's built-in linter definitions, which you can exte
 needs different behavior:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   ["eslint"] = Builtins.eslint

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 150+ pre-configured linters and formatters through the `Builtins` mo
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -7895,7 +7895,7 @@
     "sources": {},
     "files": []
   },
-  "version": "1.57.0",
+  "version": "1.58.0",
   "usage": "",
   "complete": {
     "directory": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage:** `hk [FLAGS] <SUBCOMMAND>`
 
-**Version:** 1.57.0
+**Version:** 1.58.0
 
 - **Usage:** `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined
@@ -364,8 +364,8 @@ The hkrc file follows the same format as `hk.pkl` and can define hooks and linte
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -400,7 +400,7 @@ Add steps to your hkrc. hk merges them into every project's hooks, so steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -493,7 +493,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -76,8 +76,8 @@ scripts on older versions. See [`hk install`](/cli/install) for all installation
 A typical configuration shares the same linters between automatic hooks and manual commands:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   ["eslint"] = Builtins.eslint

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -42,7 +42,7 @@ They provide dependency management, option parsing, parallel execution, and more
 Run `mise run` in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
 
 hooks {
     ["pre-commit"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line, which validates the config against hk's schema and provides the base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,9 +3,9 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,9 +3,9 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,9 +3,9 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,9 +4,9 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -6,8 +6,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -6,8 +6,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -13,8 +13,8 @@ Groups can set common step attributes such as `dir`, `workspace_indicator`, `pre
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {
@@ -114,7 +114,7 @@ its own `hk.pkl` next to its code. The root config lists the subproject director
 
 ```pkl
 // hk.pkl (repo root)
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
 
 subprojects = List("frontend", "backend", "packages/*")
 
@@ -129,8 +129,8 @@ hooks {
 
 ```pkl
 // frontend/hk.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // aube resolves these executables from frontend/node_modules/.bin
@@ -155,8 +155,8 @@ hooks {
 
 ```pkl
 // backend/hk.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   ["cargo-fmt"] = Builtins.cargo_fmt

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -7,8 +7,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,6 +1,6 @@
-amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.57.0/hk@1.57.0#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
 amends "pkl/Config.pkl"
 
 import "pkl/Builtins.pkl"

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name hk
 bin hk
-version "1.57.0"
+version "1.58.0"
 unknown_flags error
 subcommand_required #true
 flagset hook-options {


### PR DESCRIPTION
### 🚀 Features

- **(builtins)** add droast dockerfile linter by [@illesnagy1](https://github.com/illesnagy1) in [#1302](https://github.com/jdx/hk/pull/1302)

### 🐛 Bug Fixes

- **(builtins)** match root action metadata files in pinact globs by [@risu729](https://github.com/risu729) in [#1321](https://github.com/jdx/hk/pull/1321)
- **(ci)** target repository when publishing releases by [@jdx](https://github.com/jdx) in [#1292](https://github.com/jdx/hk/pull/1292)
- **(ci)** generate pkl builtins for release binaries by [@sahidvelji](https://github.com/sahidvelji) in [#1299](https://github.com/jdx/hk/pull/1299)
- **(config)** load scalar settings from pkl by [@jdx](https://github.com/jdx) in [#1307](https://github.com/jdx/hk/pull/1307)
- **(config)** scope a standalone-loaded subproject to its own directory by [@thespags](https://github.com/thespags) in [#1290](https://github.com/jdx/hk/pull/1290)
- **(hook)** honor the check and fix settings when selecting run type by [@jdx](https://github.com/jdx) in [#1318](https://github.com/jdx/hk/pull/1318)

### 📚 Documentation

- clarify lefthook stash management by [@jdx](https://github.com/jdx) in [#1297](https://github.com/jdx/hk/pull/1297)
- fix prose and factual errors in docs and CLI help by [@jdx](https://github.com/jdx) in [#1316](https://github.com/jdx/hk/pull/1316)

### ⚡ Performance

- **(ci)** reuse appliance-local mbx cache by [@jdx](https://github.com/jdx) in [#1317](https://github.com/jdx/hk/pull/1317)

### 🎨 Styling

- fix clippy lints for rust 1.98 by [@risu729](https://github.com/risu729) in [#1278](https://github.com/jdx/hk/pull/1278)

### 🧪 Testing

- run the hook-triggering commit outside a login shell by [@sahidvelji](https://github.com/sahidvelji) in [#1301](https://github.com/jdx/hk/pull/1301)

### 🛡️ Security

- **(deps)** update anthropics/claude-code-action action to v1.0.205 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1304](https://github.com/jdx/hk/pull/1304)
- add open graph share image by [@jdx](https://github.com/jdx) in [#1324](https://github.com/jdx/hk/pull/1324)
- complete social and search metadata by [@jdx](https://github.com/jdx) in [#1327](https://github.com/jdx/hk/pull/1327)
- enforce conventional commits by [@jdx](https://github.com/jdx) in [#1331](https://github.com/jdx/hk/pull/1331)

### 🔍 Other Changes

- **(ci)** restore mbx remote cache by [@jdx](https://github.com/jdx) in [#1288](https://github.com/jdx/hk/pull/1288)
- **(ci)** use runner-provided rust by [@jdx](https://github.com/jdx) in [#1310](https://github.com/jdx/hk/pull/1310)
- **(ci)** update mbx to 1.3.2 by [@jdx](https://github.com/jdx) in [#1309](https://github.com/jdx/hk/pull/1309)
- **(ci)** update mbx to 1.4.0 by [@jdx](https://github.com/jdx) in [#1312](https://github.com/jdx/hk/pull/1312)
- **(ci)** retry JavaScript dependency installation by [@jdx](https://github.com/jdx) in [#1314](https://github.com/jdx/hk/pull/1314)
- **(ci)** update performance runner image by [@jdx](https://github.com/jdx) in [#1320](https://github.com/jdx/hk/pull/1320)
- **(perf)** move benchmarks to dedicated runner by [@jdx](https://github.com/jdx) in [#1298](https://github.com/jdx/hk/pull/1298)
- **(release)** improve sponsor message by [@jdx](https://github.com/jdx) in [#1306](https://github.com/jdx/hk/pull/1306)
- **(release)** publish a signed packslip with each release by [@jdx](https://github.com/jdx) in [#1329](https://github.com/jdx/hk/pull/1329)
- **(release)** bump packslip action to v1.0.0 by [@jdx](https://github.com/jdx) in [#1332](https://github.com/jdx/hk/pull/1332)
- adopt mr-boxington 1.1 cargo shim by [@jdx](https://github.com/jdx) in [#1295](https://github.com/jdx/hk/pull/1295)
- update mr-boxington to 1.3.0 by [@jdx](https://github.com/jdx) in [#1300](https://github.com/jdx/hk/pull/1300)
- route mbx caching by runner provider by [@jdx](https://github.com/jdx) in [#1319](https://github.com/jdx/hk/pull/1319)
- reseed remote build cache by [@jdx](https://github.com/jdx) in [41cda8a](https://github.com/jdx/hk/commit/41cda8ae31e0a22e4a18077cf75fcb8a05954568)
- document remote cache seeding by [@jdx](https://github.com/jdx) in [7a44fe4](https://github.com/jdx/hk/commit/7a44fe49969e91f21ccbde14ca2d76d580127635)
- clarify cache seed authorization by [@jdx](https://github.com/jdx) in [d860a75](https://github.com/jdx/hk/commit/d860a759c8d1cb07b42378605678e6ef72ceb634)
- bump mbx to 1.6.0 by [@jdx](https://github.com/jdx) in [#1322](https://github.com/jdx/hk/pull/1322)
- configure Entire search by [@jdx](https://github.com/jdx) in [#1326](https://github.com/jdx/hk/pull/1326)
- adopt mbx 1.8.1 and benchmark its GitHub target cache by [@jdx](https://github.com/jdx) in [#1328](https://github.com/jdx/hk/pull/1328)
- use mr-boxington-action directly and retire the cache server from CI by [@jdx](https://github.com/jdx) in [#1330](https://github.com/jdx/hk/pull/1330)

### 📦️ Dependency Updates

- update jdx/mise-action action to v4.3.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1305](https://github.com/jdx/hk/pull/1305)
- update anthropics/claude-code-action action to v1.0.206 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1313](https://github.com/jdx/hk/pull/1313)

### New Contributors

- @thespags made their first contribution in [#1290](https://github.com/jdx/hk/pull/1290)
- @illesnagy1 made their first contribution in [#1302](https://github.com/jdx/hk/pull/1302)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and documentation URL updates with no application logic changes in the diff.
> 
> **Overview**
> **Cuts release v1.58.0** by bumping the crate and CLI metadata from `1.57.0` to `1.58.0` (`Cargo.toml`, `Cargo.lock`, `hk.usage.kdl`, generated CLI docs) and refreshing every documented/example `hk.pkl` `amends`/`import` URL to `v1.58.0`.
> 
> Adds a **CHANGELOG** section for 1.58.0 that records what ships in this tag— notably the **droast** Dockerfile builtin, config/hook fixes (Pkl scalar settings, subproject directory scoping, check/fix run-type selection), pinact root action globs, signed **packslip** on releases, and assorted CI/mbx/mr-boxington updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41bd72d8b77251111868582ffac7b28dbc504d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->