### PR TITLE
ci(perf): move benchmarks to dedicated runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,6 @@
 self-hosted-runner:
   labels:
+    - jdx-perf-v1
     - bamboo-perf
     - namespace-profile-endev-linux-amd64
     - namespace-profile-endev-linux-arm64

--- a/.github/workflows/perf-pr-preflight.yml
+++ b/.github/workflows/perf-pr-preflight.yml
@@ -1,0 +1,14 @@
+name: perf-pr-preflight
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  complete:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "The default-branch controller will independently validate this pull request."

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -13,15 +13,17 @@ name: perf-pr
 # main contributes to the history — a branch's numbers are not the trunk's, and
 # a series that mixes them cannot be read.
 
-on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+on: # zizmor: ignore[dangerous-triggers] validates live PR metadata before any self-hosted job
+  workflow_run:
+    workflows: [perf-pr-preflight]
+    types: [completed]
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 env:
@@ -30,9 +32,48 @@ env:
   TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-hk-rust1.97.1
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.pr.outputs.authorized }}
+      base_ref: ${{ steps.pr.outputs.base_ref }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - id: pr
+        name: Validate the pull request from the trusted default branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          TRIGGER_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          TRIGGER_EVENT: ${{ github.event.workflow_run.event }}
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          exec 3>>"$GITHUB_OUTPUT"
+          echo 'authorized=false' >&3
+          [ "$TRIGGER_EVENT" = pull_request ] || exit 0
+          [ "$TRIGGER_CONCLUSION" = success ] || exit 0
+          [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || exit 0
+          pr="$(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER")"
+          [ "$(jq -r .state <<<"$pr")" = open ] || exit 0
+          [ "$(jq -r .user.login <<<"$pr")" = jdx ] || exit 0
+          [ "$(jq -r .head.repo.full_name <<<"$pr")" = "$REPOSITORY" ] || exit 0
+          [ "$(jq -r .base.repo.full_name <<<"$pr")" = "$REPOSITORY" ] || exit 0
+          head_sha="$(jq -r .head.sha <<<"$pr")"
+          [ "$head_sha" = "$TRIGGER_SHA" ] || exit 0
+          echo 'authorized=true' >&3
+          echo "base_ref=$(jq -r .base.ref <<<"$pr")" >&3
+          echo "head_sha=$head_sha" >&3
+          echo "pr_number=$PR_NUMBER" >&3
+
   measure:
     name: Compare instruction counts
-    if: github.event.pull_request.user.login == 'jdx' && github.event.pull_request.head.repo.full_name == github.repository
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
@@ -54,7 +95,7 @@ jobs:
           # for the run, changes whenever main advances, and measuring it would
           # attribute a number to a commit nobody can check out. It would also
           # make the footer below name a commit the measurement is not of.
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.authorize.outputs.head_sha }}
           # Needed twice over: to find the merge base, and for the sparkline,
           # which walks twenty commits of trunk history.
           fetch-depth: 0
@@ -73,7 +114,7 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'environment-revision: perf-runner@78e4231'
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu
@@ -100,7 +141,7 @@ jobs:
       - name: Find the base commit
         id: base
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ needs.authorize.outputs.base_ref }}
         run: |
           git fetch --quiet origin "$BASE_REF"
           # The merge base, not the branch tip: comparing against a moving
