### PR TITLE
test: run the hook-triggering commit outside a login shell

### DIFF
--- a/test/fixer_tail_deletion_with_middle_unstaged.bats
+++ b/test/fixer_tail_deletion_with_middle_unstaged.bats
@@ -72,7 +72,9 @@ deps:
 
 EOF
 
-    run bash -lc 'git -c commit.gpgsign=false commit -m "redis"'
+    # Not a login shell: macOS path_helper would put /usr/bin/git first, and an
+    # older git ignores the config-based hook hk installed, skipping the fixer.
+    run bash -c 'git -c commit.gpgsign=false commit -m "redis"'
     echo "$output"
     assert_success
 


### PR DESCRIPTION
`pre-commit (stash=git) preserves fixer tail deletion when unstaged change is in middle` fails on every untrusted PR (e.g. #1290, #1299), and has nothing to do with the merge bug it was written to guard — the pre-commit hook simply never runs for the second commit.

## Cause

GitHub-hosted macOS runners carry two gits: Homebrew's 2.55 and Apple's older one in `/usr/bin`. `hk install` sees 2.55, so `git_at_least(2, 54)` at `src/cli/install.rs:92` selects config-based hooks and `remove_local_shims()` drops the `.git/hooks` shim. The commit then runs under `bash -lc`, and macOS `path_helper` rebuilds PATH with `/usr/bin` first — so Apple's git executes it, silently ignores `hook.hk-pre-commit.command`, and no hook mechanism is left. The fixer never strips the trailing blank lines.

The CI log shows it plainly: the `base` commit (plain `git commit`) has full hk output, the `redis` commit (`bash -lc`) has none.

This was the only test wrapping a *hook-triggering* commit in `bash -lc` — the other nine `hk install` tests use it only for `git diff`/`show`/`cat`. Namespace runners ship git 2.53, below the cutoff, so `main` takes the legacy shim path and stays green.

## Verification

Reproduced locally by installing Homebrew git 2.55 alongside Apple's 2.50, matching the runner: the unmodified test fails byte-for-byte as in CI (line 84, `5a6,7`, `1 file changed, 3 insertions(+)`), and passes with this change. All 16 tests across the nine sibling `hk install` files pass under the same setup.

## Worth a separate look

hk picks its hook mechanism from whichever git it sees at install time and removes the other. On any machine with two gits — routine on macOS with Homebrew — hooks can silently stop running with no warning. That's a real footgun beyond this test, but out of scope here.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.236.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved regression test reliability on macOS by ensuring the configured fixer hook is invoked consistently.
  * Preserved existing coverage for tail-deletion scenarios with unstaged middle changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->