### PR TITLE
chore(ci): update mbx to 1.3.2

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -16,12 +16,12 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@v1.2.0
+      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         version: ${{ inputs.version }}
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@v1.2.0
+    - uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         version: ${{ inputs.version }}
         cache-generation: v2

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -8,19 +8,22 @@ inputs:
   mirror-github-cache:
     description: Mirror a trusted main build into the restore-only cache used by fork PRs
     default: "false"
+  version:
+    description: Explicit mbx version for jobs that cannot install project tools first
+    required: false
 runs:
   using: composite
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
+      uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
       with:
-        version: 1.3.0
+        version: ${{ inputs.version }}
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
+    - uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
       with:
-        version: 1.3.0
+        version: ${{ inputs.version }}
         cache-generation: v2
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -16,12 +16,12 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
+      uses: jdx/mr-boxington-action@v1.2.0
       with:
         version: ${{ inputs.version }}
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
+    - uses: jdx/mr-boxington-action@v1.2.0
       with:
         version: ${{ inputs.version }}
         cache-generation: v2

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
-          version: 1.3.0
+          version: 1.3.2
       - name: Build
         id: build
         shell: bash
@@ -123,7 +123,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
-          version: 1.3.0
+          version: 1.3.2
       - name: Build
         id: build
         shell: bash
@@ -203,7 +203,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
-          version: 1.3.0
+          version: 1.3.2
       - name: Build
         id: build
         shell: pwsh

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
+          version: 1.3.0
       - name: Build
         id: build
         shell: bash
@@ -122,6 +123,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
+          version: 1.3.0
       - name: Build
         id: build
         shell: bash
@@ -201,6 +203,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
+          version: 1.3.0
       - name: Build
         id: build
         shell: pwsh

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -60,13 +60,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          cache: false
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.mbx-backend }}
           mirror-github-cache: "true"
-      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
-        with:
-          cache: false
       - run: mise run build
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -79,6 +79,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          cache: false
+          install_args: mr-boxington
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.mbx-backend }}
@@ -212,12 +216,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - run: mise x -- aube install
       - name: mise run test:cargo
         run: mise run test:cargo
@@ -240,12 +244,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - run: mise run msrv
   ci-windows:
     needs: build-windows
@@ -255,12 +259,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
+      - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.mbx-backend }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: hk-windows-latest

--- a/.github/workflows/docs-impl.yml
+++ b/.github/workflows/docs-impl.yml
@@ -35,10 +35,10 @@ jobs:
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
           persist-credentials: false
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.mbx-backend }}
-      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - name: Build with VitePress

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
+          version: 1.3.0
       - name: Build
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
-          version: 1.3.0
+          version: 1.3.2
       - name: Build
         if: runner.os != 'Windows'
         shell: bash

--- a/mise.lock
+++ b/mise.lock
@@ -611,68 +611,68 @@ url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/52
 provenance = "github-attestations"
 
 [[tools.mr-boxington]]
