### PR TITLE
fix(hook): honor the check and fix settings when selecting run type

### DIFF
--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -1496,7 +1496,7 @@
         "hide": false,
         "args_override_self": true,
         "help": "Run the fix hook",
-        "help_long": "Run the fix hook\n\nRuns each step's fix command to modify files in place. Passing `--check`, or setting `HK_FIX=0`, runs each step's check command instead.",
+        "help_long": "Run the fix hook\n\nRuns each step's fix command to modify files in place. Passing `--check`, or setting `HK_CHECK=1` or `HK_FIX=0`, runs each step's check command instead.",
         "name": "fix",
         "aliases": ["f"],
         "hidden_aliases": [],

--- a/docs/cli/fix.md
+++ b/docs/cli/fix.md
@@ -7,7 +7,7 @@
 
 Run the fix hook
 
-Runs each step's fix command to modify files in place. Passing `--check`, or setting `HK_FIX=0`, runs each step's check command instead.
+Runs each step's fix command to modify files in place. Passing `--check`, or setting `HK_CHECK=1` or `HK_FIX=0`, runs each step's check command instead.
 
 ## Arguments
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -29,7 +29,11 @@ Type: `bool`
 Default: `false`
 
 Forces hooks to run their check commands instead of their fix commands, the opposite of
-`HK_FIX`. Useful in CI, where you want to report problems without modifying files.
+`HK_FIX`. Useful in CI, where you want a report rather than fixes.
+
+By convention a check command only reports problems, but hk does not enforce that, so this
+variable selects which command runs rather than guaranteeing an unchanged worktree. A
+project whose check command edits files will still edit them.
 
 `--check` and `--fix` are per-invocation flags and outrank this variable, so
 `HK_CHECK=1 hk fix --fix` still runs fix commands. When both `HK_CHECK` and `HK_FIX` are

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -28,13 +28,12 @@ The cache directory to use.
 Type: `bool`
 Default: `false`
 
-> [!WARNING]
-> This variable currently has no effect on which commands hk runs. It is accepted and
-> reported by `hk config dump`, but nothing reads it when selecting check or fix
-> commands. Use `HK_FIX=0` or the `--check` flag instead.
+Forces hooks to run their check commands instead of their fix commands, the opposite of
+`HK_FIX`. Useful in CI, where you want to report problems without modifying files.
 
-Intended as the opposite of `HK_FIX`: force check commands instead of fix commands, for
-CI environments where you want to verify code quality without making changes.
+`--check` and `--fix` are per-invocation flags and outrank this variable, so
+`HK_CHECK=1 hk fix --fix` still runs fix commands. When both `HK_CHECK` and `HK_FIX` are
+enabled, `HK_CHECK` wins. `git config hk.check` sets the same value at a lower precedence.
 
 ## `HK_CHECK_FIRST`
 
