### PR TITLE
chore: adopt mr-boxington 1.1 cargo shim

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -15,12 +15,12 @@ runs:
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
-        version: 1.1.0
+        version: 1.2.0
         backend: github
         cache-generation: v2
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
-        version: 1.1.0
+        version: 1.2.0
         cache-generation: v2
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -8,13 +8,6 @@ inputs:
   mirror-github-cache:
     description: Mirror a trusted main build into the restore-only cache used by fork PRs
     default: "false"
-  cache-links:
-    description: Cache native links; "auto" enables this on Linux
-    default: auto
-  toolchain:
-    description: Rust toolchain named explicitly by the build
-    required: false
-
 runs:
   using: composite
   steps:
@@ -25,15 +18,10 @@ runs:
         version: 1.1.0
         backend: github
         cache-generation: v2
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.1.0
         cache-generation: v2
-        save-on-workflow-dispatch: ${{ github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main' }}
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/hk

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -20,14 +20,14 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@9a406893b83a977c45324a34aed553e3c43f414d
+      uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.1.0
         backend: github
         cache-generation: v2
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
-    - uses: jdx/mr-boxington-action@9a406893b83a977c45324a34aed553e3c43f414d
+    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.1.0
         cache-generation: v2

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -122,9 +122,6 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
-          # mbx 0.7.0 makes macOS debug links portable, so the benchmark
-          # exercises them the way the Linux job already does.
-          cache-links: "true"
       - name: Build
         id: build
         shell: bash

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -27,13 +27,10 @@ jobs:
         include:
           - os: ubuntu-latest
             label: Linux
-            cache-links: auto
           - os: macos-14
             label: macOS
-            cache-links: "true"
           - os: windows-latest
             label: Windows
-            cache-links: auto
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -43,7 +40,6 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
-          cache-links: ${{ matrix.cache-links }}
       - name: Build
         if: runner.os != 'Windows'
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,9 @@ command from `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without
 weakening the check. If bypassed Cargo succeeds, surface the mismatch and recommend a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
 the repository and commit, OS, `mbx --version`, `mbx doctor`, and both commands
-and outputs. Do not permanently disable the shim, and do not post externally
-without user authorization.
+and outputs. Redact secrets, absolute cache paths, remote URLs, namespaces, and
+other sensitive or identifying details. Do not permanently disable the shim,
+and do not post externally without user authorization.
 
 This file provides guidance to AI coding agents when working with code in this repository.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,15 @@
 
 ## mbx build cache
 
-Compilation-heavy mise tasks and hk checks use `mbx`. If an mbx command fails
-or creates a development papercut, rerun the exact equivalent `cargo` command
-from `CONTRIBUTING.md`; this unblocks work without weakening the check. If Cargo
-succeeds, surface the mismatch and recommend a
+Mise installs mbx 1.1 and activates its transparent Cargo shim, so
+compilation-heavy mise tasks and hk checks use ordinary `cargo` commands. If
+the shim fails or creates a development papercut, rerun the exact equivalent
+command from `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without
+weakening the check. If bypassed Cargo succeeds, surface the mismatch and recommend a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
-the repository and commit, OS, `mbx --version`, both commands and outputs, the
-cache summary, and `MBX_BYPASS_LOG` details when relevant. Do not silently make
-Cargo the permanent path, and do not post externally without user authorization.
+the repository and commit, OS, `mbx --version`, `mbx doctor`, and both commands
+and outputs. Do not permanently disable the shim, and do not post externally
+without user authorization.
 
 This file provides guidance to AI coding agents when working with code in this repository.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,20 +4,20 @@ See the [contributing guide](https://hk.jdx.dev/contributing).
 
 ## mbx build cache
 
-The normal `mise run build`, `mise run test:cargo`, and `mise run lint`
-workflows use [mbx](https://mr-boxington.jdx.dev) for compilation-heavy Cargo
-work. If mbx appears to be the problem, use the equivalent Cargo commands to
-unblock yourself without skipping or weakening the check:
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.1 and activates
+its transparent Cargo shim. The normal `mise run build`, `mise run test:cargo`,
+and `mise run lint` workflows therefore use the cache while invoking Cargo
+normally. To bypass mbx without skipping or weakening a check, prefix the
+equivalent Cargo command with `MBX_DISABLE=1`:
 
 ```sh
-cargo build
-cargo test --all --all-features
-cargo clippy --manifest-path Cargo.toml --quiet -- -D warnings
-cargo +nightly check -Zwarnings --quiet
+MBX_DISABLE=1 cargo build
+MBX_DISABLE=1 cargo test --all --all-features
+MBX_DISABLE=1 cargo clippy --manifest-path Cargo.toml --quiet -- -D warnings
+MBX_DISABLE=1 cargo +nightly check -Zwarnings --quiet
 ```
 
-If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a
+If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
-Include the repository and commit, operating system, `mbx --version`, both
-commands and their output, the mbx cache summary, and an `MBX_BYPASS_LOG` when
-relevant (for example, `MBX_BYPASS_LOG=mbx-bypasses.log mise run build`).
+Include the repository and commit, operating system, `mbx --version`,
+`mbx doctor`, and both commands and their output.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,4 +20,6 @@ MBX_DISABLE=1 cargo +nightly check -Zwarnings --quiet
 If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
 Include the repository and commit, operating system, `mbx --version`,
-`mbx doctor`, and both commands and their output.
+`mbx doctor`, and both commands and their output. Before posting, redact
+secrets, absolute cache paths, remote URLs, namespaces, and other sensitive or
+identifying details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ See the [contributing guide](https://hk.jdx.dev/contributing).
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.1 and activates
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.2 and activates
 its transparent Cargo shim. The normal `mise run build`, `mise run test:cargo`,
 and `mise run lint` workflows therefore use the cache while invoking Cargo
 normally. To bypass mbx without skipping or weakening a check, prefix the

--- a/hk.pkl
+++ b/hk.pkl
@@ -16,14 +16,14 @@ local linters = new Mapping<String, Step | Group> {
   ["cargo-clippy"] = (Builtins.cargo_clippy) {
     profiles = List("slow")
     check = new CommandSpec {
-      command = "mbx clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
+      command = "cargo clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
       effect = "write"
     }
   }
   ["cargo-check"] = (Builtins.cargo_check) {
     profiles = List("!slow")
     check = new CommandSpec {
-      command = "mbx +nightly check -Zwarnings --quiet"
+      command = "cargo +nightly check -Zwarnings --quiet"
       effect = "write"
     }
   }

--- a/mise-tasks/build
+++ b/mise-tasks/build
@@ -6,4 +6,4 @@
 
 set -eu
 
-mbx build
+cargo build

--- a/mise-tasks/test/cargo
+++ b/mise-tasks/test/cargo
@@ -4,4 +4,4 @@
 
 set -eu
 
-mbx test --all --all-features
+cargo test --all --all-features

--- a/mise.lock
+++ b/mise.lock
@@ -469,71 +469,6 @@ checksum = "sha256:e437443331865218763d44089680f4d36547353e8c3c8b394c24859203e6c
 url = "https://github.com/foresterre/cargo-msrv/releases/download/v0.19.3/cargo-msrv-x86_64-pc-windows-msvc-v0.19.3.zip"
 url_api = "https://api.github.com/repos/foresterre/cargo-msrv/releases/assets/380851496"
 
-[[tools."github:jdx/mr-boxington"]]
-version = "0.7.0"
-backend = "github:jdx/mr-boxington"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:5dfd6554293c0adc3d7178952bc2a26d01c4e3c970d43c7a630ea3fd0a9b97c3"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515056"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:5dfd6554293c0adc3d7178952bc2a26d01c4e3c970d43c7a630ea3fd0a9b97c3"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515056"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:059936e1c794b129b92e6a712eb684218927a28cdac7474b12cc1e6e957cd702"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515070"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-x64-baseline"]
-checksum = "sha256:059936e1c794b129b92e6a712eb684218927a28cdac7474b12cc1e6e957cd702"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515070"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:059936e1c794b129b92e6a712eb684218927a28cdac7474b12cc1e6e957cd702"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515070"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:059936e1c794b129b92e6a712eb684218927a28cdac7474b12cc1e6e957cd702"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515070"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:7842ae216a0dc5abc3121aafd22025285112bc36d5d906266d5139cb24c148fe"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515059"
-provenance = "github-attestations"
-provenance_verified = true
-
-[tools."github:jdx/mr-boxington"."platforms.windows-arm64"]
-checksum = "sha256:025596a5cbdd3e4f122215a712ba7e74335b278c4ceca8470b3a7637448001f9"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515058"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:4a0e0c86adc339b625b42fb8a1c3710a7255726af18eb9767dcc93d24fe03aaf"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515061"
-provenance = "github-attestations"
-
-[tools."github:jdx/mr-boxington"."platforms.windows-x64-baseline"]
-checksum = "sha256:4a0e0c86adc339b625b42fb8a1c3710a7255726af18eb9767dcc93d24fe03aaf"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.7.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/534515061"
-provenance = "github-attestations"
-
 [[tools."github:jdx/tak"]]
 version = "0.0.8"
 backend = "github:jdx/tak"
@@ -673,6 +608,71 @@ provenance = "github-attestations"
 checksum = "sha256:df7fb73aca464e455f66ab231965cfb15aaea4ccd45be4af4f7df908fc4077d2"
 url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.11/lefthook_2.1.11_Windows_x86_64.gz"
 url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/523446762"
+provenance = "github-attestations"
+
+[[tools.mr-boxington]]
+version = "1.1.0"
+backend = "github:jdx/mr-boxington"
+
+[tools.mr-boxington."platforms.linux-arm64"]
+checksum = "sha256:ded60221f2217a6e0abfe0ba3583674bae63e5a7b696c4fa145827a3a0e352af"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232514"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-arm64-musl"]
+checksum = "sha256:70a882277389bd6e6b606fc291083a857a7ef0c742b60ba5a7822cc49fe7c4ac"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232511"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64"]
+checksum = "sha256:8e718ff25e71057f758d02f3039481258cd531be914afd3f77198811d0113a74"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232519"
+provenance = "github-attestations"
+provenance_verified = true
+
+[tools.mr-boxington."platforms.linux-x64-baseline"]
+checksum = "sha256:8e718ff25e71057f758d02f3039481258cd531be914afd3f77198811d0113a74"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232519"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64-musl"]
+checksum = "sha256:9f590a0fd0fc0a5896791257863980fe9c6035458414575749cc43e68e7ff0cf"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232518"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:9f590a0fd0fc0a5896791257863980fe9c6035458414575749cc43e68e7ff0cf"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232518"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.macos-arm64"]
+checksum = "sha256:da96661534480fff35ec78e598124d208ac1f2624c6d3c287c9ae2a5852b0b29"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232513"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.windows-arm64"]
+checksum = "sha256:a544fa694f41104343138b40407a41d91a8a011fd3478592e2152e6c0067b8a5"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232512"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.windows-x64"]
+checksum = "sha256:4adbb02bf97f00644d2e1e3930e154df39a07df1e574e0829b5d6e34474a3c95"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232517"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.windows-x64-baseline"]
+checksum = "sha256:4adbb02bf97f00644d2e1e3930e154df39a07df1e574e0829b5d6e34474a3c95"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232517"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.lock
+++ b/mise.lock
@@ -611,68 +611,68 @@ url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/52
 provenance = "github-attestations"
 
 [[tools.mr-boxington]]
