### PR TITLE
feat(builtins): add droast dockerfile linter

### DIFF
--- a/pkl/builtins/droast.pkl
+++ b/pkl/builtins/droast.pkl
@@ -7,19 +7,19 @@ import "./test/helpers.pkl"
   description = "Dockerfile linter for security, layer hygiene, and best-practice violations"
   project_indicators {
     new { file = "Dockerfile" }
-    new { glob = "**/Dockerfile*" }
-    new { glob = "**/Containerfile*" }
+    new { file = "Containerfile" }
   }
 }
 droast = new Config.Step {
-  glob = List(
-    "**/Dockerfile",
-    "**/Dockerfile.*",
-    "**/*.Dockerfile",
-    "**/*.dockerfile",
-    "**/Containerfile",
-    "**/Containerfile.*",
-  )
+  glob =
+    List(
+      "**/Dockerfile",
+      "**/Dockerfile.*",
+      "**/*.Dockerfile",
+      "**/*.dockerfile",
+      "**/Containerfile",
+      "**/Containerfile.*",
+    )
   check = new Config.CommandSpec {
     command = new Config.Command { argv = List("droast", "{{files}}") }
     effect = "read"
@@ -33,7 +33,10 @@ droast = new Config.Step {
     ["check bad file"] = testMaker.checkFail("FROM debian:bookworm\nEXPOSE 99999\n", 1)
     ["check good file"] = testMaker.checkPass("FROM debian:bookworm\n")
     ["fix bad file"] =
-      testMaker.fixPass("FROM debian:bookworm\nEXPOSE 80/TCP\n", "FROM debian:bookworm\nEXPOSE 80/tcp\n")
+      testMaker.fixPass(
+        "FROM debian:bookworm\nEXPOSE 80/TCP\n",
+        "FROM debian:bookworm\nEXPOSE 80/tcp\n",
+      )
     ["fix good file"] = testMaker.fixPass("FROM debian:bookworm\n", "FROM debian:bookworm\n")
   }
 }

--- a/pkl/builtins/droast.pkl
+++ b/pkl/builtins/droast.pkl
@@ -1,0 +1,39 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+import "./test/helpers.pkl"
+
+@Builtins.meta {
+  category = "Infrastructure"
+  description = "Dockerfile linter for security, layer hygiene, and best-practice violations"
+  project_indicators {
+    new { file = "Dockerfile" }
+    new { glob = "**/Dockerfile*" }
+    new { glob = "**/Containerfile*" }
+  }
+}
+droast = new Config.Step {
+  glob = List(
+    "**/Dockerfile",
+    "**/Dockerfile.*",
+    "**/*.Dockerfile",
+    "**/*.dockerfile",
+    "**/Containerfile",
+    "**/Containerfile.*",
+  )
+  check = new Config.CommandSpec {
+    command = new Config.Command { argv = List("droast", "{{files}}") }
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command = new Config.Command { argv = List("droast", "--fix", "{{files}}") }
+    effect = "write"
+  }
+  tests {
+    local const testMaker = new helpers.TestMaker { filename = "Dockerfile" }
+    ["check bad file"] = testMaker.checkFail("FROM debian:bookworm\nEXPOSE 99999\n", 1)
+    ["check good file"] = testMaker.checkPass("FROM debian:bookworm\n")
+    ["fix bad file"] =
+      testMaker.fixPass("FROM debian:bookworm\nEXPOSE 80/TCP\n", "FROM debian:bookworm\nEXPOSE 80/tcp\n")
+    ["fix good file"] = testMaker.fixPass("FROM debian:bookworm\n", "FROM debian:bookworm\n")
+  }
+}

--- a/test/builtin_tool_stubs/droast
+++ b/test/builtin_tool_stubs/droast
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "1.6.1"
+tool = "github:immanuwell/dockerfile-roast"

--- a/test/init_creates_hk_pkl.bats
+++ b/test/init_creates_hk_pkl.bats
@@ -65,8 +65,10 @@ teardown() {
     echo 'FROM alpine' > Dockerfile
     run hk init
     assert_success
-    assert_output --partial "Detected: hadolint (Dockerfile)"
+    assert_output --partial "hadolint (Dockerfile)"
+    assert_output --partial "droast (Dockerfile)"
     assert_file_contains hk.pkl "Builtins.hadolint"
+    assert_file_contains hk.pkl "Builtins.droast"
 }
 
 @test "hk init generates default template when nothing detected" {


### PR DESCRIPTION
## Summary
- Add `droast` (https://github.com/immanuwell/dockerfile-roast) as a new built-in Dockerfile linter, matching Dockerfile/Dockerfile.*/Containerfile* patterns
- Check runs `droast {{files}}` (read-only); fix runs `droast --fix {{files}}` for its safe deterministic fixes (DF076/DF078/DF079/DF083)
- Added a `github:` backend tool stub for CI, since droast isn't in the aqua registry

## Test plan
- [x] `mise run build`
- [x] `hk test --step droast` passes (check pass/fail, fix pass)
- [x] `mise run test:bats test/builtins_tests.bats` — droast's tests pass; remaining failures (rubocop/rubocop_server) are pre-existing on `main`

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `dockerfile-roast` tool through the tool manager.
  * Configured version 1.6.1 for consistent installation and use.
  * `hk init` now detects Dockerfiles and reports `droast (Dockerfile)` when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->