### PR TITLE
chore(ci): update mbx to 1.4.0

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
-          version: 1.3.2
+          version: 1.4.0
       - name: Build
         id: build
         shell: bash
@@ -123,7 +123,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
-          version: 1.3.2
+          version: 1.4.0
       - name: Build
         id: build
         shell: bash
@@ -203,7 +203,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'server' || 'github' }}
-          version: 1.3.2
+          version: 1.4.0
       - name: Build
         id: build
         shell: pwsh

--- a/.github/workflows/docs-impl.yml
+++ b/.github/workflows/docs-impl.yml
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
-          version: 1.3.2
+          version: 1.4.0
       - name: Build
         if: runner.os != 'Windows'
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## mbx build cache
 
-`mise install` installs mbx 1.3. `mise run` activates the project's transparent
+`mise install` installs mbx 1.4. `mise run` activates the project's transparent
 Cargo wrapper, so compilation-heavy mise tasks and hk checks use ordinary
 `cargo` commands. Standalone Cargo commands require an activated mise shell. If
 the wrapper fails or creates a development papercut, rerun the exact equivalent

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ See the [contributing guide](https://hk.jdx.dev/contributing).
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3. The normal
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.4. The normal
 `mise run build`, `mise run test:cargo`, and `mise run lint` workflows activate
 its transparent Cargo wrapper and therefore use the cache while invoking Cargo
 normally. Standalone Cargo commands require an activated mise shell. To bypass

--- a/mise.lock
+++ b/mise.lock
@@ -611,68 +611,68 @@ url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/52
 provenance = "github-attestations"
 
 [[tools.mr-boxington]]
-version = "1.3.2"
+version = "1.4.0"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:18aabfdfaced4316b9e9fd488d65df0915b241aa3af8e761b4df0fc0bdc1a4f7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849887"
+checksum = "sha256:7c2771c6da3e9f63d5bd27b22be21101f928e71b09d8e3cf94d93c16df590a7b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435998"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:abbbcc8cc7c080febc5f6c77e1ae7af89faf15476248282f7bf4c331e836ee1b"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849885"
+checksum = "sha256:50e2bac80ca8902dccf25b5fc964237cc7cf1c1cda386abe210bac306d8cd7f1"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435997"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:6096035ae9bb47d718b7c0ca2860e1142047ebf724b37c02d3a520a4b9804d2d"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849911"
+checksum = "sha256:ca2e02ba52583e5617344c5be849e1c5efc1d82eac0977d716a8f486a3287289"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436013"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-baseline"]
-checksum = "sha256:6096035ae9bb47d718b7c0ca2860e1142047ebf724b37c02d3a520a4b9804d2d"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849911"
+checksum = "sha256:ca2e02ba52583e5617344c5be849e1c5efc1d82eac0977d716a8f486a3287289"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436013"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:a31a332095ac291686777736d450b2f62658145ac173ff543f83271e44850df7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849909"
+checksum = "sha256:2416466f524730f75c08026553b3e6f730e637f0d216121da165d4fecfedc656"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436016"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:a31a332095ac291686777736d450b2f62658145ac173ff543f83271e44850df7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849909"
+checksum = "sha256:2416466f524730f75c08026553b3e6f730e637f0d216121da165d4fecfedc656"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436016"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:3a91ecb2d6ff4ad84662e79599d11e79eff4738c222a35ed432db4b15ade4d1e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849886"
+checksum = "sha256:0556a8dfd32466ab9147b03cf1c722499bd68bfb24f712d8dd9c0a046a0fedaa"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435994"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-arm64"]
-checksum = "sha256:99016f76c64e60c7097da3ab19c3ddce1e55a11491008d8ebe71a2ac6f367241"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849888"
+checksum = "sha256:4c47769bb3ab30346068395289bc5a1326732a189cae114029279e3ecb95b317"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435995"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:49e3a4570034612fd7b193e4f56830bdece32c73ac92eb7f0d580c85695492df"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849907"
+checksum = "sha256:7eaab88593c03dafb0ff0e78668b81f06b7530d62bafa466193e6b3f0ccbd50c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436009"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64-baseline"]
-checksum = "sha256:49e3a4570034612fd7b193e4f56830bdece32c73ac92eb7f0d580c85695492df"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849907"
+checksum = "sha256:7eaab88593c03dafb0ff0e78668b81f06b7530d62bafa466193e6b3f0ccbd50c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436009"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@ communique                      = "latest"
 git-cliff                       = "latest"
 "github:crate-ci/cargo-release" = "latest"
 "github:foresterre/cargo-msrv"  = "latest"
-mr-boxington                    = "1.3.2"
+mr-boxington                    = "1.4.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.


### PR DESCRIPTION
## Summary

- update mr-boxington from 1.3.2 to 1.4.0 in mise.toml and the generated lockfile
- update explicit cache-benchmark installs and align contributor/agent guidance with mbx 1.4
- pick up improved Clippy caching, nested Cargo sessions, cache diagnostics, and lifecycle fixes from v1.4.0

## Validation

- mise lock mr-boxington
- verified the published v1.4.0 release has all eight platform assets
- verified the locked release installs and reports mbx 1.4.0
- git diff --check
- verified no changelog files changed

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and CI pin updates only; no application or hk CLI logic changes. Slight risk that mbx 1.4.0 could change Cargo cache behavior in dev/CI builds.
> 
> **Overview**
> Bumps **mr-boxington (mbx)** from **1.3.2** to **1.4.0** for local dev and CI: `mise.toml`, regenerated `mise.lock` (per-platform URLs/checksums), and explicit `version: 1.4.0` on the mbx setup step in **cache-benchmark** and **warm-cache-benchmark** workflows.
> 
> **AGENTS.md** and **CONTRIBUTING.md** now say `mise install` provides mbx 1.4. Other workflows that use `./.github/actions/mbx` without a pinned version pick up 1.4.0 via mise.
> 
> Also repins **actions/deploy-pages** to a newer v5 commit in **docs-impl.yml** (separate from the mbx bump).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 981abbe51603b7a89590de688db89503432a99f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the mbx build and cache tooling to version 1.4.0 across supported platforms.
  * Updated the project’s tool configuration to use mbx 1.4.0.
  * Updated the documentation deployment tooling for improved reliability.

* **Documentation**
  * Revised setup and contribution guidance to reflect the mbx 1.4 installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->