@@ -110,7 +109,7 @@ The config file to use. Setting this skips the normal [config file search](/conf
 Type: `bool`
 Default: `true`
 
-If set to `false`, hooks run their check commands instead of their fix commands. Passing `--fix` overrides it for a single run; `--check` forces check commands unconditionally.
+If set to `false`, hooks run their check commands instead of their fix commands. Passing `--fix` overrides it for a single run, and `--check` or [`HK_CHECK`](#hk-check) forces check commands. `git config hk.fix` sets the same value at a lower precedence.
 
 ## `HK_HIDE_WARNINGS`
 

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -240,7 +240,7 @@ cmd fix help="Run the fix hook" {
     long_help #"""
 Run the fix hook
 
-Runs each step's fix command to modify files in place. Passing `--check`, or setting `HK_FIX=0`, runs each step's check command instead.
+Runs each step's fix command to modify files in place. Passing `--check`, or setting `HK_CHECK=1` or `HK_FIX=0`, runs each step's check command instead.
 """#
     use hook-options
     flag "-h --help" help="Print help" action=help builtin=#true

--- a/settings.toml
+++ b/settings.toml
@@ -54,11 +54,11 @@ sources.cli = ["--check", "-c"]
 sources.env = ["HK_CHECK"]
 sources.git = ["hk.check"]
 docs = """
-Forces hk to run only check commands (read-only) instead of fix commands.
+Forces hooks to run their check commands instead of their fix commands.
 
-This is the opposite of the `fix` setting. When enabled, hk will report issues without attempting to fix them.
+This is the opposite of the `fix` setting, and wins over it when both are enabled. The `--check` and `--fix` flags outrank both.
 
-Useful for CI environments where you want to verify code quality without making changes.
+Useful for CI environments where you want to report issues without modifying files.
 """
 
 [check_first]

--- a/settings.toml
+++ b/settings.toml
@@ -58,7 +58,7 @@ Forces hooks to run their check commands instead of their fix commands.
 
 This is the opposite of the `fix` setting, and wins over it when both are enabled. The `--check` and `--fix` flags outrank both.
 
-Useful for CI environments where you want to report issues without modifying files.
+Useful for CI environments where you want a report rather than fixes. By convention a check command only reports problems, but hk does not enforce that, so this selects which command runs rather than guaranteeing an unchanged worktree.
 """
 
 [check_first]
@@ -132,12 +132,12 @@ sources.cli = ["--fix", "-f"]
 sources.env = ["HK_FIX"]
 sources.git = ["hk.fix"]
 docs = """
-Controls whether hk runs fix commands (that modify files) or check commands (read-only).
+Controls whether hk runs each step's fix command or its check command.
 
 When enabled (default), runs fix commands to automatically resolve issues.
-When disabled, only runs check commands to report issues without making changes.
+When disabled, runs check commands, which by convention only report issues.
 
-Can be toggled with `--fix` / `--check` CLI flags.
+Can be toggled with `--fix` / `--check` CLI flags, which outrank this setting. The `check` setting wins over this one when both are enabled.
 """
 
 [hide_warnings]

--- a/src/cli/fix.rs
+++ b/src/cli/fix.rs
@@ -3,7 +3,7 @@ use crate::hook_options::HookOptions;
 /// Run the fix hook
 ///
 /// Runs each step's fix command to modify files in place. Passing `--check`, or
-/// setting `HK_FIX=0`, runs each step's check command instead.
+/// setting `HK_CHECK=1` or `HK_FIX=0`, runs each step's check command instead.
 #[derive(usage_rs::Args)]
 pub struct Fix {
     #[usage(flatten)]

--- a/src/env.rs
+++ b/src/env.rs
@@ -60,7 +60,6 @@ pub static HK_STASH: LazyLock<Option<StashMethod>> = LazyLock::new(|| {
     }
 });
 pub static HK_STASH_UNTRACKED: LazyLock<bool> = LazyLock::new(|| !var_false("HK_STASH_UNTRACKED"));
-pub static HK_FIX: LazyLock<bool> = LazyLock::new(|| !var_false("HK_FIX"));
 pub static HK_MISE: LazyLock<bool> = LazyLock::new(|| var_true("HK_MISE"));
 pub static HK_SKIP_STEPS: LazyLock<IndexSet<String>> = LazyLock::new(|| {
     var_csv("HK_SKIP_STEPS")

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -589,11 +589,24 @@ impl Hook {
     }
 
     fn run_type(&self, opts: &HookOptions) -> RunType {
+        // `--check` and `--fix` are hook options rather than global flags, so
+        // they never reach the settings layer (CLI_SNAPSHOT carries only the
+        // global ones). Honor them first so a flag still outranks the env and
+        // git config sources consulted below.
         if opts.check {
             return RunType::Check;
         }
+        if opts.fix {
+            return RunType::Fix;
+        }
+        let settings = Settings::get();
+        // `check` wins over `fix` when both are set, since the safer reading of
+        // a contradictory configuration is to leave files alone.
+        if settings.check {
+            return RunType::Check;
+        }
         let fix = self.fix.unwrap_or(self.name == "fix");
-        if (*env::HK_FIX && fix) || opts.fix {
+        if settings.fix && fix {
             RunType::Fix
         } else {
             RunType::Check

--- a/test/check_fix_mode.bats
+++ b/test/check_fix_mode.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+    cat > hk.pkl << EOF
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["fix"] {
+        fix = true
+        steps {
+            ["probe"] {
+                glob = List("*.txt")
+                check = "echo RAN_CHECK"
+                fix = "echo RAN_FIX"
+            }
+        }
+    }
+    ["check"] {
+        steps {
+            ["probe"] {
+                glob = List("*.txt")
+                check = "echo RAN_CHECK"
+                fix = "echo RAN_FIX"
+            }
+        }
+    }
+}
+EOF
+    echo "hello" > a.txt
+    git add -A
+    git commit -q -m init
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "hk fix runs fix commands by default" {
+    run hk fix --all
+    assert_success
+    assert_output --partial "RAN_FIX"
+    refute_output --partial "RAN_CHECK"
+}
+
+@test "HK_CHECK forces check commands" {
+    HK_CHECK=1 run hk fix --all
+    assert_success
+    assert_output --partial "RAN_CHECK"
+    refute_output --partial "RAN_FIX"
+}
+
+@test "HK_FIX=0 forces check commands" {
+    HK_FIX=0 run hk fix --all
+    assert_success
+    assert_output --partial "RAN_CHECK"
+    refute_output --partial "RAN_FIX"
+}
+
+@test "git config hk.check forces check commands" {
+    git config --local hk.check true
+    run hk fix --all
+    assert_success
+    assert_output --partial "RAN_CHECK"
+    refute_output --partial "RAN_FIX"
+}
+
+@test "git config hk.fix=false forces check commands" {
+    git config --local hk.fix false
+    run hk fix --all
+    assert_success
+    assert_output --partial "RAN_CHECK"
+    refute_output --partial "RAN_FIX"
+}
+
+@test "HK_CHECK=0 overrides git config hk.check" {
+    git config --local hk.check true
+    HK_CHECK=0 run hk fix --all
+    assert_success
+    assert_output --partial "RAN_FIX"
+    refute_output --partial "RAN_CHECK"
+}
+
+@test "--fix overrides HK_CHECK" {
+    HK_CHECK=1 run hk fix --all --fix
+    assert_success
+    assert_output --partial "RAN_FIX"
+    refute_output --partial "RAN_CHECK"
+}
+
+@test "--fix overrides HK_FIX=0" {
+    HK_FIX=0 run hk fix --all --fix
+    assert_success
+    assert_output --partial "RAN_FIX"
+    refute_output --partial "RAN_CHECK"
+}
+
+@test "--check forces check commands" {
+    run hk fix --all --check
+    assert_success
+    assert_output --partial "RAN_CHECK"
+    refute_output --partial "RAN_FIX"
+}
+
+@test "hk check runs check commands and honors --fix" {
+    run hk check --all
+    assert_success
+    assert_output --partial "RAN_CHECK"
+    refute_output --partial "RAN_FIX"
+
+    run hk check --all --fix
+    assert_success
+    assert_output --partial "RAN_FIX"
+    refute_output --partial "RAN_CHECK"
+}


### PR DESCRIPTION
Fixes the `HK_CHECK` bug found while reviewing the docs in #1316. Now that #1316 has merged, this is rebased onto `main` and contains only the fix.

## The bug

`Hook::run_type` read `env::HK_FIX` directly and consulted only `opts.check`, so two documented configuration sources did nothing at all:

- **`HK_CHECK` / `git config hk.check`** were declared in `settings.toml` and reported by `hk config dump`, but nothing read the resulting `check` setting. `HK_CHECK=1 hk fix` still ran fix commands, so anyone setting it in CI to get a report rather than fixes silently got modified files.
- **`git config hk.fix`** was inert for the same reason, since only the `HK_FIX` env var was ever consulted.

The setting plumbing was already correct — `hk config get check` returned `true` under `HK_CHECK=1`. Only the consumer was missing.

## The fix

Read the merged `check` and `fix` settings, which picks up the env and git layers with their existing precedence:

```rust
if opts.check {
    return RunType::Check;
}
if opts.fix {
    return RunType::Fix;
}
let settings = Settings::get();
if settings.check {
    return RunType::Check;
}
let fix = self.fix.unwrap_or(self.name == "fix");
if settings.fix && fix {
    RunType::Fix
} else {
    RunType::Check
}
```

Two decisions worth flagging:

- **Flags stay ahead of the settings.** `--check` and `--fix` are hook options rather than global flags, so they never reach the settings layer (`CLI_SNAPSHOT` carries only the global ones). They are handled first so a flag still outranks the env and git sources, preserving the documented CLI > env > git precedence.
- **`check` wins over `fix`** when both are enabled, since the safer reading of a contradictory configuration is to leave files alone.

`env::HK_FIX` has no remaining callers now that the setting supersedes it, so the static is dropped.

## Behavior

Everything below was verified against a scratch repo whose step echoes which command ran. Only the three bolded rows change.

| invocation | before | after |
| --- | --- | --- |
| `hk fix` | fix | fix |
| **`HK_CHECK=1 hk fix`** | **fix** | **check** |
| **`git config hk.check true` + `hk fix`** | **fix** | **check** |
| **`git config hk.fix false` + `hk fix`** | **fix** | **check** |
| `HK_FIX=0 hk fix` | check | check |
| `hk fix --check` | check | check |
| `HK_CHECK=1 hk fix --fix` | fix | fix |
| `HK_FIX=0 hk fix --fix` | fix | fix |
| `HK_CHECK=0` + `git config hk.check true` | fix | fix |
| `hk check` | check | check |
| `hk check --fix` | fix | fix |

## Tests

`test/check_fix_mode.bats` covers the two fixed sources, their precedence against the flags and each other, and the unchanged defaults. I confirmed the tests actually guard the fix by reverting the change and re-running: the `HK_CHECK`, `hk.check`, and `hk.fix` cases fail, and the other seven pass either way as regression cover for the refactor.

Full suite: 1305 bats tests and 292 Rust tests pass. The only failures in my environment are missing local tools (`git-lfs`, `go`, `ktlint`, and similar for the builtin tool tests), which fail identically on `main`.

## Docs

The `HK_CHECK` entry now describes the working behavior, its precedence against the flags and `HK_FIX`, and the `git config hk.check` equivalent. It also states that selecting check commands is not a guarantee of an unchanged worktree, since hk does not constrain what a project's check command does — the same qualification applied to the `check` and `fix` entries in `settings.toml`, one of which still called check commands "read-only".

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)