### PR TITLE
docs: complete social and search metadata

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -12,16 +12,19 @@ if (!versionMatch) {
   console.warn('Unable to find package version in Cargo.toml');
 }
 const latestVersion = versionMatch?.[1] ?? '0.0.0';
+const siteUrl = "https://hk.jdx.dev";
+const siteDescription =
+  "Fast, language-agnostic git hooks and project linting with parallel execution, automatic fixes, file locking, and shareable Pkl configuration.";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "hk",
-  description: "git hook manager",
+  description: siteDescription,
   lang: "en-US",
   lastUpdated: true,
   appearance: "force-dark",
   sitemap: {
-    hostname: "https://hk.jdx.dev",
+    hostname: siteUrl,
   },
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
@@ -100,10 +103,45 @@ export default defineConfig({
     // OpenGraph
     ["meta", { property: "og:site_name", content: "hk" }],
     ["meta", { property: "og:type", content: "website" }],
+    ["meta", { property: "og:locale", content: "en_US" }],
     ["meta", { property: "og:image", content: "https://hk.jdx.dev/og.png" }],
     ["meta", { property: "og:image:width", content: "1200" }],
     ["meta", { property: "og:image:height", content: "630" }],
+    ["meta", { property: "og:image:alt", content: "hk — fast git hooks and project linting" }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
+    ["meta", { name: "twitter:site", content: "@jdxcode" }],
     ["meta", { name: "twitter:image", content: "https://hk.jdx.dev/og.png" }],
+    ["meta", { name: "twitter:image:alt", content: "hk — fast git hooks and project linting" }],
+    ["link", { rel: "icon", href: "/favicon.ico", sizes: "any" }],
+    ["link", { rel: "icon", type: "image/png", sizes: "32x32", href: "/favicon-32x32.png" }],
+    ["link", { rel: "apple-touch-icon", sizes: "180x180", href: "/apple-touch-icon.png" }],
+    ["link", { rel: "manifest", href: "/site.webmanifest" }],
+    ["meta", { name: "theme-color", content: "#0d0221" }],
   ],
+  transformHead({ pageData, title, description }) {
+    const url = `${siteUrl}/${pageData.relativePath}`
+      .replace(/index\.md$/, "")
+      .replace(/\.md$/, ".html");
+
+    return [
+      ["link", { rel: "canonical", href: url }],
+      ["meta", { property: "og:url", content: url }],
+      ["meta", { property: "og:title", content: title }],
+      ["meta", { property: "og:description", content: description }],
+      ["meta", { name: "twitter:title", content: title }],
+      ["meta", { name: "twitter:description", content: description }],
+      [
+        "script",
+        { type: "application/ld+json" },
+        JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "WebPage",
+          name: title,
+          description,
+          url,
+          isPartOf: { "@type": "WebSite", name: "hk", url: siteUrl },
+        }),
+      ],
+    ];
+  },
 })

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 layout: page
+title: Fast git hooks and project linting
 ---
 
 <HomePage />


### PR DESCRIPTION
## Summary

- add per-page canonical, Open Graph, Twitter, and structured data metadata
- connect the existing favicon, Apple touch icon, and web app manifest assets
- improve homepage title and description signals

## Testing

- npm run --workspace docs docs:build
- verified generated homepage and nested-page metadata

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only VitePress config and homepage frontmatter; no runtime or security-sensitive code paths.
> 
> **Overview**
> Improves **SEO and link-preview metadata** for the VitePress docs site by centralizing `siteUrl` and a richer global `siteDescription`, then wiring that description into the site config and sitemap hostname.
> 
> Adds **site-wide head tags** for Open Graph/Twitter (locale, image alt, `@jdxcode`), favicons, web manifest, and theme color. Introduces **`transformHead`** so every page gets a canonical URL, per-page `og:url` / title / description, matching Twitter fields, and JSON-LD `WebPage` structured data derived from the page path.
> 
> Sets an explicit **homepage frontmatter title** (`Fast git hooks and project linting`) so the index page emits stronger title signals in the new per-page metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5d03a9f66516311f01220a7eaf28d9ae162ae61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved site-wide metadata and page descriptions for better search engine and social media previews.
  - Added canonical URLs, structured data, social sharing details, theme color, and app icon references.
  - Set the documentation homepage title to “Fast git hooks and project linting.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->