### PR TITLE
chore: bump mbx to 1.6.0

### DIFF
--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
-          version: 1.5.0
+          version: 1.6.0
       - name: Build
         id: build
         shell: bash
@@ -124,7 +124,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
-          version: 1.5.0
+          version: 1.6.0
       - name: Build
         id: build
         shell: bash
@@ -204,7 +204,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
-          version: 1.5.0
+          version: 1.6.0
       - name: Build
         id: build
         shell: pwsh

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
-          version: 1.5.0
+          version: 1.6.0
       - name: Build
         if: runner.os != 'Windows'
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## mbx build cache
 
-`mise install` installs mbx 1.4. `mise run` activates the project's transparent
+`mise install` installs mbx 1.6. `mise run` activates the project's transparent
 Cargo wrapper, so compilation-heavy mise tasks and hk checks use ordinary
 `cargo` commands. Standalone Cargo commands require an activated mise shell. If
 the wrapper fails or creates a development papercut, rerun the exact equivalent

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ See the [contributing guide](https://hk.jdx.dev/contributing).
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.4. The normal
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.6. The normal
 `mise run build`, `mise run test:cargo`, and `mise run lint` workflows activate
 its transparent Cargo wrapper and therefore use the cache while invoking Cargo
 normally. Standalone Cargo commands require an activated mise shell. To bypass

--- a/mise.lock
+++ b/mise.lock
@@ -601,68 +601,68 @@ url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/52
 provenance = "github-attestations"
 
 [[tools.mr-boxington]]
-version = "1.5.0"
+version = "1.6.0"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:3782db0c07a47334d01d426896e9f6af2480b311def2d0f0a3ab1327b57247b2"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628921"
+checksum = "sha256:5fd146c4bfe68162036eea9fe63e8d65086f453b607ba5cf9bccc974e26473e3"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909652"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:95e189127cf22f6586b0e7337893896dfb18b2018c7226e60844955e237234b8"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628922"
+checksum = "sha256:2a57ad9fd232e6575e601c7ac6de5fa62e9b1a30f5bb3625441c63ecee2d2c50"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909653"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:83a5f4cb83a62cf028256c482a9f579911cc0793f79f1c2c06b83291c5c723d0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629161"
+checksum = "sha256:4f706e48bbaafcf8ac4178b9a8b63c1d3f399b5b9b8024a13c3f769d77f4a19a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909670"
 provenance = "github-attestations"
-provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-baseline"]
-checksum = "sha256:83a5f4cb83a62cf028256c482a9f579911cc0793f79f1c2c06b83291c5c723d0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629161"
+checksum = "sha256:4f706e48bbaafcf8ac4178b9a8b63c1d3f399b5b9b8024a13c3f769d77f4a19a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909670"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:8ffd1ffc4b53ce10ed1d0271e24d9d264e843b7be3f0a076389c4475a16e4132"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629170"
+checksum = "sha256:56c69a9c3b289f63d52cf8da1d2796191b2aebb9e7d8df348889ef198cc7c55d"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909672"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:8ffd1ffc4b53ce10ed1d0271e24d9d264e843b7be3f0a076389c4475a16e4132"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629170"
+checksum = "sha256:56c69a9c3b289f63d52cf8da1d2796191b2aebb9e7d8df348889ef198cc7c55d"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909672"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:d88ebea6ebf1a5b8b4a51a440a91baeb1214fdea49a6013dfe9b56e4bd4a6c84"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628925"
+checksum = "sha256:cb3fd29b29924f7d74dee03eb84a279a2879f956358ebcc76aaf1a90072ddde5"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909657"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools.mr-boxington."platforms.windows-arm64"]
-checksum = "sha256:306c20bac705a8c598677d436dfa276ddf5f67b051dd98e67b9cac46653ec15a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628924"
+checksum = "sha256:21996b43edb9f0ba3bbebd533c17ce4da1208330aaec4d200703f6f527d6947e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909654"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:970f974d3ee56b089c34a4b03fdb80dfcc0b260b3de950009a77240c9187a4c7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629146"
+checksum = "sha256:7736c35e5299097788ebd8a93812180fdb62e1181016d138f47b74245422680e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909669"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64-baseline"]
-checksum = "sha256:970f974d3ee56b089c34a4b03fdb80dfcc0b260b3de950009a77240c9187a4c7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629146"
+checksum = "sha256:7736c35e5299097788ebd8a93812180fdb62e1181016d138f47b74245422680e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909669"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@ communique                      = "latest"
 git-cliff                       = "latest"
 "github:crate-ci/cargo-release" = "latest"
 "github:foresterre/cargo-msrv"  = "latest"
-mr-boxington                    = "1.5.0"
+mr-boxington                    = "1.6.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.


### PR DESCRIPTION
## Summary

- bump the project mbx tool and lockfile to 1.6.0
- run cache and warm-cache benchmarks with mbx 1.6.0
- update contributor guidance to match the installed minor version

## Local benchmark

A clean macOS ARM checkout using the public read-only `jdx/hk` cache prefetched all 473 predicted actions (up from the previous 256-action ceiling) and downloaded 788.1 MiB. The run completed in 38.99s wall time. Only 2 actions were reused locally because the stored GitHub Actions compiler/environment identity does not match the local machine, so the PR cache benchmark is the authoritative hosted comparison.

## Verification

- `mise lock mr-boxington` with mise 2026.8.16
- `actionlint`
- `git diff --check`
- `mbx 1.6.0 doctor` (0 failures)

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps the Cargo build-cache wrapper used in dev and CI; behavior can change without any Rust code edits, though the bump is version-pinned and lockfile-verified.
> 
> **Overview**
> **Bumps the pinned `mr-boxington` (mbx) tool from 1.5.0 to 1.6.0** for local installs via `mise` and for CI cache benchmarks.
> 
> `mise.toml` and `mise.lock` now resolve **mbx 1.6.0** on all platforms (updated release URLs, checksums, and small provenance metadata tweaks). The **cache-benchmark** and **warm-cache-benchmark** workflows pass `version: 1.6.0` into `./.github/actions/mbx` so hosted comparisons use the same release.
> 
> **AGENTS.md** and **CONTRIBUTING.md** are updated so contributor docs say **`mise install` provides mbx 1.6**, aligning with the new pin (they previously referenced an older minor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bbacc6dce4048a68b05bf6c0a789b3a06370cfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build cache tool to version 1.6.0 across development tooling and benchmark workflows.

- **Documentation**
  - Updated contributor and development guidance to reference the newer build cache tool version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->