### PR TITLE
chore: update mr-boxington to 1.3.0

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -15,12 +15,12 @@ runs:
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
-        version: 1.2.0
+        version: 1.3.0
         backend: github
         cache-generation: v2
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
-        version: 1.2.0
+        version: 1.3.0
         cache-generation: v2
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,15 @@
 
 ## mbx build cache
 
-Mise installs mbx 1.1 and activates its transparent Cargo shim, so
+Mise installs mbx 1.3 and activates its transparent Cargo wrapper, so
 compilation-heavy mise tasks and hk checks use ordinary `cargo` commands. If
-the shim fails or creates a development papercut, rerun the exact equivalent
+the wrapper fails or creates a development papercut, rerun the exact equivalent
 command from `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without
 weakening the check. If bypassed Cargo succeeds, surface the mismatch and recommend a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
 the repository and commit, OS, `mbx --version`, `mbx doctor`, and both commands
 and outputs. Redact secrets, absolute cache paths, remote URLs, namespaces, and
-other sensitive or identifying details. Do not permanently disable the shim,
+other sensitive or identifying details. Do not permanently disable the wrapper,
 and do not post externally without user authorization.
 
 This file provides guidance to AI coding agents when working with code in this repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 ## mbx build cache
 
-Mise installs mbx 1.3 and activates its transparent Cargo wrapper, so
-compilation-heavy mise tasks and hk checks use ordinary `cargo` commands. If
+`mise install` installs mbx 1.3. `mise run` activates the project's transparent
+Cargo wrapper, so compilation-heavy mise tasks and hk checks use ordinary
+`cargo` commands. Standalone Cargo commands require an activated mise shell. If
 the wrapper fails or creates a development papercut, rerun the exact equivalent
 command from `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without
 weakening the check. If bypassed Cargo succeeds, surface the mismatch and recommend a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ See the [contributing guide](https://hk.jdx.dev/contributing).
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.2 and activates
-its transparent Cargo shim. The normal `mise run build`, `mise run test:cargo`,
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3 and activates
+its transparent Cargo wrapper. The normal `mise run build`, `mise run test:cargo`,
 and `mise run lint` workflows therefore use the cache while invoking Cargo
 normally. To bypass mbx without skipping or weakening a check, prefix the
 equivalent Cargo command with `MBX_DISABLE=1`:
@@ -17,7 +17,7 @@ MBX_DISABLE=1 cargo clippy --manifest-path Cargo.toml --quiet -- -D warnings
 MBX_DISABLE=1 cargo +nightly check -Zwarnings --quiet
 ```
 
-If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
+If bypassed Cargo succeeds where the wrapper fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
 Include the repository and commit, operating system, `mbx --version`,
 `mbx doctor`, and both commands and their output. Before posting, redact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,11 @@ See the [contributing guide](https://hk.jdx.dev/contributing).
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3 and activates
-its transparent Cargo wrapper. The normal `mise run build`, `mise run test:cargo`,
-and `mise run lint` workflows therefore use the cache while invoking Cargo
-normally. To bypass mbx without skipping or weakening a check, prefix the
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3. The normal
+`mise run build`, `mise run test:cargo`, and `mise run lint` workflows activate
+its transparent Cargo wrapper and therefore use the cache while invoking Cargo
+normally. Standalone Cargo commands require an activated mise shell. To bypass
+mbx without skipping or weakening a check, prefix the
 equivalent Cargo command with `MBX_DISABLE=1`:
 
 ```sh

--- a/mise-tasks/msrv
+++ b/mise-tasks/msrv
@@ -2,4 +2,4 @@
 
 set -eu
 
-mbx msrv verify
+cargo msrv verify

--- a/mise.lock
+++ b/mise.lock
@@ -611,68 +611,68 @@ url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/52
 provenance = "github-attestations"
 
 [[tools.mr-boxington]]
-version = "1.2.0"
+version = "1.3.0"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:511a0ec5ea3ebdfe5c1bf37b678b347969c655f7730f33e6328a385b77ee6409"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954373"
+checksum = "sha256:92a8544d26324b7803eeb1d2f1c276e322e474d45e7f40b6f6a1e72ce99d6fdc"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561463"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:59e892a14e765f1b59304c139fee998dc00f02b7d5d60a2d0c5b5bc39b958e61"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954371"
+checksum = "sha256:db505d360e8c1dfc6fb31ecf8172329ae2fa2417b14508e306626c6c1dba3514"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561466"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:8c146d2fc9a0ab4cdf493226796e11685f224e40f2695dfffc7cb83be5dbd67e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954388"
+checksum = "sha256:0717a7dc93fdd9712d648ddab0f7e0871b50b626568c62a5c1033396f50e3940"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561483"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-baseline"]
-checksum = "sha256:8c146d2fc9a0ab4cdf493226796e11685f224e40f2695dfffc7cb83be5dbd67e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954388"
+checksum = "sha256:0717a7dc93fdd9712d648ddab0f7e0871b50b626568c62a5c1033396f50e3940"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561483"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:011c3241051a3a31302fdf50c66e35aed1549bb5406afee16dea4e7466784c68"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954386"
+checksum = "sha256:385b25699ba7429fe7cd36668667c45ff8d38f4491ebb4164e95021b22374ed0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561484"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:011c3241051a3a31302fdf50c66e35aed1549bb5406afee16dea4e7466784c68"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954386"
+checksum = "sha256:385b25699ba7429fe7cd36668667c45ff8d38f4491ebb4164e95021b22374ed0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561484"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:b4da7ecacbf21a649c952025b821e8dfcec3d046bcfcdb4c86d21c9d53875489"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954370"
+checksum = "sha256:0d2e9d6e7d8228faafda68e2cd4190ce977a332821833c19a853c4a9dd91a82f"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561462"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-arm64"]
-checksum = "sha256:32775c6a715333164ea1f49df99c6dd352459ddc3b4d3a36adffb0d94d586a45"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954372"
+checksum = "sha256:21314d52d09991c49596f65f7da82ad377df57b0b5249f16ad97b79a9c9efdee"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561460"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:c65892951de08d331fcc3e80a8cde33892aaf297f186194906d42f35f8a82277"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954384"
+checksum = "sha256:e102e3e1dd0777fc7a39c91a7805cbc8636bc4ab0c5cdc30a51b7962b8a524a7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561482"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64-baseline"]
-checksum = "sha256:c65892951de08d331fcc3e80a8cde33892aaf297f186194906d42f35f8a82277"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.2.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537954384"
+checksum = "sha256:e102e3e1dd0777fc7a39c91a7805cbc8636bc4ab0c5cdc30a51b7962b8a524a7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561482"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ communique                      = "latest"
 git-cliff                       = "latest"
 "github:crate-ci/cargo-release" = "latest"
 "github:foresterre/cargo-msrv"  = "latest"
