### PR TITLE
chore(ci): use runner-provided rust

### DIFF
--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -112,11 +112,6 @@ jobs:
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
           cache: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          toolchain: nightly
-          override: false
-          cache: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: hk-${{ matrix.os }}
@@ -151,11 +146,6 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
-          cache: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          toolchain: nightly
-          override: false
           cache: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -192,11 +182,6 @@ jobs:
           persist-credentials: false
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
         with:
-          cache: false
-      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        with:
-          toolchain: nightly
-          override: false
           cache: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ equivalent Cargo command with `MBX_DISABLE=1`:
 MBX_DISABLE=1 cargo build
 MBX_DISABLE=1 cargo test --all --all-features
 MBX_DISABLE=1 cargo clippy --manifest-path Cargo.toml --quiet -- -D warnings
-MBX_DISABLE=1 cargo +nightly check -Zwarnings --quiet
+CARGO_BUILD_WARNINGS=deny MBX_DISABLE=1 cargo check --quiet
 ```
 
 If bypassed Cargo succeeds where the wrapper fails, or mbx introduces a papercut, please start a

--- a/hk.pkl
+++ b/hk.pkl
@@ -23,7 +23,7 @@ local linters = new Mapping<String, Step | Group> {
   ["cargo-check"] = (Builtins.cargo_check) {
     profiles = List("!slow")
     check = new CommandSpec {
-      command = "cargo +nightly check -Zwarnings --quiet"
+      command = "cargo check --quiet"
       effect = "write"
     }
   }

--- a/pkl/builtins/cargo_check.pkl
+++ b/pkl/builtins/cargo_check.pkl
@@ -8,10 +8,8 @@ import "./test/helpers.pkl"
 }
 cargo_check = new Config.Step {
   glob = "**/*.rs"
-  // NB: We need nightly to enable `warnings` unstable feature: https://doc.rust-lang.org/cargo/reference/unstable.html#warnings
-  // (See the comment for `CARGO_BUILD_WARNINGS` below)
   check = new Config.CommandSpec {
-    command = "cargo +nightly check -Zwarnings --quiet"
+    command = "cargo check --quiet"
     effect = "write"
   }
   fix = new Config.CommandSpec {
@@ -20,8 +18,8 @@ cargo_check = new Config.Step {
   }
   env {
     ["CARGO_TERM_COLOR"] = "{% if color %}always{% else %}never{% endif %}"
-    // NB: This is needed to treat warnings as errors.
-    // (which, since `cargo fix` will maintain parity between `check` and `fix`)
+    // Treat warnings as errors while keeping `check` and `fix` in parity.
+    // Cargo stabilized build.warnings in 1.97.
     ["CARGO_BUILD_WARNINGS"] = "deny"
   }
   tests {


### PR DESCRIPTION
## Summary

- remove nightly Rust setup from the three Bats jobs
- update the cargo-check builtin to use stabilized `build.warnings` with ordinary stable Cargo
- keep warnings denied through `CARGO_BUILD_WARNINGS=deny`

## Validation

- `actionlint .github/workflows/ci-impl.yml`
- `mise run pkl:gen`
- `mise run build`
- `target/debug/hk test --step cargo-check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined continuous integration workflows by removing unnecessary nightly Rust setup steps.
  * Test jobs now proceed directly to artifact retrieval and validation.
  * Updated contributor guidance to use stable Cargo checks with stricter warning handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and lint-hook changes only; no runtime product logic. Risk is mainly that environments with Cargo older than 1.97 would not get warning-as-error behavior from `CARGO_BUILD_WARNINGS`.
> 
> **Overview**
> CI no longer installs a **nightly** Rust toolchain in the three Bats jobs (`libgit2`, `nolibgit2`, `nogit`); those workflows rely on the runner/mise-provided Rust after checkout and artifact download.
> 
> The **`cargo-check`** hook and builtin switch from `cargo +nightly check -Zwarnings` to ordinary **`cargo check`**, with warnings still treated as errors via **`CARGO_BUILD_WARNINGS=deny`** (stable since Cargo 1.97). **CONTRIBUTING.md** documents the same stable bypass pattern for manual `MBX_DISABLE=1` checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d396dd91089afe2efa8da3292fbda3df95cab14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->