### PR TITLE
chore: bump mr-boxington to 1.3.2

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -15,12 +15,12 @@ runs:
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
-        version: 1.3.0
+        version: 1.3.2
         backend: github
         cache-generation: v2
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
-        version: 1.3.0
+        version: 1.3.2
         cache-generation: v2
         backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
         server-url: https://cache.mise.jdx.dev

--- a/mise.lock
+++ b/mise.lock
@@ -611,68 +611,68 @@ url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/52
 provenance = "github-attestations"
 
 [[tools.mr-boxington]]
-version = "1.3.0"
+version = "1.3.2"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:92a8544d26324b7803eeb1d2f1c276e322e474d45e7f40b6f6a1e72ce99d6fdc"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561463"
+checksum = "sha256:18aabfdfaced4316b9e9fd488d65df0915b241aa3af8e761b4df0fc0bdc1a4f7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849887"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:db505d360e8c1dfc6fb31ecf8172329ae2fa2417b14508e306626c6c1dba3514"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561466"
+checksum = "sha256:abbbcc8cc7c080febc5f6c77e1ae7af89faf15476248282f7bf4c331e836ee1b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849885"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:0717a7dc93fdd9712d648ddab0f7e0871b50b626568c62a5c1033396f50e3940"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561483"
+checksum = "sha256:6096035ae9bb47d718b7c0ca2860e1142047ebf724b37c02d3a520a4b9804d2d"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849911"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-baseline"]
-checksum = "sha256:0717a7dc93fdd9712d648ddab0f7e0871b50b626568c62a5c1033396f50e3940"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561483"
+checksum = "sha256:6096035ae9bb47d718b7c0ca2860e1142047ebf724b37c02d3a520a4b9804d2d"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849911"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:385b25699ba7429fe7cd36668667c45ff8d38f4491ebb4164e95021b22374ed0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561484"
+checksum = "sha256:a31a332095ac291686777736d450b2f62658145ac173ff543f83271e44850df7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849909"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:385b25699ba7429fe7cd36668667c45ff8d38f4491ebb4164e95021b22374ed0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561484"
+checksum = "sha256:a31a332095ac291686777736d450b2f62658145ac173ff543f83271e44850df7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849909"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:0d2e9d6e7d8228faafda68e2cd4190ce977a332821833c19a853c4a9dd91a82f"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561462"
+checksum = "sha256:3a91ecb2d6ff4ad84662e79599d11e79eff4738c222a35ed432db4b15ade4d1e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849886"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-arm64"]
-checksum = "sha256:21314d52d09991c49596f65f7da82ad377df57b0b5249f16ad97b79a9c9efdee"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561460"
+checksum = "sha256:99016f76c64e60c7097da3ab19c3ddce1e55a11491008d8ebe71a2ac6f367241"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849888"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:e102e3e1dd0777fc7a39c91a7805cbc8636bc4ab0c5cdc30a51b7962b8a524a7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561482"
+checksum = "sha256:49e3a4570034612fd7b193e4f56830bdece32c73ac92eb7f0d580c85695492df"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849907"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64-baseline"]
-checksum = "sha256:e102e3e1dd0777fc7a39c91a7805cbc8636bc4ab0c5cdc30a51b7962b8a524a7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561482"
+checksum = "sha256:49e3a4570034612fd7b193e4f56830bdece32c73ac92eb7f0d580c85695492df"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849907"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@ communique                      = "latest"
 git-cliff                       = "latest"
 "github:crate-ci/cargo-release" = "latest"
 "github:foresterre/cargo-msrv"  = "latest"
-mr-boxington                    = "1.3.0"
+mr-boxington                    = "1.3.2"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.


### PR DESCRIPTION
## Summary
- bump mr-boxington from 1.3.0 to 1.3.2 in mise configuration and CI setup
- refresh lockfile URLs, checksums, and provenance for the 1.3.2 release artifacts
- pick up shared Cargo prediction improvements

## Validation
- ran mise lock mr-boxington
- verified mr-boxington v1.3.2 is published with all GitHub release assets
- verified mbx 1.3.2 is published and unyanked on crates.io
- CI exercises the upgraded version

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `mr-boxington` tool to version 1.3.2.
  * Updated the automated workflow to use the latest tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->