### PR TITLE
fix(builtins): match root action metadata files in pinact globs

### DIFF
--- a/pkl/builtins/pinact.pkl
+++ b/pkl/builtins/pinact.pkl
@@ -7,7 +7,7 @@ import "./test/helpers.pkl"
   description = "Pin GitHub Actions to commit SHA for security"
 }
 const pinact = new Config.Step {
-  glob = List(".github/workflows/*", "*/action.*")
+  glob = List(".github/workflows/*", "**/action.*")
   types = List("yaml")
   // `verify-comment` verifies pairs of commit SHA and version comments are correct
   check_diff = new Config.CommandSpec {

--- a/pkl/builtins/pinact_update.pkl
+++ b/pkl/builtins/pinact_update.pkl
@@ -6,7 +6,7 @@ import "../Config.pkl"
   description = "Pin GitHub Actions to update actions to latest versions"
 }
 const pinact_update = new Config.Step {
-  glob = List(".github/workflows/*", "*/action.*")
+  glob = List(".github/workflows/*", "**/action.*")
   types = List("yaml")
   // `verify-comment` verifies pairs of commit SHA and version comments are correct
   check_diff = new Config.CommandSpec {


### PR DESCRIPTION
The `pinact` and `pinact_update` builtins' glob `List(".github/workflows/*", "*/action.*")` never matches a root-level `action.yml`/`action.yaml` (standalone action repositories), because the pattern requires a `/` before `action.`.

pinact's own default discovery does include root action metadata (see `defaultWorkflowPatterns` in [`pkg/controller/run/list_workflows.go`](https://github.com/suzuki-shunsuke/pinact/blob/main/pkg/controller/run/list_workflows.go): `action.yml`, `action.yaml`, and one-to-three-level-deep variants). Under hk, `{{files}}` replaces pinact's own discovery, so the step glob is the gate — this change restores parity for both builtins (they define the same glob independently; `pinact_v3`/`pinact_update_v3` inherit it).

Notes:
- hk builds step globs without `literal_separator` (`src/glob.rs`), so `*` already crosses `/` and nested files like `.github/actions/setup/action.yml` matched before this change; root was the only gap. `**/action.*` covers root and all depths.
- `types = List("yaml")` composes with AND, so the widened glob still only selects YAML.
- No test added: `StepTest` passes `files` explicitly, so glob selection is not exercised by `hk test`.

Supersedes #1268 (and #1269): #1268 was auto-closed after 7 days of failing checks — the failures were the macOS fixer-tail-deletion flake (since fixed on `main` by #1301) and the `fastq@1.20.2` trust-policy incident, both unrelated to this diff. Reopening was not possible because the branch was rebased onto current `main` after closure, so this is a fresh PR with the same two one-line changes.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: 2.1.241.*