-version = "1.1.0"
+version = "1.2.0"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:ded60221f2217a6e0abfe0ba3583674bae63e5a7b696c4fa145827a3a0e352af"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232514"
+checksum = "sha256:511a0ec5ea3ebdfe5c1bf37b678b347969c655f7730f33e6328a385b77ee6409"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954373"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:70a882277389bd6e6b606fc291083a857a7ef0c742b60ba5a7822cc49fe7c4ac"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232511"
+checksum = "sha256:59e892a14e765f1b59304c139fee998dc00f02b7d5d60a2d0c5b5bc39b958e61"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954371"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:8e718ff25e71057f758d02f3039481258cd531be914afd3f77198811d0113a74"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232519"
+checksum = "sha256:8c146d2fc9a0ab4cdf493226796e11685f224e40f2695dfffc7cb83be5dbd67e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954388"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-baseline"]
-checksum = "sha256:8e718ff25e71057f758d02f3039481258cd531be914afd3f77198811d0113a74"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232519"
+checksum = "sha256:8c146d2fc9a0ab4cdf493226796e11685f224e40f2695dfffc7cb83be5dbd67e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954388"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:9f590a0fd0fc0a5896791257863980fe9c6035458414575749cc43e68e7ff0cf"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232518"
+checksum = "sha256:011c3241051a3a31302fdf50c66e35aed1549bb5406afee16dea4e7466784c68"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954386"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:9f590a0fd0fc0a5896791257863980fe9c6035458414575749cc43e68e7ff0cf"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232518"
+checksum = "sha256:011c3241051a3a31302fdf50c66e35aed1549bb5406afee16dea4e7466784c68"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954386"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:da96661534480fff35ec78e598124d208ac1f2624c6d3c287c9ae2a5852b0b29"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232513"
+checksum = "sha256:b4da7ecacbf21a649c952025b821e8dfcec3d046bcfcdb4c86d21c9d53875489"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954370"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-arm64"]
-checksum = "sha256:a544fa694f41104343138b40407a41d91a8a011fd3478592e2152e6c0067b8a5"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232512"
+checksum = "sha256:32775c6a715333164ea1f49df99c6dd352459ddc3b4d3a36adffb0d94d586a45"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954372"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:4adbb02bf97f00644d2e1e3930e154df39a07df1e574e0829b5d6e34474a3c95"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232517"
+checksum = "sha256:c65892951de08d331fcc3e80a8cde33892aaf297f186194906d42f35f8a82277"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954384"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64-baseline"]
-checksum = "sha256:4adbb02bf97f00644d2e1e3930e154df39a07df1e574e0829b5d6e34474a3c95"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232517"
+checksum = "sha256:c65892951de08d331fcc3e80a8cde33892aaf297f186194906d42f35f8a82277"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954384"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ communique                      = "latest"
 git-cliff                       = "latest"
 "github:crate-ci/cargo-release" = "latest"
 "github:foresterre/cargo-msrv"  = "latest"
