### PR TITLE
fix(stash): skip stashing while a merge or other operation is in progress

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -705,6 +705,32 @@ impl Git {
         }
     }
 
+    /// True when the repository has an operation in progress (merge,
+    /// cherry-pick, revert, rebase, …) whose state files under $GIT_DIR
+    /// would be deleted by the hard reset inside `git stash push` /
+    /// libgit2's stash_save.
+    fn operation_in_progress(&self) -> bool {
+        if let Some(repo) = &self.repo {
+            return repo.state() != git2::RepositoryState::Clean;
+        }
+        // Shell fallback: mirror libgit2's repository-state detection.
+        let Ok(git_dir) = git_cmd(["rev-parse", "--git-dir"]).read() else {
+            return false;
+        };
+        let git_dir = PathBuf::from(git_dir.trim());
+        [
+            "MERGE_HEAD",
+            "CHERRY_PICK_HEAD",
+            "REVERT_HEAD",
+            "BISECT_LOG",
+            "rebase-merge",
+            "rebase-apply",
+            "sequencer",
+        ]
+        .iter()
+        .any(|state| git_dir.join(state).exists())
+    }
+
     #[tracing::instrument(level = "info", name = "git.stash.push", skip_all)]
     pub fn stash_unstaged(
         &mut self,
@@ -719,6 +745,19 @@ impl Git {
         if let Some(repo) = &self.repo
             && repo.head().is_err()
         {
+            return Ok(());
+        }
+        // A full `git stash push` (and libgit2's stash_save) hard-resets the
+        // worktree, which deletes in-progress operation state — MERGE_HEAD,
+        // MERGE_MSG, CHERRY_PICK_HEAD, rebase state, etc. Stashing while e.g.
+        // a merge is being committed corrupts the merge: the commit either
+        // fails ("could not open MERGE_HEAD") or silently lands as a
+        // single-parent commit with the merged changes squashed in. Skip
+        // stashing instead; steps run against the worktree as-is.
+        if self.operation_in_progress() {
+            job.set_body("{{spinner()}} stash – {{message}}");
+            job.prop("message", "Skipped – merge/rebase/cherry-pick in progress");
+            job.set_status(ProgressStatus::Done);
             return Ok(());
         }
         job.set_body("{{spinner()}} stash – {{message}}{% if files is defined %} ({{files}} file{{files|pluralize}}){% endif %}");

--- a/test/stash_skipped_during_merge.bats
+++ b/test/stash_skipped_during_merge.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common_setup'
+    _common_setup
+    export HK_SUMMARY_TEXT=1
+}
+
+teardown() {
+    _common_teardown
+}
+
+# Minimal pre-commit with stash=git and a no-op step so the stash path runs
+create_minimal_precommit() {
+    cat <<PKL > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+  ["pre-commit"] {
+    fix = true
+    stash = "git"
+    steps = new Mapping<String, Step> {
+      ["noop"] {
+        glob = "*.txt"
+        check = "bash -lc 'true'"
+      }
+    }
+  }
+}
+PKL
+    git add hk.pkl
+    git -c commit.gpgsign=false commit -m "init hk"
+    hk install
+}
+
+# Create a conflicting merge, resolve it, and stage the resolution.
+# Leaves the repo mid-merge (MERGE_HEAD present).
+prepare_resolved_merge() {
+    printf 'base\n' > conflict.txt
+    printf 'other\n' > other.txt
+    git add conflict.txt other.txt
+    git -c commit.gpgsign=false commit -m "base"
+    git switch -c side
+    printf 'side\n' > conflict.txt
+    git -c commit.gpgsign=false commit -am "side"
+    git switch main
+    printf 'main\n' > conflict.txt
+    git -c commit.gpgsign=false commit -am "main change"
+    git switch side
+    run git merge main
+    assert_failure
+    printf 'resolved\n' > conflict.txt
+    git add conflict.txt
+    assert_file_exists .git/MERGE_HEAD
+}
+
+@test "stash=git: skipped during merge; untracked-only dirt; merge commit keeps both parents" {
+    create_minimal_precommit
+    prepare_resolved_merge
+    # Only an untracked file is dirty: without the merge guard this takes the
+    # full-stash path (git stash push / libgit2 stash_save), whose internal
+    # hard reset deletes MERGE_HEAD/MERGE_MSG and corrupts the merge commit.
+    printf 'u\n' > untracked.tmp
+
+    run git -c commit.gpgsign=false commit --no-edit
+    assert_success
+
+    # HEAD must be a real merge commit (two parents)
+    run git rev-parse -q --verify HEAD^2
+    assert_success
+    # Untracked file untouched, no stray stash entries
+    assert_file_exists untracked.tmp
+    run git stash list
+    assert_output ""
+}
+
+@test "stash=git: skipped during merge; unstaged tracked change preserved" {
+    create_minimal_precommit
+    prepare_resolved_merge
+    # Unstaged change to a tracked file alongside the staged merge resolution
+    printf 'unstaged\n' > other.txt
+
+    run git -c commit.gpgsign=false commit --no-edit
+    assert_success
+
+    run git rev-parse -q --verify HEAD^2
+    assert_success
+    # Unstaged change still in the worktree, not committed
+    run grep -q 'unstaged' other.txt
+    assert_success
+    run bash -c "git show HEAD:other.txt | grep -F 'unstaged'"
+    assert_failure
+    run git stash list
+    assert_output ""
+}


