### PR TITLE
ci(release): publish a signed packslip with each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,10 @@ jobs:
     runs-on: namespace-profile-endev-linux-amd64
     permissions:
       contents: write
+      # The packslip is signed with this job's OIDC identity and its
+      # artifacts are attested; neither is possible without these.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -302,6 +306,36 @@ jobs:
             --notes-file release-notes.md \
             --draft \
             release-assets/*
+      # A consumer that has this file can generate completions, a man page,
+      # and documentation with its own copy of usage, so nothing of hk's
+      # runs on the machine it is installed on.
+      - name: Publish the CLI specification
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ -n "${INPUTS_VERSION}" ]]; then
+            TAG_NAME="v${INPUTS_VERSION}"
+          else
+            TAG_NAME="${GITHUB_REF_NAME}"
+          fi
+          mkdir -p bin
+          tar -xzf release-assets/hk-x86_64-unknown-linux-gnu.tar.gz -C bin
+          bin/hk usage > hk.usage.kdl
+          gh release upload "$TAG_NAME" hk.usage.kdl --clobber
+      # The packslip is this release's signed inventory: every archive's
+      # digest, the executable inside it, the shared objects it needs from
+      # the host, and the workflow identity that signed for all of it. It
+      # lets an installer check a download against jdx/hk's identity rather
+      # than against a key this project would have to hold. The Pkl package
+      # is not an artifact anyone installs a binary from, so it stays out.
+      # See https://packslip.dev.
+      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+        with:
+          tag: ${{ inputs.version != '' && format('v{0}', inputs.version) || github.ref_name }}
+          artifacts: release-assets/hk-*.tar.gz release-assets/hk-*.tar.xz release-assets/hk-*.zip
+          bin: hk
+          resources: cli-spec/usage=asset:hk.usage.kdl
 
   publish-crate:
     needs: [create-release]


### PR DESCRIPTION
Part of adopting [packslip](https://packslip.dev) across the jdx.dev CLIs.

Each release now publishes `packslip.sigstore.json` beside the archives — one signed document listing:

- every archive's sha256 and sha512
- the executable inside each one (`hk`, `hk.exe` on Windows)
- the shared objects each build needs from the host, read out of the binaries
- a build-provenance attestation per file, linked by digest
- the source repo, tag, and commit

signed keylessly with this workflow's OIDC identity, so an installer verifies a download against the identity `github.com/jdx/hk` instead of a signing key this project would have to hold and rotate.

`hk usage` is run against the freshly built Linux binary and uploaded as `hk.usage.kdl`, listed as a `cli-spec` resource. A consumer generates completions, a man page, and docs from it with its own copy of usage — nothing of hk's runs on the installing machine.

### Changes

- `create-release` gains `id-token: write` and `attestations: write` (needed to sign and to attest).
- A step that extracts the linux-gnu tarball, runs `hk usage`, and uploads the spec.
- The `jdx/packslip` action, pinned to v0.3.0, after the release is created and while it is still a draft.

The `artifacts` glob is `release-assets/hk-*` on purpose: the Pkl package assets (`hk@<version>`, `hk@<version>.zip`) are not artifacts anyone installs a binary from, and they already ship with their own `.sha256` sidecars.

### Verification

Ran `hk usage` against the released v1.57.0 linux-gnu binary — 576 lines of spec, exit 0. Rehearsed `packslip create` locally against real release assets of the same shape. `zizmor --offline` reports no findings on the changed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands release job permissions and adds steps that run extracted release binaries and upload attested metadata; mistakes could affect release asset integrity or publish incorrect specs, but scope is limited to CI/release automation.
> 
> **Overview**
> Release CI now publishes a **packslip** alongside binary archives so installers can verify downloads against the workflow’s GitHub OIDC identity instead of a project-held signing key.
> 
> The **`create-release`** job gets **`id-token: write`** and **`attestations: write`** for keyless signing and artifact attestations. After the draft release is created, a new step extracts the **linux-gnu** tarball, runs **`hk usage`**, and uploads **`hk.usage.kdl`** for downstream completion/man-page generation without running hk on install machines. **`jdx/packslip@v0.3.0`** then inventories only **`hk-*`** archives (not Pkl packages), references the usage file as a **`cli-spec`** resource, and attaches the signed manifest to the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a44bd291d1136d52224593f95021354ff4d3d809. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release packages now include a usage specification file.
  - Release archives now include a signed inventory to improve authenticity and traceability.

- **Chores**
  - Enhanced release publishing with artifact attestation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->