-mr-boxington                    = { version = "1.2.0", postinstall = "mbx setup --global" }
+mr-boxington                    = "1.3.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.
@@ -22,6 +22,10 @@ ripgrep          = "latest"
 taplo            = "latest"
 uv               = "latest"
 vhs              = "latest"
+
+[wrappers.cargo]
+command = "mbx"
+env = { MBX_CARGO_SHIM_MODE = "1" }
 
 # Instruction-counted benchmarks (see tak.toml). Needs valgrind for the counts;
 # without it tak reports wall clock only and says so, so this still works on

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
+min_version = "2026.8.16"
+
 [env]
 _.path = ["test/bats/bin", "{{ env.CARGO_TARGET_DIR | default(value='target') }}/debug", "node_modules/.bin"]
 
@@ -25,7 +27,7 @@ vhs              = "latest"
 
 [wrappers.cargo]
 command = "mbx"
-env = { MBX_CARGO_SHIM_MODE = "1" }
+env     = { MBX_CARGO_SHIM_MODE = "1" }
 
 # Instruction-counted benchmarks (see tak.toml). Needs valgrind for the counts;
 # without it tak reports wall clock only and says so, so this still works on


### PR DESCRIPTION
## Summary
- update mr-boxington to 1.3.0 and refresh its lock entry
- commit the project-scoped Cargo wrapper instead of running global setup
- update mbx contributor and agent guidance for command wrappers

## Validation
- `mise lock --dry-run --json mr-boxington`
- verified `mbx 1.3.0` and Cargo resolution through mise command wrappers

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and CI cache version bump with project-local Cargo wrapping; no application runtime or security-sensitive logic changes.
> 
> **Overview**
> Bumps **mr-boxington (mbx)** from 1.2.0 to **1.3.0** in `mise.toml`, `mise.lock`, and the GitHub **mbx** composite action (both cache steps).
> 
> Cargo caching is wired through mise instead of a global post-install: **`mbx setup --global` is removed**, **`[wrappers.cargo]`** routes `cargo` through `mbx` with `MBX_CARGO_SHIM_MODE=1`, and **`min_version = "2026.8.16"`** is added for mise. The **msrv** task now runs **`cargo msrv verify`** so it uses that wrapper like other mise tasks.
> 
> **AGENTS.md** and **CONTRIBUTING.md** are updated for 1.3, “shim” → “wrapper”, and the note that standalone `cargo` needs an activated mise shell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342037939eca99033467975bab86649667fa7655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated mbx setup and troubleshooting guidance to reference version 1.3.
  * Clarified “Cargo wrapper” terminology and documented activation requirements for standalone Cargo commands.
* **Chores**
  * Updated project tooling and CI configuration to use mbx 1.3.
  * Improved Cargo command integration through the mbx wrapper.
  * Simplified mbx setup by removing the separate post-install step.
  * Updated minimum mise version requirements.
  * MSRV verification now runs through Cargo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->