### PR DESCRIPTION
## Problem

`hk run pre-commit` with `stash = "git"` destroys in-progress merge state, which can silently corrupt history.

A full `git stash push` (and libgit2's `stash_save`) hard-resets the worktree, which deletes the operation state files under `$GIT_DIR`: `MERGE_HEAD`, `MERGE_MSG`, `CHERRY_PICK_HEAD`, rebase state, etc.

When committing a **resolved merge** (conflicts fixed and staged, `MERGE_HEAD` present), any dirt that routes through the full-stash path destroys the merge state mid-commit. The most common trigger: the only dirty files are *untracked*, so `push_stash`'s tracked pathspec subset is empty and `HK_STASH_UNTRACKED` (default true) falls back to a bare `git stash push --keep-index --include-untracked` / libgit2 `stash_save`. After hk restores the stash and exits 0, `git commit` continues and either:

- fails with `fatal: could not open '.git/MERGE_HEAD' for reading: No such file or directory`, leaving the user mid-"merge" with no merge metadata, or
- (if the user then re-commits the surviving staged result) produces a **single-parent commit with the merged branch's changes squashed in** — a "merge" that isn't, i.e. silent history corruption.

The pathspec form (`git stash push -- <tracked files>`) does not hard-reset and is unaffected, which is why this only bites intermittently.

### Repro

```sh
git init -b main t && cd t
# hk.pkl: pre-commit with fix = true, stash = "git", one no-op step
printf 'base\n' > f.txt && git add -A && git commit -m base
git switch -c side && printf 's\n' > f.txt && git commit -am s
git switch main    && printf 'm\n' > f.txt && git commit -am m
git switch side && git merge main       # conflict
printf 'resolved\n' > f.txt && git add f.txt
printf 'u\n' > untracked.tmp            # untracked-only dirt → full-stash path
hk install
git commit --no-edit
# → fatal: could not open '.git/MERGE_HEAD' for reading
# → MERGE_HEAD and MERGE_MSG are gone
```

(Interestingly there's an old commented-out `head_commit_message().contains("Merge")` block right at this spot in `stash_unstaged`, so this has been circled before.)

## Fix

Skip the stash step entirely when the repository has an operation in progress: `repo.state() != RepositoryState::Clean` via libgit2, with a `$GIT_DIR` state-file check for the shell-git fallback. The progress line reports `stash – Skipped – merge/rebase/cherry-pick in progress`, and steps run against the worktree as-is — matching how other hook managers (e.g. pre-commit's `staged_files_only`) treat merge state.

## Tests

`test/stash_skipped_during_merge.bats`:
- untracked-only dirt during a resolved merge → commit succeeds as a true two-parent merge, untracked file intact, no stray stash entries (fails on `main` with the `MERGE_HEAD` fatal above)
- unstaged tracked change during a resolved merge → merge parents correct and the unstaged change stays in the worktree

Ran the neighboring stash suites (`stash_current_behavior`, `stash_untracked_with_partial_stash`, `pre_commit_does_not_stash_staged_only_files`) — green. (`stash_default` has a pre-existing trailing-whitespace failure on my machine, unpatched too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic stashing from disrupting in-progress merge, rebase, cherry-pick, and revert operations.
  * Merge commits now complete successfully while preserving untracked files and unstaged changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->