### PR TITLE
ci: adopt mbx 1.8.1 and benchmark its GitHub target cache

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -8,17 +8,20 @@ inputs:
   version:
     description: Explicit mbx version for jobs that cannot install project tools first
     required: false
+  executable-dir:
+    description: Directory containing a prebuilt mbx executable; skips installation
+    required: false
 runs:
   using: composite
   steps:
     - name: Set up mise for the mbx install
-      if: runner.os != 'Windows'
+      if: inputs.executable-dir == '' && runner.os != 'Windows'
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       with:
         install: false
         cache: false
     - name: Set up mise for the mbx install on Windows
-      if: runner.os == 'Windows'
+      if: inputs.executable-dir == '' && runner.os == 'Windows'
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       env:
         MISE_DATA_DIR: ${{ format('{0}/mise-data', runner.tool_cache) }}
@@ -37,20 +40,25 @@ runs:
       shell: bash
       env:
         MBX_BACKEND: ${{ inputs.backend }}
+        MBX_EXECUTABLE_DIR: ${{ inputs.executable-dir }}
         MBX_VERSION: ${{ inputs.version }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
-        if [[ "$RUNNER_OS" == Windows ]]; then
-          export MISE_DATA_DIR="$RUNNER_TOOL_CACHE/mise-data"
-          export MISE_CACHE_DIR="$RUNNER_TOOL_CACHE/mise-cache"
+        if [[ -n "$MBX_EXECUTABLE_DIR" ]]; then
+          echo "$MBX_EXECUTABLE_DIR" >> "$GITHUB_PATH"
+        else
+          if [[ "$RUNNER_OS" == Windows ]]; then
+            export MISE_DATA_DIR="$RUNNER_TOOL_CACHE/mise-data"
+            export MISE_CACHE_DIR="$RUNNER_TOOL_CACHE/mise-cache"
+          fi
+          tool=mr-boxington
+          if [[ -n "$MBX_VERSION" ]]; then
+            tool="mr-boxington@$MBX_VERSION"
+          fi
+          mise install "$tool"
+          mise reshim -f
+          mise where "$tool" >> "$GITHUB_PATH"
         fi
-        tool=mr-boxington
-        if [[ -n "$MBX_VERSION" ]]; then
-          tool="mr-boxington@$MBX_VERSION"
-        fi
-        mise install "$tool"
-        mise reshim -f
-        mise where "$tool" >> "$GITHUB_PATH"
         {
           if [[ "$MBX_BACKEND" == server ]]; then
             echo "MBX_REMOTE_URL=https://cache.jdx.dev"

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
-          version: 1.6.0
+          version: 1.8.1
       - name: Build
         id: build
         shell: bash
@@ -95,9 +95,42 @@ jobs:
           echo "build_seconds=$build_elapsed" >> "$GITHUB_OUTPUT"
           echo "total_seconds=$total_elapsed" >> "$GITHUB_OUTPUT"
 
+  mbx_github_linux:
+    name: mbx GitHub target cache (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Start cache timer
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
+      # The action restores Cargo's pruned target tree from the GitHub cache and,
+      # like rust-cache above, saves a new entry only on main-branch pushes.
+      - uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777 # v1.3.0
+        with:
+          version: 1.8.1
+          cache-generation: cache-benchmark-v1
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          mbx build
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "build_seconds=$build_elapsed" >> "$GITHUB_OUTPUT"
+          echo "total_seconds=$total_elapsed" >> "$GITHUB_OUTPUT"
+
   comparison_linux:
     name: comparison (Linux)
-    needs: [mbx_linux, rust_cache_linux]
+    needs: [mbx_linux, mbx_github_linux, rust_cache_linux]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     env:
@@ -105,6 +138,8 @@ jobs:
       MBX_TOTAL_SECONDS: ${{ needs.mbx_linux.outputs.total_seconds }}
       RUST_CACHE_BUILD_SECONDS: ${{ needs.rust_cache_linux.outputs.build_seconds }}
       RUST_CACHE_TOTAL_SECONDS: ${{ needs.rust_cache_linux.outputs.total_seconds }}
+      MBX_GITHUB_BUILD_SECONDS: ${{ needs.mbx_github_linux.outputs.build_seconds }}
+      MBX_GITHUB_TOTAL_SECONDS: ${{ needs.mbx_github_linux.outputs.total_seconds }}
     steps:
       - name: Summarize results
         shell: bash
@@ -113,17 +148,24 @@ jobs:
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           total_delta=$(awk -v mbx="$MBX_TOTAL_SECONDS" -v rust="$RUST_CACHE_TOTAL_SECONDS" \
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          github_build_delta=$(awk -v mbx="$MBX_GITHUB_BUILD_SECONDS" -v rust="$RUST_CACHE_BUILD_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          github_total_delta=$(awk -v mbx="$MBX_GITHUB_TOTAL_SECONDS" -v rust="$RUST_CACHE_TOTAL_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           {
             echo "## Linux cache build comparison"
             echo
             echo "| Backend | Cache + build | Build only |"
             echo "| --- | ---: | ---: |"
-            echo "| mbx | ${MBX_TOTAL_SECONDS}s | ${MBX_BUILD_SECONDS}s |"
+            echo "| mbx (cache server) | ${MBX_TOTAL_SECONDS}s | ${MBX_BUILD_SECONDS}s |"
+            echo "| mbx (GitHub target cache) | ${MBX_GITHUB_TOTAL_SECONDS}s | ${MBX_GITHUB_BUILD_SECONDS}s |"
             echo "| Swatinem/rust-cache | ${RUST_CACHE_TOTAL_SECONDS}s | ${RUST_CACHE_BUILD_SECONDS}s |"
             echo
-            echo "mbx delta: **${total_delta}** end to end; **${build_delta}** build only (positive means mbx was faster)."
+            echo "mbx cache server delta: **${total_delta}** end to end; **${build_delta}** build only (positive means mbx was faster)."
             echo
-            echo "> Cache + build starts after checkout and includes mbx installation or rust-cache restoration. The main-branch push seeds both backends; compare it with the warm benchmark dispatched on main."
+            echo "mbx GitHub target cache delta: **${github_total_delta}** end to end; **${github_build_delta}** build only."
+            echo
+            echo "> Cache + build starts after checkout and includes mbx installation or rust-cache restoration. The main-branch push seeds every backend; compare it with the warm benchmark dispatched on main."
           } >> "$GITHUB_STEP_SUMMARY"
 
   mbx:
@@ -146,7 +188,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
-          version: 1.6.0
+          version: 1.8.1
       - name: Build
         id: build
         shell: bash
@@ -193,9 +235,42 @@ jobs:
           echo "build_seconds=$build_elapsed" >> "$GITHUB_OUTPUT"
           echo "total_seconds=$total_elapsed" >> "$GITHUB_OUTPUT"
 
+  mbx_github_macos:
+    name: mbx GitHub target cache (macOS)
+    runs-on: macos-14
+    timeout-minutes: 20
+    outputs:
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Start cache timer
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
+      # The action restores Cargo's pruned target tree from the GitHub cache and,
+      # like rust-cache above, saves a new entry only on main-branch pushes.
+      - uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777 # v1.3.0
+        with:
+          version: 1.8.1
+          cache-generation: cache-benchmark-v1
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          mbx build
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "build_seconds=$build_elapsed" >> "$GITHUB_OUTPUT"
+          echo "total_seconds=$total_elapsed" >> "$GITHUB_OUTPUT"
+
   comparison_macos:
     name: comparison (macOS)
-    needs: [mbx, rust-cache]
+    needs: [mbx, mbx_github_macos, rust-cache]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     env:
@@ -203,6 +278,8 @@ jobs:
       MBX_TOTAL_SECONDS: ${{ needs.mbx.outputs.total_seconds }}
       RUST_CACHE_BUILD_SECONDS: ${{ needs.rust-cache.outputs.build_seconds }}
       RUST_CACHE_TOTAL_SECONDS: ${{ needs.rust-cache.outputs.total_seconds }}
+      MBX_GITHUB_BUILD_SECONDS: ${{ needs.mbx_github_macos.outputs.build_seconds }}
+      MBX_GITHUB_TOTAL_SECONDS: ${{ needs.mbx_github_macos.outputs.total_seconds }}
     steps:
       - name: Summarize results
         shell: bash
@@ -211,17 +288,24 @@ jobs:
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           total_delta=$(awk -v mbx="$MBX_TOTAL_SECONDS" -v rust="$RUST_CACHE_TOTAL_SECONDS" \
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          github_build_delta=$(awk -v mbx="$MBX_GITHUB_BUILD_SECONDS" -v rust="$RUST_CACHE_BUILD_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          github_total_delta=$(awk -v mbx="$MBX_GITHUB_TOTAL_SECONDS" -v rust="$RUST_CACHE_TOTAL_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           {
             echo "## macOS cache build comparison"
             echo
             echo "| Backend | Cache + build | Build only |"
             echo "| --- | ---: | ---: |"
-            echo "| mbx | ${MBX_TOTAL_SECONDS}s | ${MBX_BUILD_SECONDS}s |"
+            echo "| mbx (cache server) | ${MBX_TOTAL_SECONDS}s | ${MBX_BUILD_SECONDS}s |"
+            echo "| mbx (GitHub target cache) | ${MBX_GITHUB_TOTAL_SECONDS}s | ${MBX_GITHUB_BUILD_SECONDS}s |"
             echo "| Swatinem/rust-cache | ${RUST_CACHE_TOTAL_SECONDS}s | ${RUST_CACHE_BUILD_SECONDS}s |"
             echo
-            echo "mbx delta: **${total_delta}** end to end; **${build_delta}** build only (positive means mbx was faster)."
+            echo "mbx cache server delta: **${total_delta}** end to end; **${build_delta}** build only (positive means mbx was faster)."
             echo
-            echo "> Cache + build starts after checkout and includes mbx installation or rust-cache restoration. The main-branch push seeds both backends; compare it with the warm benchmark dispatched on main."
+            echo "mbx GitHub target cache delta: **${github_total_delta}** end to end; **${github_build_delta}** build only."
+            echo
+            echo "> Cache + build starts after checkout and includes mbx installation or rust-cache restoration. The main-branch push seeds every backend; compare it with the warm benchmark dispatched on main."
           } >> "$GITHUB_STEP_SUMMARY"
 
   mbx_windows:
@@ -244,7 +328,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
-          version: 1.6.0
+          version: 1.8.1
       - name: Build
         id: build
         shell: pwsh
@@ -293,9 +377,43 @@ jobs:
           "build_seconds=$buildElapsed" >> $env:GITHUB_OUTPUT
           "total_seconds=$totalElapsed" >> $env:GITHUB_OUTPUT
 
+  mbx_github_windows:
+    name: mbx GitHub target cache (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    outputs:
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Start cache timer
+        shell: pwsh
+        run: '[System.Diagnostics.Stopwatch]::GetTimestamp() | Set-Content "$env:RUNNER_TEMP/cache-benchmark-start"'
+      # The action restores Cargo's pruned target tree from the GitHub cache and,
+      # like rust-cache above, saves a new entry only on main-branch pushes.
+      - uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777 # v1.3.0
+        with:
+          version: 1.8.1
+          cache-generation: cache-benchmark-v1
+      - name: Build
+        id: build
+        shell: pwsh
+        run: |
+          $buildStarted = [System.Diagnostics.Stopwatch]::GetTimestamp()
+          mbx build --features git2/vendored-libgit2,git2/vendored-openssl
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $ended = [System.Diagnostics.Stopwatch]::GetTimestamp()
+          $cacheStarted = [long](Get-Content "$env:RUNNER_TEMP/cache-benchmark-start")
+          $buildElapsed = (($ended - $buildStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          $totalElapsed = (($ended - $cacheStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "build_seconds=$buildElapsed" >> $env:GITHUB_OUTPUT
+          "total_seconds=$totalElapsed" >> $env:GITHUB_OUTPUT
+
   comparison_windows:
     name: comparison (Windows)
-    needs: [mbx_windows, rust_cache_windows]
+    needs: [mbx_windows, mbx_github_windows, rust_cache_windows]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     env:
@@ -303,6 +421,8 @@ jobs:
       MBX_TOTAL_SECONDS: ${{ needs.mbx_windows.outputs.total_seconds }}
       RUST_CACHE_BUILD_SECONDS: ${{ needs.rust_cache_windows.outputs.build_seconds }}
       RUST_CACHE_TOTAL_SECONDS: ${{ needs.rust_cache_windows.outputs.total_seconds }}
+      MBX_GITHUB_BUILD_SECONDS: ${{ needs.mbx_github_windows.outputs.build_seconds }}
+      MBX_GITHUB_TOTAL_SECONDS: ${{ needs.mbx_github_windows.outputs.total_seconds }}
     steps:
       - name: Summarize results
         shell: bash
@@ -311,15 +431,22 @@ jobs:
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           total_delta=$(awk -v mbx="$MBX_TOTAL_SECONDS" -v rust="$RUST_CACHE_TOTAL_SECONDS" \
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          github_build_delta=$(awk -v mbx="$MBX_GITHUB_BUILD_SECONDS" -v rust="$RUST_CACHE_BUILD_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          github_total_delta=$(awk -v mbx="$MBX_GITHUB_TOTAL_SECONDS" -v rust="$RUST_CACHE_TOTAL_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           {
             echo "## Windows cache build comparison"
             echo
             echo "| Backend | Cache + build | Build only |"
             echo "| --- | ---: | ---: |"
-            echo "| mbx | ${MBX_TOTAL_SECONDS}s | ${MBX_BUILD_SECONDS}s |"
+            echo "| mbx (cache server) | ${MBX_TOTAL_SECONDS}s | ${MBX_BUILD_SECONDS}s |"
+            echo "| mbx (GitHub target cache) | ${MBX_GITHUB_TOTAL_SECONDS}s | ${MBX_GITHUB_BUILD_SECONDS}s |"
             echo "| Swatinem/rust-cache | ${RUST_CACHE_TOTAL_SECONDS}s | ${RUST_CACHE_BUILD_SECONDS}s |"
             echo
-            echo "mbx delta: **${total_delta}** end to end; **${build_delta}** build only (positive means mbx was faster)."
+            echo "mbx cache server delta: **${total_delta}** end to end; **${build_delta}** build only (positive means mbx was faster)."
             echo
-            echo "> Cache + build starts after checkout and includes mbx installation or rust-cache restoration. The main-branch push seeds both backends; compare it with the warm benchmark dispatched on main."
+            echo "mbx GitHub target cache delta: **${github_total_delta}** end to end; **${github_build_delta}** build only."
+            echo
+            echo "> Cache + build starts after checkout and includes mbx installation or rust-cache restoration. The main-branch push seeds every backend; compare it with the warm benchmark dispatched on main."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cache-benchmark.yml
+++ b/.github/workflows/cache-benchmark.yml
@@ -36,11 +36,15 @@ jobs:
       contents: read
       id-token: write # Main pushes authenticate to the cache server; its policy keeps other events read-only.
     outputs:
-      seconds: ${{ steps.build.outputs.seconds }}
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
       - uses: ./.github/actions/mbx
         with:
           backend: server
@@ -49,11 +53,14 @@ jobs:
         id: build
         shell: bash
         run: |
-          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
           mbx build
           ended=$(python3 -c 'import time; print(time.monotonic_ns())')
-          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
-          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "build_seconds=$build_elapsed" >> "$GITHUB_OUTPUT"
+          echo "total_seconds=$total_elapsed" >> "$GITHUB_OUTPUT"
           mbx cache stats
 
   rust_cache_linux:
@@ -61,11 +68,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
-      seconds: ${{ steps.build.outputs.seconds }}
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:
@@ -75,11 +86,14 @@ jobs:
         id: build
         shell: bash
         run: |
-          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
           cargo build
           ended=$(python3 -c 'import time; print(time.monotonic_ns())')
-          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
-          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "build_seconds=$build_elapsed" >> "$GITHUB_OUTPUT"
+          echo "total_seconds=$total_elapsed" >> "$GITHUB_OUTPUT"
 
   comparison_linux:
     name: comparison (Linux)
@@ -87,25 +101,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     env:
-      MBX_SECONDS: ${{ needs.mbx_linux.outputs.seconds }}
-      RUST_CACHE_SECONDS: ${{ needs.rust_cache_linux.outputs.seconds }}
+      MBX_BUILD_SECONDS: ${{ needs.mbx_linux.outputs.build_seconds }}
+      MBX_TOTAL_SECONDS: ${{ needs.mbx_linux.outputs.total_seconds }}
+      RUST_CACHE_BUILD_SECONDS: ${{ needs.rust_cache_linux.outputs.build_seconds }}
+      RUST_CACHE_TOTAL_SECONDS: ${{ needs.rust_cache_linux.outputs.total_seconds }}
     steps:
       - name: Summarize results
         shell: bash
         run: |
-          delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
+          build_delta=$(awk -v mbx="$MBX_BUILD_SECONDS" -v rust="$RUST_CACHE_BUILD_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          total_delta=$(awk -v mbx="$MBX_TOTAL_SECONDS" -v rust="$RUST_CACHE_TOTAL_SECONDS" \
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           {
             echo "## Linux cache build comparison"
             echo
-            echo "| Backend | Build time |"
-            echo "| --- | ---: |"
-            echo "| mbx | ${MBX_SECONDS}s |"
-            echo "| Swatinem/rust-cache | ${RUST_CACHE_SECONDS}s |"
+            echo "| Backend | Cache + build | Build only |"
+            echo "| --- | ---: | ---: |"
+            echo "| mbx | ${MBX_TOTAL_SECONDS}s | ${MBX_BUILD_SECONDS}s |"
+            echo "| Swatinem/rust-cache | ${RUST_CACHE_TOTAL_SECONDS}s | ${RUST_CACHE_BUILD_SECONDS}s |"
             echo
-            echo "mbx delta: **${delta}** (positive means mbx was faster)."
+            echo "mbx delta: **${total_delta}** end to end; **${build_delta}** build only (positive means mbx was faster)."
             echo
-            echo "> The main-branch push seeds both backends. Compare them with the warm cache benchmark dispatched on main. Build time excludes checkout and cache setup; compare those step durations separately."
+            echo "> Cache + build starts after checkout and includes mbx installation or rust-cache restoration. The main-branch push seeds both backends; compare it with the warm benchmark dispatched on main."
           } >> "$GITHUB_STEP_SUMMARY"
 
   mbx:
@@ -116,11 +134,15 @@ jobs:
       contents: read
       id-token: write # Main pushes authenticate to the cache server; its policy keeps other events read-only.
     outputs:
-      seconds: ${{ steps.build.outputs.seconds }}
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
       - uses: ./.github/actions/mbx
         with:
           backend: server
@@ -129,11 +151,14 @@ jobs:
         id: build
         shell: bash
         run: |
-          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
           mbx build
           ended=$(python3 -c 'import time; print(time.monotonic_ns())')
-          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
-          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "build_seconds=$build_elapsed" >> "$GITHUB_OUTPUT"
+          echo "total_seconds=$total_elapsed" >> "$GITHUB_OUTPUT"
           mbx cache stats
 
   rust-cache:
@@ -141,11 +166,15 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 20
     outputs:
-      seconds: ${{ steps.build.outputs.seconds }}
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:
@@ -155,11 +184,14 @@ jobs:
         id: build
         shell: bash
         run: |
-          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
           cargo build
           ended=$(python3 -c 'import time; print(time.monotonic_ns())')
-          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
-          echo "seconds=$elapsed" >> "$GITHUB_OUTPUT"
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "build_seconds=$build_elapsed" >> "$GITHUB_OUTPUT"
+          echo "total_seconds=$total_elapsed" >> "$GITHUB_OUTPUT"
 
   comparison_macos:
     name: comparison (macOS)
@@ -167,25 +199,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     env:
-      MBX_SECONDS: ${{ needs.mbx.outputs.seconds }}
-      RUST_CACHE_SECONDS: ${{ needs.rust-cache.outputs.seconds }}
+      MBX_BUILD_SECONDS: ${{ needs.mbx.outputs.build_seconds }}
+      MBX_TOTAL_SECONDS: ${{ needs.mbx.outputs.total_seconds }}
+      RUST_CACHE_BUILD_SECONDS: ${{ needs.rust-cache.outputs.build_seconds }}
+      RUST_CACHE_TOTAL_SECONDS: ${{ needs.rust-cache.outputs.total_seconds }}
     steps:
       - name: Summarize results
         shell: bash
         run: |
-          delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
+          build_delta=$(awk -v mbx="$MBX_BUILD_SECONDS" -v rust="$RUST_CACHE_BUILD_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          total_delta=$(awk -v mbx="$MBX_TOTAL_SECONDS" -v rust="$RUST_CACHE_TOTAL_SECONDS" \
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           {
             echo "## macOS cache build comparison"
             echo
-            echo "| Backend | Build time |"
-            echo "| --- | ---: |"
-            echo "| mbx | ${MBX_SECONDS}s |"
-            echo "| Swatinem/rust-cache | ${RUST_CACHE_SECONDS}s |"
+            echo "| Backend | Cache + build | Build only |"
+            echo "| --- | ---: | ---: |"
+            echo "| mbx | ${MBX_TOTAL_SECONDS}s | ${MBX_BUILD_SECONDS}s |"
+            echo "| Swatinem/rust-cache | ${RUST_CACHE_TOTAL_SECONDS}s | ${RUST_CACHE_BUILD_SECONDS}s |"
             echo
-            echo "mbx delta: **${delta}** (positive means mbx was faster)."
+            echo "mbx delta: **${total_delta}** end to end; **${build_delta}** build only (positive means mbx was faster)."
             echo
-            echo "> The main-branch push seeds both backends. Compare them with the warm cache benchmark dispatched on main. Build time excludes checkout and cache setup; compare those step durations separately."
+            echo "> Cache + build starts after checkout and includes mbx installation or rust-cache restoration. The main-branch push seeds both backends; compare it with the warm benchmark dispatched on main."
           } >> "$GITHUB_STEP_SUMMARY"
 
   mbx_windows:
@@ -196,11 +232,15 @@ jobs:
       contents: read
       id-token: write # Main pushes authenticate to the cache server; its policy keeps other events read-only.
     outputs:
-      seconds: ${{ steps.build.outputs.seconds }}
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        shell: pwsh
+        run: '[System.Diagnostics.Stopwatch]::GetTimestamp() | Set-Content "$env:RUNNER_TEMP/cache-benchmark-start"'
       - uses: ./.github/actions/mbx
         with:
           backend: server
@@ -209,12 +249,15 @@ jobs:
         id: build
         shell: pwsh
         run: |
-          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          $buildStarted = [System.Diagnostics.Stopwatch]::GetTimestamp()
           mbx build --features git2/vendored-libgit2,git2/vendored-openssl
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $timer.Stop()
-          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
-          "seconds=$elapsed" >> $env:GITHUB_OUTPUT
+          $ended = [System.Diagnostics.Stopwatch]::GetTimestamp()
+          $cacheStarted = [long](Get-Content "$env:RUNNER_TEMP/cache-benchmark-start")
+          $buildElapsed = (($ended - $buildStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          $totalElapsed = (($ended - $cacheStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "build_seconds=$buildElapsed" >> $env:GITHUB_OUTPUT
+          "total_seconds=$totalElapsed" >> $env:GITHUB_OUTPUT
           mbx cache stats
 
   rust_cache_windows:
@@ -222,11 +265,15 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     outputs:
-      seconds: ${{ steps.build.outputs.seconds }}
+      build_seconds: ${{ steps.build.outputs.build_seconds }}
+      total_seconds: ${{ steps.build.outputs.total_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        shell: pwsh
+        run: '[System.Diagnostics.Stopwatch]::GetTimestamp() | Set-Content "$env:RUNNER_TEMP/cache-benchmark-start"'
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2 # zizmor: ignore[cache-poisoning] save-if restricts writes to main pushes
         with:
@@ -236,12 +283,15 @@ jobs:
         id: build
         shell: pwsh
         run: |
-          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          $buildStarted = [System.Diagnostics.Stopwatch]::GetTimestamp()
           cargo build --features git2/vendored-libgit2,git2/vendored-openssl
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $timer.Stop()
-          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
-          "seconds=$elapsed" >> $env:GITHUB_OUTPUT
+          $ended = [System.Diagnostics.Stopwatch]::GetTimestamp()
+          $cacheStarted = [long](Get-Content "$env:RUNNER_TEMP/cache-benchmark-start")
+          $buildElapsed = (($ended - $buildStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          $totalElapsed = (($ended - $cacheStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "build_seconds=$buildElapsed" >> $env:GITHUB_OUTPUT
+          "total_seconds=$totalElapsed" >> $env:GITHUB_OUTPUT
 
   comparison_windows:
     name: comparison (Windows)
@@ -249,23 +299,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     env:
-      MBX_SECONDS: ${{ needs.mbx_windows.outputs.seconds }}
-      RUST_CACHE_SECONDS: ${{ needs.rust_cache_windows.outputs.seconds }}
+      MBX_BUILD_SECONDS: ${{ needs.mbx_windows.outputs.build_seconds }}
+      MBX_TOTAL_SECONDS: ${{ needs.mbx_windows.outputs.total_seconds }}
+      RUST_CACHE_BUILD_SECONDS: ${{ needs.rust_cache_windows.outputs.build_seconds }}
+      RUST_CACHE_TOTAL_SECONDS: ${{ needs.rust_cache_windows.outputs.total_seconds }}
     steps:
       - name: Summarize results
         shell: bash
         run: |
-          delta=$(awk -v mbx="$MBX_SECONDS" -v rust="$RUST_CACHE_SECONDS" \
+          build_delta=$(awk -v mbx="$MBX_BUILD_SECONDS" -v rust="$RUST_CACHE_BUILD_SECONDS" \
+            'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
+          total_delta=$(awk -v mbx="$MBX_TOTAL_SECONDS" -v rust="$RUST_CACHE_TOTAL_SECONDS" \
             'BEGIN { if (rust == 0) print "n/a"; else printf "%.1f%%", ((rust - mbx) / rust) * 100 }')
           {
             echo "## Windows cache build comparison"
             echo
-            echo "| Backend | Build time |"
-            echo "| --- | ---: |"
-            echo "| mbx | ${MBX_SECONDS}s |"
-            echo "| Swatinem/rust-cache | ${RUST_CACHE_SECONDS}s |"
+            echo "| Backend | Cache + build | Build only |"
+            echo "| --- | ---: | ---: |"
+            echo "| mbx | ${MBX_TOTAL_SECONDS}s | ${MBX_BUILD_SECONDS}s |"
+            echo "| Swatinem/rust-cache | ${RUST_CACHE_TOTAL_SECONDS}s | ${RUST_CACHE_BUILD_SECONDS}s |"
             echo
-            echo "mbx delta: **${delta}** (positive means mbx was faster)."
+            echo "mbx delta: **${total_delta}** end to end; **${build_delta}** build only (positive means mbx was faster)."
             echo
-            echo "> The main-branch push seeds both backends. Compare them with the warm cache benchmark dispatched on main. Build time excludes checkout and cache setup; compare those step durations separately."
+            echo "> Cache + build starts after checkout and includes mbx installation or rust-cache restoration. The main-branch push seeds both backends; compare it with the warm benchmark dispatched on main."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -7,6 +7,10 @@ on:
         description: Optional jdx/mr-boxington Git ref to build and benchmark instead of the pinned release
         required: false
         type: string
+      rust_toolchain:
+        description: Optional Rust toolchain for the timed hk build, useful for stale-manifest tests
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -64,6 +68,14 @@ jobs:
           RUSTC_WRAPPER: ""
           RUSTC_WORKSPACE_WRAPPER: ""
         run: cargo build --locked --release --package mbx --manifest-path .mbx-candidate-source/Cargo.toml
+      - name: Select an alternate Rust toolchain for hk
+        if: inputs.rust_toolchain != ''
+        shell: bash
+        env:
+          BENCH_RUST_TOOLCHAIN: ${{ inputs.rust_toolchain }}
+        run: |
+          rustup toolchain install "$BENCH_RUST_TOOLCHAIN" --profile minimal
+          echo "RUSTUP_TOOLCHAIN=$BENCH_RUST_TOOLCHAIN" >> "$GITHUB_ENV"
       - name: Start cache timer
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       mbx_ref:
-        description: Optional jdx/mr-boxington Git ref to build and benchmark instead of the pinned release
+        description: Optional current jdx/mr-boxington branch-head SHA to build instead of the pinned release
         required: false
         type: string
       rust_toolchain:
@@ -46,6 +46,23 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Validate unreleased mbx revision
+        if: inputs.mbx_ref != ''
+        shell: bash
+        env:
+          MBX_CANDIDATE_SHA: ${{ inputs.mbx_ref }}
+        run: |
+          if [[ ! "$MBX_CANDIDATE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "mbx_ref must be a full commit SHA" >&2
+            exit 1
+          fi
+          candidate_sha=${MBX_CANDIDATE_SHA,,}
+          if ! git ls-remote --heads https://github.com/jdx/mr-boxington.git |
+            awk -v candidate="$candidate_sha" '$1 == candidate { found = 1 } END { exit !found }'
+          then
+            echo "mbx_ref must be the current head of a branch in jdx/mr-boxington" >&2
+            exit 1
+          fi
       - name: Check out unreleased mbx
         if: inputs.mbx_ref != ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   mbx:
     name: mbx (${{ matrix.label }})
-    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main'
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && (github.ref == 'refs/heads/main' || inputs.mbx_ref != '')
     permissions:
       contents: read
       id-token: write # Authenticate the main-branch dispatch to the cache server.

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -27,6 +27,8 @@ jobs:
   mbx:
     name: mbx (${{ matrix.label }})
     if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && (github.ref == 'refs/heads/main' || inputs.mbx_ref != '')
+    env:
+      MBX_SUMMARY: full
     permissions:
       contents: read
       id-token: write # Authenticate the main-branch dispatch to the cache server.
@@ -134,7 +136,7 @@ jobs:
 
   rust_cache:
     name: Swatinem rust-cache (${{ matrix.label }})
-    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && github.ref == 'refs/heads/main'
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && (github.ref == 'refs/heads/main' || inputs.mbx_ref != '')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -37,6 +37,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        if: runner.os != 'Windows'
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
+      - name: Start cache timer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: '[System.Diagnostics.Stopwatch]::GetTimestamp() | Set-Content "$env:RUNNER_TEMP/cache-benchmark-start"'
       - uses: ./.github/actions/mbx
         with:
           backend: server
@@ -45,22 +53,26 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
           mbx build
           ended=$(python3 -c 'import time; print(time.monotonic_ns())')
-          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
-          echo "## mbx ${{ matrix.label }}: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "## mbx ${{ matrix.label }}: ${total_elapsed}s total (${build_elapsed}s build)" >> "$GITHUB_STEP_SUMMARY"
           mbx cache stats
       - name: Build
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          $buildStarted = [System.Diagnostics.Stopwatch]::GetTimestamp()
           mbx build --features git2/vendored-libgit2,git2/vendored-openssl
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $timer.Stop()
-          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
-          "## mbx ${{ matrix.label }}: ${elapsed}s" >> $env:GITHUB_STEP_SUMMARY
+          $ended = [System.Diagnostics.Stopwatch]::GetTimestamp()
+          $cacheStarted = [long](Get-Content "$env:RUNNER_TEMP/cache-benchmark-start")
+          $buildElapsed = (($ended - $buildStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          $totalElapsed = (($ended - $cacheStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## mbx ${{ matrix.label }}: ${totalElapsed}s total (${buildElapsed}s build)" >> $env:GITHUB_STEP_SUMMARY
           mbx cache stats
 
   rust_cache:
@@ -85,6 +97,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Start cache timer
+        if: runner.os != 'Windows'
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
+      - name: Start cache timer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: '[System.Diagnostics.Stopwatch]::GetTimestamp() | Set-Content "$env:RUNNER_TEMP/cache-benchmark-start"'
       - name: Restore Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
@@ -94,18 +114,22 @@ jobs:
         if: runner.os != 'Windows'
         shell: bash
         run: |
-          started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
           cargo build
           ended=$(python3 -c 'import time; print(time.monotonic_ns())')
-          elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$started" "$ended")
-          echo "## Swatinem/rust-cache ${{ matrix.label }}: ${elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "## Swatinem/rust-cache ${{ matrix.label }}: ${total_elapsed}s total (${build_elapsed}s build)" >> "$GITHUB_STEP_SUMMARY"
       - name: Build
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $timer = [System.Diagnostics.Stopwatch]::StartNew()
+          $buildStarted = [System.Diagnostics.Stopwatch]::GetTimestamp()
           cargo build --features git2/vendored-libgit2,git2/vendored-openssl
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $timer.Stop()
-          $elapsed = $timer.Elapsed.TotalSeconds.ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
-          "## Swatinem/rust-cache ${{ matrix.label }}: ${elapsed}s" >> $env:GITHUB_STEP_SUMMARY
+          $ended = [System.Diagnostics.Stopwatch]::GetTimestamp()
+          $cacheStarted = [long](Get-Content "$env:RUNNER_TEMP/cache-benchmark-start")
+          $buildElapsed = (($ended - $buildStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          $totalElapsed = (($ended - $cacheStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## Swatinem/rust-cache ${{ matrix.label }}: ${totalElapsed}s total (${buildElapsed}s build)" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -2,6 +2,11 @@ name: warm cache benchmark
 
 on:
   workflow_dispatch:
+    inputs:
+      mbx_ref:
+        description: Optional jdx/mr-boxington Git ref to build and benchmark instead of the pinned release
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -37,6 +42,28 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - name: Check out unreleased mbx
+        if: inputs.mbx_ref != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: jdx/mr-boxington
+          ref: ${{ inputs.mbx_ref }}
+          path: .mbx-candidate-source
+          persist-credentials: false
+      - name: Build unreleased mbx outside the hk cache
+        if: inputs.mbx_ref != ''
+        shell: bash
+        env:
+          CARGO_HOME: ${{ runner.temp }}/mbx-candidate-cargo-home
+          CARGO_TARGET_DIR: ${{ runner.temp }}/mbx-candidate-target
+          MBX_CACHE_DIR: ${{ runner.temp }}/mbx-candidate-disabled-cache
+          MBX_REMOTE_URL: ""
+          MBX_REMOTE_NAMESPACE: ""
+          MBX_REMOTE_TOKEN: ""
+          MBX_REMOTE_OIDC_AUDIENCE: ""
+          RUSTC_WRAPPER: ""
+          RUSTC_WORKSPACE_WRAPPER: ""
+        run: cargo build --locked --release --package mbx --manifest-path .mbx-candidate-source/Cargo.toml
       - name: Start cache timer
         if: runner.os != 'Windows'
         shell: bash
@@ -48,6 +75,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: server
+          executable-dir: ${{ inputs.mbx_ref != '' && format('{0}/mbx-candidate-target/release', runner.temp) || '' }}
           version: 1.6.0
       - name: Build
         if: runner.os != 'Windows'

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           backend: server
           executable-dir: ${{ inputs.mbx_ref != '' && format('{0}/mbx-candidate-target/release', runner.temp) || '' }}
-          version: 1.6.0
+          version: 1.8.1
       - name: Build
         if: runner.os != 'Windows'
         shell: bash
@@ -192,3 +192,59 @@ jobs:
           $buildElapsed = (($ended - $buildStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
           $totalElapsed = (($ended - $cacheStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
           "## Swatinem/rust-cache ${{ matrix.label }}: ${totalElapsed}s total (${buildElapsed}s build)" >> $env:GITHUB_STEP_SUMMARY
+
+  mbx_github:
+    name: mbx GitHub target cache (${{ matrix.label }})
+    if: github.actor == 'jdx' && github.triggering_actor == 'jdx' && (github.ref == 'refs/heads/main' || inputs.mbx_ref != '')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: Linux
+          - os: macos-14
+            label: macOS
+          - os: windows-latest
+            label: Windows
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Start cache timer
+        if: runner.os != 'Windows'
+        shell: bash
+        run: python3 -c 'import pathlib, time; pathlib.Path("${{ runner.temp }}/cache-benchmark-start").write_text(str(time.monotonic_ns()))'
+      - name: Start cache timer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: '[System.Diagnostics.Stopwatch]::GetTimestamp() | Set-Content "$env:RUNNER_TEMP/cache-benchmark-start"'
+      # Restore-only: the cache benchmark's main-branch pushes seed this entry.
+      - uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777 # v1.3.0
+        with:
+          version: 1.8.1
+          cache-generation: cache-benchmark-v1
+      - name: Build
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          build_started=$(python3 -c 'import time; print(time.monotonic_ns())')
+          mbx build
+          ended=$(python3 -c 'import time; print(time.monotonic_ns())')
+          cache_started=$(<"$RUNNER_TEMP/cache-benchmark-start")
+          build_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$build_started" "$ended")
+          total_elapsed=$(python3 -c 'import sys; print(f"{(int(sys.argv[2]) - int(sys.argv[1])) / 1e9:.3f}")' "$cache_started" "$ended")
+          echo "## mbx GitHub target cache ${{ matrix.label }}: ${total_elapsed}s total (${build_elapsed}s build)" >> "$GITHUB_STEP_SUMMARY"
+      - name: Build
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $buildStarted = [System.Diagnostics.Stopwatch]::GetTimestamp()
+          mbx build --features git2/vendored-libgit2,git2/vendored-openssl
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $ended = [System.Diagnostics.Stopwatch]::GetTimestamp()
+          $cacheStarted = [long](Get-Content "$env:RUNNER_TEMP/cache-benchmark-start")
+          $buildElapsed = (($ended - $buildStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          $totalElapsed = (($ended - $cacheStarted) / [System.Diagnostics.Stopwatch]::Frequency).ToString("F3", [Globalization.CultureInfo]::InvariantCulture)
+          "## mbx GitHub target cache ${{ matrix.label }}: ${totalElapsed}s total (${buildElapsed}s build)" >> $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/warm-cache-benchmark.yml
+++ b/.github/workflows/warm-cache-benchmark.yml
@@ -56,7 +56,7 @@ jobs:
             echo "mbx_ref must be a full commit SHA" >&2
             exit 1
           fi
-          candidate_sha=${MBX_CANDIDATE_SHA,,}
+          candidate_sha=$(printf '%s' "$MBX_CANDIDATE_SHA" | tr '[:upper:]' '[:lower:]')
           if ! git ls-remote --heads https://github.com/jdx/mr-boxington.git |
             awk -v candidate="$candidate_sha" '$1 == candidate { found = 1 } END { exit !found }'
           then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ See the [contributing guide](https://hk.jdx.dev/contributing).
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.6. The normal
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.8. The normal
 `mise run build`, `mise run test:cargo`, and `mise run lint` workflows activate
 its transparent Cargo wrapper and therefore use the cache while invoking Cargo
 normally. Standalone Cargo commands require an activated mise shell. To bypass

--- a/mise.lock
+++ b/mise.lock
@@ -601,68 +601,68 @@ url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/52
 provenance = "github-attestations"
 
 [[tools.mr-boxington]]
-version = "1.6.0"
+version = "1.8.1"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:5fd146c4bfe68162036eea9fe63e8d65086f453b607ba5cf9bccc974e26473e3"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909652"
+checksum = "sha256:32ee1fa381884b62cf5f99cd5261ec566403f5a74a7579591af367d2eeb7913c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207197"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:2a57ad9fd232e6575e601c7ac6de5fa62e9b1a30f5bb3625441c63ecee2d2c50"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909653"
+checksum = "sha256:520c0d546f345f1f34880af2bcabd6e31106d2c8b58e85cf1993f4472e6ad007"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207199"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:4f706e48bbaafcf8ac4178b9a8b63c1d3f399b5b9b8024a13c3f769d77f4a19a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909670"
-provenance = "github-attestations"
-
-[tools.mr-boxington."platforms.linux-x64-baseline"]
-checksum = "sha256:4f706e48bbaafcf8ac4178b9a8b63c1d3f399b5b9b8024a13c3f769d77f4a19a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909670"
-provenance = "github-attestations"
-
-[tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:56c69a9c3b289f63d52cf8da1d2796191b2aebb9e7d8df348889ef198cc7c55d"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909672"
-provenance = "github-attestations"
-
-[tools.mr-boxington."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:56c69a9c3b289f63d52cf8da1d2796191b2aebb9e7d8df348889ef198cc7c55d"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909672"
-provenance = "github-attestations"
-
-[tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:cb3fd29b29924f7d74dee03eb84a279a2879f956358ebcc76aaf1a90072ddde5"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909657"
+checksum = "sha256:d87968853cc485237e0f739c23e897e3616a569e6a17b27c40e43afec72758a6"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207219"
 provenance = "github-attestations"
 provenance_verified = true
 
+[tools.mr-boxington."platforms.linux-x64-baseline"]
+checksum = "sha256:d87968853cc485237e0f739c23e897e3616a569e6a17b27c40e43afec72758a6"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207219"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64-musl"]
+checksum = "sha256:dcddf9c35d6c28213d396a9fac9d8987b6741dcf7e003f3dd0396458869b71e2"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207220"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:dcddf9c35d6c28213d396a9fac9d8987b6741dcf7e003f3dd0396458869b71e2"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207220"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.macos-arm64"]
+checksum = "sha256:541e715487e9348c389011dd2c6fc9640719e3c65ef352dd43abe84a890ba60a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207201"
+provenance = "github-attestations"
+
 [tools.mr-boxington."platforms.windows-arm64"]
-checksum = "sha256:21996b43edb9f0ba3bbebd533c17ce4da1208330aaec4d200703f6f527d6947e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909654"
+checksum = "sha256:5269e6dbe709da3487082e19ce4d1a12fbc23e8862f6de77e03678dbeb82f41e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207202"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:7736c35e5299097788ebd8a93812180fdb62e1181016d138f47b74245422680e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909669"
+checksum = "sha256:7f8b25823f381da29147cc612fdb858fd3ef21cbcf6927063a5dcd9b1d65011b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207206"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64-baseline"]
-checksum = "sha256:7736c35e5299097788ebd8a93812180fdb62e1181016d138f47b74245422680e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.6.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/542909669"
+checksum = "sha256:7f8b25823f381da29147cc612fdb858fd3ef21cbcf6927063a5dcd9b1d65011b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207206"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@ communique                      = "latest"
 git-cliff                       = "latest"
 "github:crate-ci/cargo-release" = "latest"
 "github:foresterre/cargo-msrv"  = "latest"
-mr-boxington                    = "1.6.0"
+mr-boxington                    = "1.8.1"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.


### PR DESCRIPTION
## Summary

- adopt mbx 1.8.1 (`mise.toml`, `mise.lock`, benchmark pins, CONTRIBUTING)
- add a third arm to both cache benchmarks: mbx restoring Cargo's pruned target tree from the GitHub Actions cache through `jdx/mr-boxington-action` v1.3.0, alongside the existing cache-server arm and Swatinem/rust-cache
- report all three backends with end-to-end (cache setup + build) and build-only columns

Includes #1323 (end-to-end cache timing and unreleased-ref support), which this branch is based on.

## Why

Recent main-branch comparisons had mbx's cache-server arm at 55–70s Linux builds against 15–18s for rust-cache. Paired same-runner measurements in jdx/mr-boxington showed the target-tree payload matching rust-cache within noise (ahead on build/test) while the previous objects payload trailed by 10s+; mr-boxington-action v1.3.0 ships that payload as its default. This adds it here so hk's own numbers show the comparison on the real workload.

## Reading the first runs

The pull-request run of `cache benchmark` is restore-only, so the GitHub target arm has no entry to restore until the first main-branch push after merge seeds it (rust-cache and the server arm are already seeded). The meaningful comparison is the `warm cache benchmark` dispatched on main after that push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI benchmarks, mise tool pins, and the mbx setup action; no application runtime or security-sensitive production paths.
> 
> **Overview**
> **Bumps mbx to 1.8.1** in `mise.toml`, `mise.lock`, `CONTRIBUTING.md`, and CI pins.
> 
> The **`.github/actions/mbx`** composite action gains an **`executable-dir`** input: when set, mise install is skipped and that directory is added to `PATH`, enabling benchmarks against a locally built mbx.
> 
> **Cache benchmarks** (`cache-benchmark.yml`, `warm-cache-benchmark.yml`) now measure **two timings**—**cache + build** (from post-checkout through build) and **build only**—and report them in step summaries and comparison tables. A **third backend** is added on Linux, macOS, and Windows: **mbx with GitHub Actions target cache** via `jdx/mr-boxington-action` v1.3.0, compared alongside the existing **mbx cache server** arm and **Swatinem/rust-cache**.
> 
> **Warm cache benchmark** adds optional **`workflow_dispatch` inputs** (`mbx_ref`, `rust_toolchain`): validate and build an unreleased mr-boxington branch head (outside hk’s cache), wire it through `executable-dir`, and optionally run the timed hk build on a different Rust toolchain. Job gates allow dispatch when `mbx_ref` is set even off `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab4b84671fabcd63d07a010865a7854235e4fe44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub Action users can provide a prebuilt mbx executable directory to skip installation.
  * Benchmark workflows now support alternate mbx revisions and Rust toolchains.
  * Benchmark reporting now includes build-only and total end-to-end timing.
  * Added coverage for GitHub target caching across Linux, macOS, and Windows.

* **Updates**
  * Updated the documented and configured mbx version from 1.6 to 1.8.1.
  * Benchmark workflows now use mbx 1.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->