-mr-boxington                     = { version = "1.1.0", postinstall = "mbx setup --global" }
+mr-boxington                    = { version = "1.1.0", postinstall = "mbx setup --global" }
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.

--- a/mise.toml
+++ b/mise.toml
@@ -31,14 +31,14 @@ env = { MBX_DISABLE = "1" }
 run = "cargo build --release"
 
 [tasks.perf]
-dir = "{{config_root}}"
 depends = ["perf:build"]
-run = "tak run"
+dir     = "{{config_root}}"
+run     = "tak run"
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
 # `perf` workflow on every push to main; the notes are the history. Safe to run
 # locally — nothing leaves the machine until `tak push`.
 [tasks."perf:record"]
-dir = "{{config_root}}"
 depends = ["perf:build"]
-run = "tak run --record"
+dir     = "{{config_root}}"
+run     = "tak run --record"

--- a/mise.toml
+++ b/mise.toml
@@ -26,13 +26,19 @@ vhs              = "latest"
 # Instruction-counted benchmarks (see tak.toml). Needs valgrind for the counts;
 # without it tak reports wall clock only and says so, so this still works on
 # macOS where there is no usable cachegrind.
+[tasks."perf:build"]
+env = { MBX_DISABLE = "1" }
+run = "cargo build --release"
+
 [tasks.perf]
 dir = "{{config_root}}"