@@ -128,7 +169,7 @@ jobs:
         if: always()
         env:
           BASE_SHA: ${{ steps.base.outputs.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
         run: |
           mkdir -p /tmp/tak-out
           # A missing report means an earlier step died. Say so, rather than
@@ -157,8 +198,8 @@ jobs:
   # code: it reads an artifact and talks to the API.
   report:
     name: Report and gate
-    needs: measure
-    if: always() && github.event.pull_request.user.login == 'jdx'
+    needs: [authorize, measure]
+    if: always() && needs.authorize.outputs.authorized == 'true' && needs.measure.result != 'cancelled'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -172,11 +213,10 @@ jobs:
       # Skipped for pull requests from forks, which get a read-only token. The
       # comparison and the gate still run there; only the comment is missing.
       - name: Comment on the pull request
-        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
           GH_hk: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
         run: |
           marker='<!-- hk-perf-pr -->'
           read -r head_sha base_sha < /tmp/tak-out/shas

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -14,7 +14,7 @@ name: perf-pr
 # a series that mixes them cannot be read.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -27,17 +27,20 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-hk-rust1.97.1
 
 jobs:
   measure:
     name: Compare instruction counts
-    if: github.event.pull_request.user.login == 'jdx'
+    if: github.event.pull_request.user.login == 'jdx' && github.event.pull_request.head.repo.full_name == github.repository
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
     # the report would say "nothing was compared" instead of anything useful.
-    runs-on: bamboo-perf
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
       # Read only. This job builds and runs code from the pull request, so it
@@ -57,26 +60,42 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Compile inside this disposable VM. Restoring target/ can relabel a
-      # binary built on a different runner class as a Bamboo measurement.
+      # Compile inside the pinned job container. Restoring target/ could relabel
+      # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
         env:
           MISE_LOCKED: "1"
 
-      - name: Install valgrind
+      - name: Runner metadata
         run: |
-          command -v valgrind || {
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends valgrind
-          }
-          valgrind --version
+          {
+            echo '### Runner metadata'
+            echo '```text'
+            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            uname -a
+            lscpu
+            mise --version
+            rustc --version
+            cargo --version
+            valgrind --version
+            for zone in /sys/class/thermal/thermal_zone*/temp; do
+              [ -r "$zone" ] && printf '%s: %s\n' "$zone" "$(cat "$zone")"
+            done
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify valgrind
+        run: valgrind --version
 
       # `--record` writes a git note locally and nothing more. There is no
       # `tak push` in this workflow and there should never be one.
       - name: Measure this pull request
-        run: mise run perf:record
+        run: |
+          cargo build --release
+          taskset -c 0-3 mise run perf:record
 
       - name: Find the base commit
         id: base

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -80,7 +80,7 @@ jobs:
     # the report would say "nothing was compared" instead of anything useful.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
       options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
@@ -117,8 +117,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@78e4231'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            echo 'environment-revision: perf-runner@6ab972a'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -80,7 +80,7 @@ jobs:
     # the report would say "nothing was compared" instead of anything useful.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
+      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
       options: --cpuset-cpus 0-7
     timeout-minutes: 40
     permissions:
@@ -118,7 +118,7 @@ jobs:
             echo '### Runner metadata'
             echo '```text'
             echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -87,6 +87,9 @@ jobs:
       # Read only. This job builds and runs code from the pull request, so it
       # must not hold a token that can write anything — see the `report` job.
       contents: read
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -203,6 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      checks: write # attach the regression gate to the measured PR head SHA
       pull-requests: write # the sticky comment, and nothing else
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -247,6 +248,29 @@ jobs:
       # after it, and the gate is the reason this workflow exists. Without it a
       # `gh api` hiccup would skip the gate — red for the wrong reason, and with
       # no regression error to read.
+      - name: Publish the pull request check
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          status=$(cat /tmp/tak-out/status 2>/dev/null || echo 2)
+          if [ "$status" -eq 0 ]; then
+            conclusion=success
+            title='Instruction counts passed'
+          else
+            conclusion=failure
+            title='Instruction-count regression or measurement failure'
+          fi
+          test -f /tmp/tak-out/report.md || echo 'The comparison did not produce a report.' > /tmp/tak-out/report.md
+          jq -n --arg head_sha "$HEAD_SHA" --arg conclusion "$conclusion" \
+            --arg title "$title" --arg details_url "$RUN_URL" \
+            --rawfile summary /tmp/tak-out/report.md \
+            '{name:"perf / instruction-count",head_sha:$head_sha,status:"completed",conclusion:$conclusion,details_url:$details_url,output:{title:$title,summary:$summary}}' \
+            | gh api --method POST "repos/$GH_REPO/check-runs" --input -
+
       - name: Fail on a regression
         if: always()
         run: |

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -23,7 +23,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number }}
   cancel-in-progress: true
 
 env:
@@ -256,6 +256,7 @@ jobs:
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          mkdir -p /tmp/tak-out
           status=$(cat /tmp/tak-out/status 2>/dev/null || echo 2)
           if [ "$status" -eq 0 ]; then
             conclusion=success

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-hk-rust1.97.1
 
 jobs:
   measure:
@@ -35,17 +35,20 @@ jobs:
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series
     # that wanders between runners is unreadable.
-    runs-on: bamboo-perf
+    runs-on: [self-hosted, jdx-perf-v1]
+    container:
+      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
-      contents: write # pushing refs/notes/tak is a write to this repository
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      # Compile inside this disposable VM. Restoring target/ can relabel a
-      # binary built on a different runner class as a Bamboo measurement.
+      # Compile inside the pinned job container. Restoring target/ could relabel
+      # a binary built on another runner class as a jdx-perf-v1 measurement.
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
@@ -56,35 +59,77 @@ jobs:
       # to ~0.02% run-to-run where wall clock on this same hardware moves by
       # 4-20%. Without it tak still records timing, but the series stops being
       # precise enough to detect anything.
-      - name: Install valgrind
+      - name: Runner metadata
         run: |
-          command -v valgrind || {
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends valgrind
-          }
-          valgrind --version
+          {
+            echo '### Runner metadata'
+            echo '```text'
+            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            uname -a
+            lscpu
+            mise --version
+            rustc --version
+            cargo --version
+            valgrind --version
+            for zone in /sys/class/thermal/thermal_zone*/temp; do
+              [ -r "$zone" ] && printf '%s: %s\n' "$zone" "$(cat "$zone")"
+            done
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify valgrind
+        run: valgrind --version
 
       - name: Measure and record
-        run: mise run perf:record
-
-      # persist-credentials: false means the push needs its own auth. Same
-      # pattern as bench-refresh.yml: re-point origin rather than pushing to a
-      # one-shot URL, so tak's retry path has a remote to fetch from when it
-      # loses a race.
-      #
-      # Only main publishes. workflow_dispatch can be pointed at any branch or
-      # tag, and refs/notes/tak is a shared baseline that should hold main's
-      # history and nothing else. Gating the push rather than the whole job
-      # means a dispatch on a branch still measures and still prints its
-      # numbers in the summary — it just keeps them local.
-      - name: Push measurements
+        run: |
+          cargo build --release
+          taskset -c 0-3 mise run perf:record
+      - name: Package measurement note
         if: github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p /tmp/tak-out
+          git notes --ref=tak show HEAD > /tmp/tak-out/note
+          git rev-parse HEAD > /tmp/tak-out/sha
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: github.ref == 'refs/heads/main'
+        with:
+          name: tak-measurement
+          path: /tmp/tak-out
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Summary
+        run: tak history >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Publish measurement note
+    needs: measure
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tak-measurement
+          path: /tmp/tak-out
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Publish refs/notes/tak
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
-          tak push
-
-      - name: Summary
-        run: tak history >> "$GITHUB_STEP_SUMMARY"
+          sha=$(cat /tmp/tak-out/sha)
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin refs/notes/tak:refs/notes/tak || true
+          git notes --ref=tak add -f -F /tmp/tak-out/note "$sha"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" refs/notes/tak

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -64,7 +64,7 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@d7c0e81'
+            echo 'environment-revision: perf-runner@78e4231'
             echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
             uname -a
             lscpu

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -37,7 +37,7 @@ jobs:
     # that wanders between runners is unreadable.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922
+      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
       options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
@@ -64,8 +64,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@78e4231'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:1b44fc9f1c93fc1b7a2db56a1ef743bbf8a8df60035121d455c9834fe8001922'
+            echo 'environment-revision: perf-runner@6ab972a'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -37,7 +37,7 @@ jobs:
     # that wanders between runners is unreadable.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b
+      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
       options: --cpuset-cpus 0-7
     timeout-minutes: 30
     permissions:
@@ -65,7 +65,7 @@ jobs:
             echo '### Runner metadata'
             echo '```text'
             echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:8935770e7f656f7b0bcd0204328aa3d6998b32d8bb04084851731b30df56941b'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -130,6 +130,25 @@ jobs:
           sha=$(cat /tmp/tak-out/sha)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git fetch origin refs/notes/tak:refs/notes/tak || true
-          git notes --ref=tak add -f -F /tmp/tak-out/note "$sha"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" refs/notes/tak
+          git fetch origin +refs/notes/tak:refs/notes/tak-remote || true
+          if git rev-parse --verify --quiet refs/notes/tak-remote >/dev/null; then
+            git update-ref refs/notes/tak refs/notes/tak-remote
+          fi
+          {
+            git notes --ref=tak show "$sha" 2>/dev/null || true
+            cat /tmp/tak-out/note
+          } | LC_ALL=C sort -u > /tmp/tak-out/merged-note
+          git notes --ref=tak add -f -F /tmp/tak-out/merged-note "$sha"
+
+          remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          for attempt in 1 2 3 4 5; do
+            if git push --quiet "$remote" refs/notes/tak:refs/notes/tak; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::could not publish refs/notes/tak after five attempts"
+              exit 1
+            fi
+            git fetch --quiet "$remote" +refs/notes/tak:refs/notes/tak-remote
+            git notes --ref=tak merge -s cat_sort_uniq refs/notes/tak-remote
+          done

--- a/mise.lock
+++ b/mise.lock
@@ -535,68 +535,68 @@ url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/5345150
 provenance = "github-attestations"
 
 [[tools."github:jdx/tak"]]
-version = "0.0.8"
+version = "0.0.9"
 backend = "github:jdx/tak"
 
 [tools."github:jdx/tak"."platforms.linux-arm64"]
-checksum = "sha256:d3b5ee39a9be283586fcc1f40fffbe4003d0fce79905462f9e798ec488e148dd"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283627"
+checksum = "sha256:9069450a581d5918c7f40fe4120f054a71835da322604becb42b7acb5bd1e0a1"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992902"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-arm64-musl"]
-checksum = "sha256:a3261a9ffe9fcb2c997687d1d044107ff311429e0d7385ec98e92c6ea1935e2c"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283626"
+checksum = "sha256:0caa3b6b66fe98298714a90e6de0690402a417f5b3c34d9aa9c912edf69a18f1"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992901"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-x64"]
-checksum = "sha256:8def2146c565a331e2de9abebda238c22bb868335dc139db9a76aff1de1339c4"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283644"
+checksum = "sha256:dfb0020b976d679af5a7504190ffbcb201c0e11b2f7788901fd6f60740cd87d4"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992912"
 provenance = "github-attestations"
