### PR TITLE
chore(release): improve sponsor message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -352,9 +352,9 @@ jobs:
           cat <<'EOF' >> /tmp/release-notes.md
           ## 💚 Sponsor hk
 
-          hk is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), and more. Work on hk is funded by sponsorships.
+          hk is built and maintained by [@jdx](https://github.com/jdx), an open source developer at [**entire.io**](https://entire.io/), the title sponsor of his open source work.
 
-          If hk has sped up your pre-commit loop or made linting feel less painful, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Sponsorships are what keep hk moving and the project independent.
+          If hk speeds up your pre-commit loop or makes linting less painful, please consider becoming an [individual or company sponsor](https://jdx.dev/sponsors.html). Your support funds ongoing development and helps keep hk fast, free, and independent.
           EOF
 
           gh release edit "$TAG_NAME" --notes-file /tmp/release-notes.md


### PR DESCRIPTION
## Summary

- clarify Entire's sponsorship of jdx's open source work
- link the sponsorship call to action directly to the individual and company sponsor page
- tighten the release-note copy while preserving each CLI's tailored message

## Testing

- git diff --check
- parsed the updated workflow as YAML

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in release-note generation; no runtime, auth, or build behavior changes.
> 
> **Overview**
> Updates the **“💚 Sponsor hk”** blurb that the `enhance-release` job appends to GitHub release notes after stripping any prior sponsor section.
> 
> The first paragraph now describes [@jdx](https://github.com/jdx) as working at **entire.io** and frames Entire as the title sponsor of his open source work, instead of the longer list of jdx.dev tools (mise, aube, etc.). The CTA now points readers to **[individual or company sponsor](https://jdx.dev/sponsors.html)** with tightened wording about funding development and keeping hk independent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfbe9d7e8088d49d287150ff5c12f33187e5dde4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sponsor message included in GitHub release notes.
  * The message now highlights jdx’s open source development work and invites individual or company sponsorship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->