-version = "1.3.0"
+version = "1.3.2"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:92a8544d26324b7803eeb1d2f1c276e322e474d45e7f40b6f6a1e72ce99d6fdc"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561463"
+checksum = "sha256:18aabfdfaced4316b9e9fd488d65df0915b241aa3af8e761b4df0fc0bdc1a4f7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849887"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:db505d360e8c1dfc6fb31ecf8172329ae2fa2417b14508e306626c6c1dba3514"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561466"
+checksum = "sha256:abbbcc8cc7c080febc5f6c77e1ae7af89faf15476248282f7bf4c331e836ee1b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849885"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:0717a7dc93fdd9712d648ddab0f7e0871b50b626568c62a5c1033396f50e3940"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561483"
+checksum = "sha256:6096035ae9bb47d718b7c0ca2860e1142047ebf724b37c02d3a520a4b9804d2d"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849911"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-baseline"]
-checksum = "sha256:0717a7dc93fdd9712d648ddab0f7e0871b50b626568c62a5c1033396f50e3940"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561483"
+checksum = "sha256:6096035ae9bb47d718b7c0ca2860e1142047ebf724b37c02d3a520a4b9804d2d"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849911"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:385b25699ba7429fe7cd36668667c45ff8d38f4491ebb4164e95021b22374ed0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561484"
+checksum = "sha256:a31a332095ac291686777736d450b2f62658145ac173ff543f83271e44850df7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849909"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:385b25699ba7429fe7cd36668667c45ff8d38f4491ebb4164e95021b22374ed0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561484"
+checksum = "sha256:a31a332095ac291686777736d450b2f62658145ac173ff543f83271e44850df7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849909"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:0d2e9d6e7d8228faafda68e2cd4190ce977a332821833c19a853c4a9dd91a82f"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561462"
+checksum = "sha256:3a91ecb2d6ff4ad84662e79599d11e79eff4738c222a35ed432db4b15ade4d1e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849886"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-arm64"]
-checksum = "sha256:21314d52d09991c49596f65f7da82ad377df57b0b5249f16ad97b79a9c9efdee"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561460"
+checksum = "sha256:99016f76c64e60c7097da3ab19c3ddce1e55a11491008d8ebe71a2ac6f367241"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849888"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:e102e3e1dd0777fc7a39c91a7805cbc8636bc4ab0c5cdc30a51b7962b8a524a7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561482"
+checksum = "sha256:49e3a4570034612fd7b193e4f56830bdece32c73ac92eb7f0d580c85695492df"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849907"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64-baseline"]
-checksum = "sha256:e102e3e1dd0777fc7a39c91a7805cbc8636bc4ab0c5cdc30a51b7962b8a524a7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561482"
+checksum = "sha256:49e3a4570034612fd7b193e4f56830bdece32c73ac92eb7f0d580c85695492df"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849907"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@ communique                      = "latest"
 git-cliff                       = "latest"
 "github:crate-ci/cargo-release" = "latest"
 "github:foresterre/cargo-msrv"  = "latest"
-mr-boxington                    = "1.3.0"
+mr-boxington                    = "1.3.2"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.


### PR DESCRIPTION
## Summary

- use mr-boxington-action v1.2.0, pinned to its release commit
- use the project-installed mbx instead of installing a separate copy in CI
- update the project mbx pin and lockfile to 1.3.2
- keep explicit benchmark or specialized workflow installs on mbx 1.3.2 where applicable

## Validation

- mise lock mr-boxington
- git diff --check
- GitHub Actions

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow ordering and tooling version changes only; no application or auth logic. Benchmark jobs pin mbx explicitly; CI correctness depends on mr-boxington-action v1.2.0 honoring PATH when `version` is omitted.
> 
> **Overview**
> CI now installs **mr-boxington** via **mise** (project pin in `mise.toml`, bumped to **1.3.2**) **before** the `./.github/actions/mbx` step in build, docs, and several test jobs, so cache setup can use the same `mbx` binary as local dev instead of the action downloading its own copy.
> 
> The **mbx** composite action gains an optional **`version`** input, bumps **`jdx/mr-boxington-action`** to **v1.2.0**, and forwards `version` to that action (replacing a hardcoded **1.3.0**). Benchmark workflows that bootstrap without mise still pass **`version: 1.3.2`** explicitly. Windows **`build-windows`** installs **`mr-boxington`** through mise (`install_args`) ahead of mbx.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af09b0797b84df05a32f292c5b8761a4ac2134a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build, documentation, and benchmark workflows by consistently preparing required tooling before execution.
  - Added support for selecting an explicit mbx version when needed.
  - Standardized mbx version usage across benchmark jobs for more predictable results.
  - Updated workflow action references and setup ordering for greater consistency across Linux and Windows environments.
  - Updated the tooling setup used by documentation builds to a newer release.
  - Upgraded the default mbx tooling version to 1.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->