### PR TITLE
ci: measure cache setup end to end

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -8,17 +8,20 @@ inputs:
   version:
     description: Explicit mbx version for jobs that cannot install project tools first
     required: false
+  executable-dir:
+    description: Directory containing a prebuilt mbx executable; skips installation
+    required: false
 runs:
   using: composite
   steps:
     - name: Set up mise for the mbx install
-      if: runner.os != 'Windows'
+      if: inputs.executable-dir == '' && runner.os != 'Windows'
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       with:
         install: false
         cache: false
     - name: Set up mise for the mbx install on Windows
-      if: runner.os == 'Windows'
+      if: inputs.executable-dir == '' && runner.os == 'Windows'
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       env:
         MISE_DATA_DIR: ${{ format('{0}/mise-data', runner.tool_cache) }}
@@ -37,20 +40,25 @@ runs:
       shell: bash
       env:
         MBX_BACKEND: ${{ inputs.backend }}
+        MBX_EXECUTABLE_DIR: ${{ inputs.executable-dir }}
         MBX_VERSION: ${{ inputs.version }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
-        if [[ "$RUNNER_OS" == Windows ]]; then
-          export MISE_DATA_DIR="$RUNNER_TOOL_CACHE/mise-data"
-          export MISE_CACHE_DIR="$RUNNER_TOOL_CACHE/mise-cache"
+        if [[ -n "$MBX_EXECUTABLE_DIR" ]]; then
+          echo "$MBX_EXECUTABLE_DIR" >> "$GITHUB_PATH"
+        else
+          if [[ "$RUNNER_OS" == Windows ]]; then
+            export MISE_DATA_DIR="$RUNNER_TOOL_CACHE/mise-data"
+            export MISE_CACHE_DIR="$RUNNER_TOOL_CACHE/mise-cache"
+          fi
+          tool=mr-boxington
+          if [[ -n "$MBX_VERSION" ]]; then
+            tool="mr-boxington@$MBX_VERSION"
+          fi
+          mise install "$tool"
+          mise reshim -f
+          mise where "$tool" >> "$GITHUB_PATH"
         fi
-        tool=mr-boxington
-        if [[ -n "$MBX_VERSION" ]]; then
-          tool="mr-boxington@$MBX_VERSION"
-        fi
-        mise install "$tool"
-        mise reshim -f
-        mise where "$tool" >> "$GITHUB_PATH"
         {
           if [[ "$MBX_BACKEND" == server ]]; then
             echo "MBX_REMOTE_URL=https://cache.jdx.dev"

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -36,11 +36,15 @@ jobs:
       contents: read
       id-token: write # Main pushes authenticate to the cache server; its policy keeps other events read-only.
     outputs:
-      seconds: ${{ steps.build.outputs.seconds }}
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
       - uses: ./.github/actions/mbx
         with:
           backend: server
@@ -49,11 +53,14 @@ jobs:
         id: build
         shell: bash
         run: |
-          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
           mbx build
           ended=$(python3 -c 'import time; print(time.monotonic_ns())')
-          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
-          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "build_seconds=$build_elapsed" >> "$GITHUB_OUTPUT"
+          echo "total_seconds=$total_elapsed" >> "$GITHUB_OUTPUT"
           mbx cache stats
 
   rust_cache_linux:
@@ -61,11 +68,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
-      seconds: ${{ steps.build.outputs.seconds }}
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:
@@ -75,11 +86,14 @@ jobs:
         id: build
         shell: bash
         run: |
-          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
           cargo build
           ended=$(python3 -c 'import time; print(time.monotonic_ns())')
-          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
-          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "build_seconds=$build_elapsed" >> "$GITHUB_OUTPUT"
+          echo "total_seconds=$total_elapsed" >> "$GITHUB_OUTPUT"
 
   comparison_linux:
     name: comparison (Linux)
@@ -87,25 +101,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     env:
-      MBX_SECONDS: ${{ needs.mbx_linux.outputs.seconds }}
-      RUST_CACHE_SECONDS: ${{ needs.rust_cache_linux.outputs.seconds }}
+      MBX_BUILD_SECONDS: ${{ needs.mbx_linux.outputs.build_seconds }}
+      MBX_TOTAL_SECONDS: ${{ needs.mbx_linux.outputs.total_seconds }}
+      RUST_CACHE_BUILD_SECONDS: ${{ needs.rust_cache_linux.outputs.build_seconds }}
+      RUST_CACHE_TOTAL_SECONDS: ${{ needs.rust_cache_linux.outputs.total_seconds }}
     steps:
       - name: Summarize results
         shell: bash
         run: |
-          delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
+          build_delta=$(awk -v mbx="$MBX_BUILD_SECONDS" -v rust="$RUST_CACHE_BUILD_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          total_delta=$(awk -v mbx="$MBX_TOTAL_SECONDS" -v rust="$RUST_CACHE_TOTAL_SECONDS" \
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           {
             echo "## Linux cache build comparison"
             echo
-            echo "| Backend | Build time |"
-            echo "| --- | ---: |"
-            echo "| mbx | ${MBX_SECONDS}s |"
-            echo "| Swatinem/rust-cache | ${RUST_CACHE_SECONDS}s |"
+            echo "| Backend | Cache + build | Build only |"
+            echo "| --- | ---: | ---: |"
+            echo "| mbx | ${MBX_TOTAL_SECONDS}s | ${MBX_BUILD_SECONDS}s |"
+            echo "| Swatinem/rust-cache | ${RUST_CACHE_TOTAL_SECONDS}s | ${RUST_CACHE_BUILD_SECONDS}s |"
             echo
-            echo "mbx delta: **${delta}** (positive means mbx was faster)."
+            echo "mbx delta: **${total_delta}** end to end; **${build_delta}** build only (positive means mbx was faster)."
             echo
-            echo "> The main-branch push seeds both backends. Compare them with the warm cache benchmark dispatched on main. Build time excludes checkout and cache setup; compare those step durations separately."
+            echo "> Cache + build starts after checkout and includes mbx installation or rust-cache restoration. The main-branch push seeds both backends; compare it with the warm benchmark dispatched on main."
           } >> "$GITHUB_STEP_SUMMARY"
 
   mbx:
@@ -116,11 +134,15 @@ jobs:
       contents: read
       id-token: write # Main pushes authenticate to the cache server; its policy keeps other events read-only.
     outputs:
-      seconds: ${{ steps.build.outputs.seconds }}
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
       - uses: ./.github/actions/mbx
         with:
           backend: server
@@ -129,11 +151,14 @@ jobs:
         id: build
         shell: bash
         run: |
-          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
           mbx build
           ended=$(python3 -c 'import time; print(time.monotonic_ns())')
-          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
-          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "build_seconds=$build_elapsed" >> "$GITHUB_OUTPUT"
+          echo "total_seconds=$total_elapsed" >> "$GITHUB_OUTPUT"
           mbx cache stats
 
   rust-cache:
@@ -141,11 +166,15 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 20
     outputs:
-      seconds: ${{ steps.build.outputs.seconds }}
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:
@@ -155,11 +184,14 @@ jobs:
         id: build
         shell: bash
         run: |
-          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
           cargo build
           ended=$(python3 -c 'import time; print(time.monotonic_ns())')
-          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
-          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "build_seconds=$build_elapsed" >> "$GITHUB_OUTPUT"
+          echo "total_seconds=$total_elapsed" >> "$GITHUB_OUTPUT"
 
   comparison_macos:
     name: comparison (macOS)
@@ -167,25 +199,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     env:
-      MBX_SECONDS: ${{ needs.mbx.outputs.seconds }}
-      RUST_CACHE_SECONDS: ${{ needs.rust-cache.outputs.seconds }}
+      MBX_BUILD_SECONDS: ${{ needs.mbx.outputs.build_seconds }}
+      MBX_TOTAL_SECONDS: ${{ needs.mbx.outputs.total_seconds }}
+      RUST_CACHE_BUILD_SECONDS: ${{ needs.rust-cache.outputs.build_seconds }}
+      RUST_CACHE_TOTAL_SECONDS: ${{ needs.rust-cache.outputs.total_seconds }}
     steps:
       - name: Summarize results
         shell: bash
         run: |
-          delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
+          build_delta=$(awk -v mbx="$MBX_BUILD_SECONDS" -v rust="$RUST_CACHE_BUILD_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          total_delta=$(awk -v mbx="$MBX_TOTAL_SECONDS" -v rust="$RUST_CACHE_TOTAL_SECONDS" \
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           {
             echo "## macOS cache build comparison"
             echo
-            echo "| Backend | Build time |"
-            echo "| --- | ---: |"
-            echo "| mbx | ${MBX_SECONDS}s |"
-            echo "| Swatinem/rust-cache | ${RUST_CACHE_SECONDS}s |"
+            echo "| Backend | Cache + build | Build only |"
+            echo "| --- | ---: | ---: |"
+            echo "| mbx | ${MBX_TOTAL_SECONDS}s | ${MBX_BUILD_SECONDS}s |"
+            echo "| Swatinem/rust-cache | ${RUST_CACHE_TOTAL_SECONDS}s | ${RUST_CACHE_BUILD_SECONDS}s |"
             echo
-            echo "mbx delta: **${delta}** (positive means mbx was faster)."
+            echo "mbx delta: **${total_delta}** end to end; **${build_delta}** build only (positive means mbx was faster)."
             echo
-            echo "> The main-branch push seeds both backends. Compare them with the warm cache benchmark dispatched on main. Build time excludes checkout and cache setup; compare those step durations separately."
+            echo "> Cache + build starts after checkout and includes mbx installation or rust-cache restoration. The main-branch push seeds both backends; compare it with the warm benchmark dispatched on main."
           } >> "$GITHUB_STEP_SUMMARY"
 
   mbx_windows:
@@ -196,11 +232,15 @@ jobs:
       contents: read
       id-token: write # Main pushes authenticate to the cache server; its policy keeps other events read-only.
     outputs:
-      seconds: ${{ steps.build.outputs.seconds }}
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        shell: pwsh
+        run: '[System.Diagnostics.Stopwatch]::GetTimestamp() | Set-Content "$env:RUNNER_TEMP/cache-benchmark-start"'
       - uses: ./.github/actions/mbx
         with:
           backend: server
@@ -209,12 +249,15 @@ jobs:
         id: build
         shell: pwsh
         run: |
-          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          $buildStarted = [System.Diagnostics.Stopwatch]::GetTimestamp()
           mbx build --features git2/vendored-libgit2,git2/vendored-openssl
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $timer.Stop()
-          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
-          "seconds=$elapsed" >> $env:GITHUB_OUTPUT
+          $ended = [System.Diagnostics.Stopwatch]::GetTimestamp()
+          $cacheStarted = [long](Get-Content "$env:RUNNER_TEMP/cache-benchmark-start")
+          $buildElapsed = (($ended - $buildStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          $totalElapsed = (($ended - $cacheStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "build_seconds=$buildElapsed" >> $env:GITHUB_OUTPUT
+          "total_seconds=$totalElapsed" >> $env:GITHUB_OUTPUT
           mbx cache stats
 
   rust_cache_windows:
@@ -222,11 +265,15 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     outputs:
-      seconds: ${{ steps.build.outputs.seconds }}
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        shell: pwsh
+        run: '[System.Diagnostics.Stopwatch]::GetTimestamp() | Set-Content "$env:RUNNER_TEMP/cache-benchmark-start"'
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:
@@ -236,12 +283,15 @@ jobs:
         id: build
         shell: pwsh
         run: |
-          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          $buildStarted = [System.Diagnostics.Stopwatch]::GetTimestamp()
           cargo build --features git2/vendored-libgit2,git2/vendored-openssl
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $timer.Stop()
-          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
-          "seconds=$elapsed" >> $env:GITHUB_OUTPUT
+          $ended = [System.Diagnostics.Stopwatch]::GetTimestamp()
+          $cacheStarted = [long](Get-Content "$env:RUNNER_TEMP/cache-benchmark-start")
+          $buildElapsed = (($ended - $buildStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          $totalElapsed = (($ended - $cacheStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "build_seconds=$buildElapsed" >> $env:GITHUB_OUTPUT
+          "total_seconds=$totalElapsed" >> $env:GITHUB_OUTPUT
 
   comparison_windows:
     name: comparison (Windows)
@@ -249,23 +299,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     env:
-      MBX_SECONDS: ${{ needs.mbx_windows.outputs.seconds }}
-      RUST_CACHE_SECONDS: ${{ needs.rust_cache_windows.outputs.seconds }}
+      MBX_BUILD_SECONDS: ${{ needs.mbx_windows.outputs.build_seconds }}
+      MBX_TOTAL_SECONDS: ${{ needs.mbx_windows.outputs.total_seconds }}
+      RUST_CACHE_BUILD_SECONDS: ${{ needs.rust_cache_windows.outputs.build_seconds }}
+      RUST_CACHE_TOTAL_SECONDS: ${{ needs.rust_cache_windows.outputs.total_seconds }}
     steps:
       - name: Summarize results
         shell: bash
         run: |
-          delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
+          build_delta=$(awk -v mbx="$MBX_BUILD_SECONDS" -v rust="$RUST_CACHE_BUILD_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          total_delta=$(awk -v mbx="$MBX_TOTAL_SECONDS" -v rust="$RUST_CACHE_TOTAL_SECONDS" \
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           {
             echo "## Windows cache build comparison"
             echo
-            echo "| Backend | Build time |"
-            echo "| --- | ---: |"
-            echo "| mbx | ${MBX_SECONDS}s |"
-            echo "| Swatinem/rust-cache | ${RUST_CACHE_SECONDS}s |"
+            echo "| Backend | Cache + build | Build only |"
+            echo "| --- | ---: | ---: |"
+            echo "| mbx | ${MBX_TOTAL_SECONDS}s | ${MBX_BUILD_SECONDS}s |"
+            echo "| Swatinem/rust-cache | ${RUST_CACHE_TOTAL_SECONDS}s | ${RUST_CACHE_BUILD_SECONDS}s |"
             echo
-            echo "mbx delta: **${delta}** (positive means mbx was faster)."
+            echo "mbx delta: **${total_delta}** end to end; **${build_delta}** build only (positive means mbx was faster)."
             echo
-            echo "> The main-branch push seeds both backends. Compare them with the warm cache benchmark dispatched on main. Build time excludes checkout and cache setup; compare those step durations separately."
+            echo "> Cache + build starts after checkout and includes mbx installation or rust-cache restoration. The main-branch push seeds both backends; compare it with the warm benchmark dispatched on main."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -7,6 +7,10 @@ on:
         description: Optional jdx/mr-boxington Git ref to build and benchmark instead of the pinned release
         required: false
         type: string
+      rust_toolchain:
+        description: Optional Rust toolchain for the timed hk build, useful for stale-manifest tests
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -64,6 +68,14 @@ jobs:
           RUSTC_WRAPPER: ""
           RUSTC_WORKSPACE_WRAPPER: ""
         run: cargo build --locked --release --package mbx --manifest-path .mbx-candidate-source/Cargo.toml
+      - name: Select an alternate Rust toolchain for hk
+        if: inputs.rust_toolchain != ''
+        shell: bash
+        env:
+          BENCH_RUST_TOOLCHAIN: ${{ inputs.rust_toolchain }}
+        run: |
+          rustup toolchain install "$BENCH_RUST_TOOLCHAIN" --profile minimal
+          echo "RUSTUP_TOOLCHAIN=$BENCH_RUST_TOOLCHAIN" >> "$GITHUB_ENV"
       - name: Start cache timer
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       mbx_ref:
-        description: Optional jdx/mr-boxington Git ref to build and benchmark instead of the pinned release
+        description: Optional current jdx/mr-boxington branch-head SHA to build instead of the pinned release
         required: false
         type: string
       rust_toolchain:
@@ -46,6 +46,23 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Validate unreleased mbx revision
+        if: inputs.mbx_ref != ''
+        shell: bash
+        env:
+          MBX_CANDIDATE_SHA: ${{ inputs.mbx_ref }}
+        run: |
+          if [[ ! "$MBX_CANDIDATE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "mbx_ref must be a full commit SHA" >&2
+            exit 1
+          fi
+          candidate_sha=${MBX_CANDIDATE_SHA,,}
+          if ! git ls-remote --heads https://github.com/jdx/mr-boxington.git |
+            awk -v candidate="$candidate_sha" '$1 == candidate { found = 1 } END { exit !found }'
+          then
+            echo "mbx_ref must be the current head of a branch in jdx/mr-boxington" >&2
+            exit 1
+          fi
       - name: Check out unreleased mbx
         if: inputs.mbx_ref != ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   mbx:
     name: mbx (${{ matrix.label }})
-    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main'
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && (github.ref == 'refs/heads/main' || inputs.mbx_ref != '')
     permissions:
       contents: read
       id-token: write # Authenticate the main-branch dispatch to the cache server.

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -27,6 +27,8 @@ jobs:
   mbx:
     name: mbx (${{ matrix.label }})
     if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && (github.ref == 'refs/heads/main' || inputs.mbx_ref != '')
+    env:
+      MBX_SUMMARY: full
     permissions:
       contents: read
       id-token: write # Authenticate the main-branch dispatch to the cache server.
@@ -134,7 +136,7 @@ jobs:
 
   rust_cache:
     name: Swatinem rust-cache (${{ matrix.label }})
-    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main'
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && (github.ref == 'refs/heads/main' || inputs.mbx_ref != '')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -37,6 +37,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        if: runner.os != 'Windows'
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
+      - name: Start cache timer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: '[System.Diagnostics.Stopwatch]::GetTimestamp() | Set-Content "$env:RUNNER_TEMP/cache-benchmark-start"'
       - uses: ./.github/actions/mbx
         with:
           backend: server
@@ -45,22 +53,26 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
           mbx build
           ended=$(python3 -c 'import time; print(time.monotonic_ns())')
-          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
-          echo "## mbx ${{ matrix.label }}: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "## mbx ${{ matrix.label }}: ${total_elapsed}s total (${build_elapsed}s build)" >> "$GITHUB_STEP_SUMMARY"
           mbx cache stats
       - name: Build
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          $buildStarted = [System.Diagnostics.Stopwatch]::GetTimestamp()
           mbx build --features git2/vendored-libgit2,git2/vendored-openssl
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $timer.Stop()
-          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
-          "## mbx ${{ matrix.label }}: ${elapsed}s" >> $env:GITHUB_STEP_SUMMARY
+          $ended = [System.Diagnostics.Stopwatch]::GetTimestamp()
+          $cacheStarted = [long](Get-Content "$env:RUNNER_TEMP/cache-benchmark-start")
+          $buildElapsed = (($ended - $buildStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          $totalElapsed = (($ended - $cacheStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## mbx ${{ matrix.label }}: ${totalElapsed}s total (${buildElapsed}s build)" >> $env:GITHUB_STEP_SUMMARY
           mbx cache stats
 
   rust_cache:
@@ -85,6 +97,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        if: runner.os != 'Windows'
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
+      - name: Start cache timer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: '[System.Diagnostics.Stopwatch]::GetTimestamp() | Set-Content "$env:RUNNER_TEMP/cache-benchmark-start"'
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
@@ -94,18 +114,22 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
           cargo build
           ended=$(python3 -c 'import time; print(time.monotonic_ns())')
-          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
-          echo "## Swatinem/rust-cache ${{ matrix.label }}: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "## Swatinem/rust-cache ${{ matrix.label }}: ${total_elapsed}s total (${build_elapsed}s build)" >> "$GITHUB_STEP_SUMMARY"
       - name: Build
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          $buildStarted = [System.Diagnostics.Stopwatch]::GetTimestamp()
           cargo build --features git2/vendored-libgit2,git2/vendored-openssl
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $timer.Stop()
-          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
-          "## Swatinem/rust-cache ${{ matrix.label }}: ${elapsed}s" >> $env:GITHUB_STEP_SUMMARY
+          $ended = [System.Diagnostics.Stopwatch]::GetTimestamp()
+          $cacheStarted = [long](Get-Content "$env:RUNNER_TEMP/cache-benchmark-start")
+          $buildElapsed = (($ended - $buildStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          $totalElapsed = (($ended - $cacheStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## Swatinem/rust-cache ${{ matrix.label }}: ${totalElapsed}s total (${buildElapsed}s build)" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -2,6 +2,11 @@ name: warm cache benchmark
 
 on:
   workflow_dispatch:
+    inputs:
+      mbx_ref:
+        description: Optional jdx/mr-boxington Git ref to build and benchmark instead of the pinned release
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -37,6 +42,28 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Check out unreleased mbx
+        if: inputs.mbx_ref != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: jdx/mr-boxington
+          ref: ${{ inputs.mbx_ref }}
+          path: .mbx-candidate-source
+          persist-credentials: false
+      - name: Build unreleased mbx outside the hk cache
+        if: inputs.mbx_ref != ''
+        shell: bash
+        env:
+          CARGO_HOME: ${{ runner.temp }}/mbx-candidate-cargo-home
+          CARGO_TARGET_DIR: ${{ runner.temp }}/mbx-candidate-target
+          MBX_CACHE_DIR: ${{ runner.temp }}/mbx-candidate-disabled-cache
+          MBX_REMOTE_URL: ""
+          MBX_REMOTE_NAMESPACE: ""
+          MBX_REMOTE_TOKEN: ""
+          MBX_REMOTE_OIDC_AUDIENCE: ""
+          RUSTC_WRAPPER: ""
+          RUSTC_WORKSPACE_WRAPPER: ""
+        run: cargo build --locked --release --package mbx --manifest-path .mbx-candidate-source/Cargo.toml
       - name: Start cache timer
         if: runner.os != 'Windows'
         shell: bash
@@ -48,6 +75,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
+          executable-dir: ${{ inputs.mbx_ref != '' && format('{0}/mbx-candidate-target/release', runner.temp) || '' }}
           version: 1.6.0
       - name: Build
         if: runner.os != 'Windows'

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -56,7 +56,7 @@ jobs:
             echo "mbx_ref must be a full commit SHA" >&2
             exit 1
           fi
-          candidate_sha=${MBX_CANDIDATE_SHA,,}
+          candidate_sha=$(printf '%s' "$MBX_CANDIDATE_SHA" | tr '[:upper:]' '[:lower:]')
           if ! git ls-remote --heads https://github.com/jdx/mr-boxington.git |
             awk -v candidate="$candidate_sha" '$1 == candidate { found = 1 } END { exit !found }'
           then


### PR DESCRIPTION
## Summary

- start cache benchmark timing immediately after checkout
- report cache setup plus build alongside the existing build-only time
- compare mbx installation and prefetch against rust-cache restoration on equal footing
- allow trusted warm-cache dispatches to build an unreleased mr-boxington ref before timing
- isolate the candidate build with separate Cargo home, target, and disabled mbx remote settings so it cannot seed the hk build

## Verification

- `actionlint`
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflows and the mbx setup action; no application runtime or auth logic in the product itself.
> 
> **Overview**
> Cache benchmarks now record **two timings**: **cache + build** (from right after checkout through install/restore and compile) and **build only**. Comparison jobs on Linux, macOS, and Windows report both columns and separate mbx vs rust-cache deltas.
> 
> The **mbx** composite action gains an optional **`executable-dir`** input that puts a prebuilt binary on `PATH` and skips mise install when set.
> 
> The **warm cache benchmark** workflow adds dispatch inputs **`mbx_ref`** (branch-head SHA in `jdx/mr-boxington`, validated via `git ls-remote`) and **`rust_toolchain`**. When `mbx_ref` is set, jobs can run off `main`, build the candidate mbx in an isolated Cargo/mbx-remote environment, then time hk using that binary via `executable-dir`. Step summaries use the same total vs build breakdown; mbx jobs set `MBX_SUMMARY: full`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 686a8e466aae40e2b59b622866e6491d70721f63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for benchmarking current branch-head builds against benchmark targets.
  - Added support for using a prebuilt executable during benchmark runs.
  - Added optional Rust toolchain selection for benchmark runs.

- **Improvements**
  - Benchmark results now separately report cache-plus-build and build-only times.
  - Comparison summaries show distinct performance deltas for both measurements.
  - Timing is captured consistently across supported operating systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->