-run = ["MBX_DISABLE=1 cargo build --release", "tak run"]
+depends = ["perf:build"]
+run = "tak run"
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
 # `perf` workflow on every push to main; the notes are the history. Safe to run
 # locally — nothing leaves the machine until `tak push`.
 [tasks."perf:record"]
 dir = "{{config_root}}"
-run = ["MBX_DISABLE=1 cargo build --release", "tak run --record"]
+depends = ["perf:build"]
+run = "tak run --record"

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ communique                      = "latest"
 git-cliff                       = "latest"
 "github:crate-ci/cargo-release" = "latest"
 "github:foresterre/cargo-msrv"  = "latest"
-mr-boxington                    = { version = "1.1.0", postinstall = "mbx setup --global" }
+mr-boxington                    = { version = "1.2.0", postinstall = "mbx setup --global" }
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ communique                      = "latest"
 git-cliff                       = "latest"
 "github:crate-ci/cargo-release" = "latest"
 "github:foresterre/cargo-msrv"  = "latest"
-"github:jdx/mr-boxington"       = "latest"
+mr-boxington                     = { version = "1.1.0", postinstall = "mbx setup --yes" }
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ communique                      = "latest"
 git-cliff                       = "latest"
 "github:crate-ci/cargo-release" = "latest"
 "github:foresterre/cargo-msrv"  = "latest"
