### PR TITLE
chore(release): bump packslip action to v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,7 +330,7 @@ jobs:
       # than against a key this project would have to hold. The Pkl package
       # is not an artifact anyone installs a binary from, so it stays out.
       # See https://packslip.dev.
-      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
         with:
           tag: ${{ inputs.version != '' && format('v{0}', inputs.version) || github.ref_name }}
           artifacts: release-assets/hk-*.tar.gz release-assets/hk-*.tar.xz release-assets/hk-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,7 +330,7 @@ jobs:
       # than against a key this project would have to hold. The Pkl package
       # is not an artifact anyone installs a binary from, so it stays out.
       # See https://packslip.dev.
-      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
+      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
         with:
           tag: ${{ inputs.version != '' && format('v{0}', inputs.version) || github.ref_name }}
           artifacts: release-assets/hk-*.tar.gz release-assets/hk-*.tar.xz release-assets/hk-*.zip


### PR DESCRIPTION
## Summary
- Bumps the pinned `jdx/packslip` action from v0.3.0 to v1.0.0.
- v1.0.0 declares the manifest format stable, fixes the `packslip.dev/releases/v1` predicate URL that previously 404d, and requires every artifact to declare a format (already satisfied here — every artifact is an archive, which infers its format from the file name).

## Test plan
- [ ] Next tagged release runs the packslip step successfully and uploads `packslip.sigstore.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency pin in the release workflow with no application or runtime code changes; risk is limited to the packslip step on the next tagged release.
> 
> **Overview**
> Updates the **create-release** job to run **`jdx/packslip`** at **v1.0.1** (commit `a6eddff…`) instead of **v0.3.0**. The action’s inputs—release tag, archive globs, `hk` binary name, and `cli-spec/usage` resource—are unchanged; only the pinned action version moves forward so release signing/inventory generation uses the newer packslip release (stable v1 manifest, fixed verification predicate URL, stricter artifact format handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd23e85d840d05dcdef8c6afb3c3ddf55f41e38d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release packaging process to use a newer version of its packaging tool.
  * No changes were made to user-facing functionality or the overall release workflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: unavailable.*
