### PR TITLE
chore(ci): retry JavaScript dependency installation

### DIFF
--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -36,7 +36,12 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
-      - run: mise x -- aube ci
+      - name: Install JavaScript dependencies
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: mise x -- aube ci
       - run: ./mcp-ui/node_modules/.bin/vitest run --root mcp-ui
       - run: ./scripts/check_mcp_ui_fresh
 


### PR DESCRIPTION
## Summary

- retry the MCP UI dependency installation up to three times
- keep each attempt bounded to five minutes
- reuse the pinned retry action already used by the test jobs

This prevents transient registry response errors such as the `lightningcss-darwin-arm64` body-decoding failure in #1312 from failing the entire workflow. Persistent installation failures still fail after three attempts.

## Validation

- `git diff --check`
- `mise x -- actionlint -shellcheck= .github/workflows/ci-impl.yml`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to how dependency install is invoked; no application, auth, or runtime behavior changes.
> 
> **Overview**
> The **mcp-ui** CI job no longer runs `mise x -- aube ci` as a single-shot shell step. That install is now an **Install JavaScript dependencies** step using the pinned `nick-fields/retry` action (same pattern as the Bats test jobs), with **up to 3 attempts** and a **5-minute cap per attempt**.
> 
> Transient npm/registry failures during MCP UI dependency install should no longer fail the whole workflow on the first error; repeated failures still fail after three tries. Vitest and `check_mcp_ui_fresh` steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cf09eaebf9992bc60b137e7afa4c15fdf5ba6fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build automation to use the latest standardized tool setup.
  * Improved CI reliability by automatically retrying dependency installation up to three times when transient failures occur.
  * Streamlined platform-specific build configuration for more consistent results across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->