### PR TITLE
fix(config): load scalar settings from pkl

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -437,6 +437,7 @@ impl Config {
         Ok(())
     }
 
+    /// Merge Config-format user settings as fallbacks while preserving project values.
     fn merge_from_hkrc(&mut self, hkrc: Config) {
         // Environment: project wins. hkrc values are set only if not defined by project.
         // set_var is unsafe in Rust 2024 but required so child processes inherit these.

--- a/src/config.rs
+++ b/src/config.rs
@@ -462,6 +462,9 @@ impl Config {
         self.skip_steps = self.skip_steps.take().or(hkrc.skip_steps);
         self.default_branch = self.default_branch.take().or(hkrc.default_branch);
         self.min_hk_version = self.min_hk_version.take().or(hkrc.min_hk_version);
+        self.stash_backup_count = self.stash_backup_count.or(hkrc.stash_backup_count);
+        self.terminal_progress = self.terminal_progress.or(hkrc.terminal_progress);
+        self.walk_ignore = self.walk_ignore.or(hkrc.walk_ignore);
 
         // Hooks: additive, project wins on same-named step collision
         for (hook_name, hkrc_hook) in hkrc.hooks {
@@ -1001,9 +1004,12 @@ pub struct Config {
     pub profiles: Option<Vec<String>>,
     pub skip_hooks: Option<Vec<String>>,
     pub skip_steps: Option<Vec<String>>,
+    pub stash_backup_count: Option<usize>,
     /// Directories (or glob patterns) containing their own hk config files.
     /// Their hooks are merged into this config, scoped to the subdirectory.
     pub subprojects: Option<Vec<String>>,
+    pub terminal_progress: Option<bool>,
+    pub walk_ignore: Option<bool>,
 }
 
 impl std::fmt::Display for Config {

--- a/test/config_unification.bats
+++ b/test/config_unification.bats
@@ -18,6 +18,21 @@ teardown() {
     echo "$output" | grep -q '"exclude"'
 }
 
+@test "hk config dump includes scalar settings from pkl" {
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+stash_backup_count = 0
+terminal_progress = false
+walk_ignore = false
+EOF
+
+    run hk config dump
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.stash_backup_count')" = "0" ]
+    [ "$(echo "$output" | jq -r '.terminal_progress')" = "false" ]
+    [ "$(echo "$output" | jq -r '.walk_ignore')" = "false" ]
+}
+
 @test "hk config get retrieves specific values" {
     run hk config get fail_fast
     [ "$status" -eq 0 ]

--- a/test/hkrc.bats
+++ b/test/hkrc.bats
@@ -511,6 +511,27 @@ EOF
     assert_output --partial "project step"
 }
 
+@test "hkrc: XDG config provides scalar pkl settings" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+EOF
+
+    export HK_CONFIG_DIR="$TEST_TEMP_DIR/.config/hk"
+    mkdir -p "$HK_CONFIG_DIR"
+    cat <<EOF > "$HK_CONFIG_DIR/config.pkl"
+amends "$PKL_PATH/Config.pkl"
+stash_backup_count = 0
+terminal_progress = false
+walk_ignore = false
+EOF
+
+    run hk config dump
+    assert_success
+    [ "$(echo "$output" | jq -r '.stash_backup_count')" = "0" ]
+    [ "$(echo "$output" | jq -r '.terminal_progress')" = "false" ]
+    [ "$(echo "$output" | jq -r '.walk_ignore')" = "false" ]
+}
+
 @test "hkrc: CWD hkrc wins over home hkrc" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"


### PR DESCRIPTION
## Summary

- deserialize `terminal_progress`, `walk_ignore`, and `stash_backup_count` from Pkl config
- merge these settings from Config-format user-global config
- add project and user-global regression coverage

Fixes the configuration bridge issue reported in https://github.com/jdx/hk/discussions/1303.

## Tests

- `cargo fmt --check`
- `cargo test`
- `mise run test:bats test/config_unification.bats`
- `mise run test:bats test/hkrc.bats`
- `target/debug/hk check` with the local binary first on `PATH`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow config deserialization and merge change with regression tests; no auth or data-path logic touched.
> 
> **Overview**
> **Fixes Pkl/global config for `stash_backup_count`, `terminal_progress`, and `walk_ignore`** — these scalars were defined in Pkl but were dropped when hk deserialized evaluated config JSON because they were missing from the Rust `Config` model.
> 
> The PR adds those fields on `Config`, merges them in `merge_from_hkrc` with the same **project-first** fallback pattern as other scalar settings, and documents that merge path. **`hk config dump`** and effective settings should now reflect values from project `hk.pkl` and from XDG/global `config.pkl` when the project leaves them unset.
> 
> **Tests** assert dump output for project Pkl and for XDG user config (including explicit `false`/`0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3ef936b0c60ea8a06fbb3895b1f642cf4ed63e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring stash backup counts, terminal progress display, and ignored-file walking.
  * These settings can now be defined in both project and global configuration, with project values taking precedence.

* **Bug Fixes**
  * Ensured all three settings are correctly merged and shown by the configuration dump command.

* **Tests**
  * Added coverage for project and global configuration values, including disabled boolean settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->