-provenance_verified = true
 
 [tools."github:jdx/tak"."platforms.linux-x64-baseline"]
-checksum = "sha256:8def2146c565a331e2de9abebda238c22bb868335dc139db9a76aff1de1339c4"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283644"
+checksum = "sha256:dfb0020b976d679af5a7504190ffbcb201c0e11b2f7788901fd6f60740cd87d4"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992912"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-x64-musl"]
-checksum = "sha256:442c866a7572936f639c39edb32042a2f60d78a9dd86116a429f6e31cc9840fe"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283646"
+checksum = "sha256:c761a4dbf695dc493744c79de0f3ab67a1698ee5af9afd35f6d019af36145420"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992915"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:442c866a7572936f639c39edb32042a2f60d78a9dd86116a429f6e31cc9840fe"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283646"
+checksum = "sha256:c761a4dbf695dc493744c79de0f3ab67a1698ee5af9afd35f6d019af36145420"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992915"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.macos-arm64"]
-checksum = "sha256:fbd5e2c3366f085cb8ce71362bcdc05fbf549e7787bd401ae085a1dee09bdb22"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283628"
+checksum = "sha256:be4690bad41265946803d11f145c22e01368164e7f1fe49befef8789259c9471"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992905"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools."github:jdx/tak"."platforms.windows-arm64"]
-checksum = "sha256:112cdf448b50403cfae63b62b017851d0c9ae5fa435473066ff4a6487be978be"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283630"
+checksum = "sha256:0a883d26af032a0a80a4285aad77fe2aa46fb2371c9912524445a8975c9887d6"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992903"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.windows-x64"]
-checksum = "sha256:fd3157419889dc558c87e5779f89d123dc909bfc4f7557c970dcb95d71a97d1b"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283641"
+checksum = "sha256:a15f62ea6fa0051f8ae01fca58da26c550ae95fd9d7eccaa167ca53d6f2262b3"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992910"
 provenance = "github-attestations"
 
 [tools."github:jdx/tak"."platforms.windows-x64-baseline"]