-mr-boxington                     = { version = "1.1.0", postinstall = "mbx setup --yes" }
+mr-boxington                     = { version = "1.1.0", postinstall = "mbx setup --global" }
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.

--- a/mise.toml
+++ b/mise.toml
@@ -28,11 +28,11 @@ vhs              = "latest"
 # macOS where there is no usable cachegrind.
 [tasks.perf]
 dir = "{{config_root}}"
-run = ["cargo build --release", "tak run"]
+run = ["MBX_DISABLE=1 cargo build --release", "tak run"]
 
 # Same measurement, appended to refs/notes/tak for this commit. Run by the
 # `perf` workflow on every push to main; the notes are the history. Safe to run
 # locally — nothing leaves the machine until `tak push`.
 [tasks."perf:record"]
 dir = "{{config_root}}"
-run = ["cargo build --release", "tak run --record"]
+run = ["MBX_DISABLE=1 cargo build --release", "tak run --record"]


### PR DESCRIPTION
## Summary

- adopt the `mr-boxington` mise shorthand at 1.1.0 with the setup post-install hook
- run compilation-heavy tasks through ordinary `cargo` commands and the transparent shim
- refresh the locked release and contributor/agent guidance

## Validation

- `MISE_LOCKED=1 mise install mr-boxington`
- `mise exec -- mbx --version` (`mbx 1.1.0`)
- `mise tasks ls`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches how every contributor and CI job compiles Rust (shim + cache action), so a misconfigured shim or cache regression could break builds or skew benchmarks until caught.
> 
> **Overview**
> Switches local and hook workflows from explicit **`mbx`** invocations to ordinary **`cargo`**, relying on mise-installed **mr-boxington 1.2.0** and **`mbx setup --global`** for a transparent build cache shim. **`mise.lock`** moves from **`github:jdx/mr-boxington` 0.7.0** to the **`mr-boxington`** shorthand at **1.2.0**; **`hk.pkl`**, **`mise-tasks/build`**, and **`mise-tasks/test/cargo`** now run **`cargo`** for clippy, check, build, and test.
> 
> **`AGENTS.md`** and **`CONTRIBUTING.md`** document shim behavior, **`MBX_DISABLE=1`** bypass, **`mbx doctor`**, and redacting sensitive details when reporting issues. **`perf:build`** runs release **`cargo`** with **`MBX_DISABLE=1`** so **`perf`** / **`perf:record`** measure hk without cache interference.
> 
> CI updates **`.github/actions/mbx`** to **mr-boxington-action** and **mbx 1.2.0**, drops **`cache-links`**, **`toolchain`**, and **`save-on-workflow-dispatch`**, and removes per-OS **`cache-links`** tuning from cache benchmark workflows (benchmark jobs still call **`mbx build`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ac2958bf61104d64f7017977fb7557c3321353f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated build-cache guidance with clearer setup, bypass, troubleshooting, and privacy-redaction instructions.
  - Clarified that the build-cache tool is installed and configured automatically.

- **Chores**
  - Standardized build and test tasks to use regular Cargo commands.
  - Updated automatic build-cache setup to the pinned 1.1.0 release.
  - Refreshed continuous integration caching configuration and action versions for more consistent benchmark behavior across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->