-checksum = "sha256:fd3157419889dc558c87e5779f89d123dc909bfc4f7557c970dcb95d71a97d1b"
-url = "https://github.com/jdx/tak/releases/download/v0.0.8/tak-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/tak/releases/assets/531283641"
+checksum = "sha256:a15f62ea6fa0051f8ae01fca58da26c550ae95fd9d7eccaa167ca53d6f2262b3"
+url = "https://github.com/jdx/tak/releases/download/v0.0.9/tak-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/537992910"
 provenance = "github-attestations"
 
 [[tools.lefthook]]

--- a/mise.toml
+++ b/mise.toml
@@ -14,7 +14,7 @@ git-cliff                       = "latest"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.
-"github:jdx/tak" = "v0.0.8"
+"github:jdx/tak" = "v0.0.9"
 node             = "latest"
 "npm:prettier"   = "latest"
 pkl              = "latest"


### PR DESCRIPTION
## Summary

- route post-merge and trusted pull-request benchmarks to `jdx-perf-v1`
- keep pull-request measurement read-only and perform comments/check updates on GitHub-hosted runners
- authorize only same-repository pull requests authored by `jdx` from the default-branch controller
- pin the benchmark container and actions, disable build caches, and attach runner metadata

## Validation

- `actionlint -color .github/workflows/perf-pr-preflight.yml .github/workflows/perf-pr.yml .github/workflows/perf.yml`
- workflow review for read-only measurement permissions and exact head-SHA checkout

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how performance history is published and how PR code runs on self-hosted hardware; a runner or note-merge regression could break gates or skew the tak series.
> 
> **Overview**
> Moves **main** and **PR instruction-count benchmarks** from `bamboo-perf` to **`jdx-perf-v1`**, using a **pinned `ghcr.io/jdx/perf-runner` container**, **disabled mise cache**, explicit **`cargo build --release`**, and **`taskset`** for more stable measurements. **`TAK_RUNNER`** and actionlint now recognize the new label.
> 
> **PR perf (`perf-pr.yml`)** no longer runs directly on `pull_request`. A new **`perf-pr-preflight`** workflow fires on PR updates; **`perf-pr`** runs on **`workflow_run`** and adds an **`authorize`** job that re-fetches PR metadata (open, same-repo, author **`jdx`**, head SHA matches the trigger) before any self-hosted work. Measurement stays **read-only**; **`report`** on `ubuntu-latest` posts the sticky comment, publishes a **`perf / instruction-count`** check on the validated head SHA, and fails the workflow on regressions.
> 
> **Main perf (`perf.yml`)** splits **measure** (read-only, artifact upload) from **`publish`** (GitHub-hosted **`contents: write`**) so **`refs/notes/tak`** is updated via fetch/merge/retry push instead of **`tak push`** on the runner that built the code.
> 
> **`github:jdx/tak`** is bumped **v0.0.8 → v0.0.9** in `mise.toml` / `mise.lock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70c1ef49ba066ebcc1e808e9ab321e7824d7dec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated performance validation for pull requests.
  * Performance measurements now run on dedicated, standardized hardware and publish results as a check.
  * Added runner details to performance summaries.
  * Improved reliability when publishing performance data.

* **Bug Fixes**
  * Added validation to ensure measurements run only for the intended pull request revision.
  * Improved consistency by building and measuring the exact validated revision.
  * Updated performance tooling to the latest supported version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Tak release

Tak 0.0.9 is pinned through its checksum-verified GitHub release artifacts; no Cargo compilation is used.