### PR TITLE
chore: release v1.58.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.58.1](https://github.com/jdx/hk/compare/v1.58.0..v1.58.1) - 2026-09-05
+
+### 📚 Documentation
+
+- generate page-specific social preview images by [@jdx](https://github.com/jdx) in [#1333](https://github.com/jdx/hk/pull/1333)
+
 ## [1.58.0](https://github.com/jdx/hk/compare/v1.57.0..v1.58.0) - 2026-09-05
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hk"
-version = "1.58.0"
+version = "1.58.1"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "hk"
 repository = "https://github.com/jdx/hk"
 resolver = "3"
 rust-version = "1.91.0"
-version = "1.58.0"
+version = "1.58.1"
 
 [[bin]]
 name = "generate-docs"

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The generated `hk.pkl` uses hk's built-in linter definitions, which you can exte
 needs different behavior:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   ["eslint"] = Builtins.eslint

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -11,8 +11,8 @@ hk provides 150+ pre-configured linters and formatters through the `Builtins` mo
 Import and use builtins in your `hk.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 hooks {
   ["pre-commit"] {

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -7895,7 +7895,7 @@
     "sources": {},
     "files": []
   },
-  "version": "1.58.0",
+  "version": "1.58.1",
   "usage": "",
   "complete": {
     "directory": {

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,7 +4,7 @@
 
 **Usage:** `hk [FLAGS] <SUBCOMMAND>`
 
-**Version:** 1.58.0
+**Version:** 1.58.1
 
 - **Usage:** `hk [FLAGS] <SUBCOMMAND>`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,8 +44,8 @@ Set [`HK_FILE`](/environment_variables#hk-file) to override the search and use a
 Here's a basic `hk.pkl` file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     // steps can be manually defined
@@ -364,8 +364,8 @@ The hkrc file follows the same format as `hk.pkl` and can define hooks and linte
 Example hkrc file:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 local linters {
     ["prettier"] = Builtins.prettier
@@ -400,7 +400,7 @@ Add steps to your hkrc. hk merges them into every project's hooks, so steps with
 
 ```pkl
 // ~/.config/hk/config.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
 
 hooks {
     ["pre-commit"] {
@@ -493,7 +493,7 @@ Git config supports both multivar entries (multiple values with the same key) an
 User-specific defaults can be set in `~/.config/hk/config.pkl`:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
 
 jobs = 4
 fail_fast = false

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -76,8 +76,8 @@ scripts on older versions. See [`hk install`](/cli/install) for all installation
 A typical configuration shares the same linters between automatic hooks and manual commands:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   ["eslint"] = Builtins.eslint

--- a/docs/mise_integration.md
+++ b/docs/mise_integration.md
@@ -42,7 +42,7 @@ They provide dependency management, option parsing, parallel execution, and more
 Run `mise run` in `hk.pkl` like any other command:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
 
 hooks {
     ["pre-commit"] {

--- a/docs/pkl_introduction.md
+++ b/docs/pkl_introduction.md
@@ -175,7 +175,7 @@ This is a multi-line comment
 Every `hk.pkl` should start with this line, which validates the config against hk's schema and provides the base classes:
 
 ```pkl
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
 ```
 
 ### Imports

--- a/docs/public/custom-linters.pkl
+++ b/docs/public/custom-linters.pkl
@@ -3,9 +3,9 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/public/javascript-project.pkl
+++ b/docs/public/javascript-project.pkl
@@ -3,9 +3,9 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/public/monorepo.pkl
+++ b/docs/public/monorepo.pkl
@@ -3,9 +3,9 @@
 /// * Backend: Rust
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {

--- a/docs/public/python-project.pkl
+++ b/docs/public/python-project.pkl
@@ -4,9 +4,9 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/docs/reference/examples/custom-linters.md
+++ b/docs/reference/examples/custom-linters.md
@@ -6,8 +6,8 @@
 /// * Demonstrates platform-specific commands
 /// * Uses conditions and workspace indicators
 /// * Shows test configuration
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 local custom_linters = new Mapping<String, Step> {
   // Custom SQL formatter

--- a/docs/reference/examples/javascript-project.md
+++ b/docs/reference/examples/javascript-project.md
@@ -6,8 +6,8 @@
 /// * Uses eslint for linting
 /// * Runs type checking with tsc
 /// * Enables automatic fixes in pre-commit
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 // Configure environment for all tools
 env {

--- a/docs/reference/examples/monorepo.md
+++ b/docs/reference/examples/monorepo.md
@@ -13,8 +13,8 @@ Groups can set common step attributes such as `dir`, `workspace_indicator`, `pre
 /// * Infrastructure: Terraform
 /// * Uses groups to organize steps by component
 
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 // Frontend linters (JavaScript/TypeScript)
 local frontend = new Group {
@@ -114,7 +114,7 @@ its own `hk.pkl` next to its code. The root config lists the subproject director
 
 ```pkl
 // hk.pkl (repo root)
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
 
 subprojects = List("frontend", "backend", "packages/*")
 
@@ -129,8 +129,8 @@ hooks {
 
 ```pkl
 // frontend/hk.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // aube resolves these executables from frontend/node_modules/.bin
@@ -155,8 +155,8 @@ hooks {
 
 ```pkl
 // backend/hk.pkl
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   ["cargo-fmt"] = Builtins.cargo_fmt

--- a/docs/reference/examples/python-project.md
+++ b/docs/reference/examples/python-project.md
@@ -7,8 +7,8 @@
 /// * Uses mypy for type checking
 /// * Sorts imports with isort
 /// * Validates with flake8
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 local python_linters = new Mapping<String, Step> {
   // Ruff is a fast Python linter

--- a/hk-example.pkl
+++ b/hk-example.pkl
@@ -1,6 +1,6 @@
-amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
 
-import "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Builtins.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
   // some linters are built into hk

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,4 +1,4 @@
-// amends "package://github.com/jdx/hk/releases/download/v1.58.0/hk@1.58.0#/Config.pkl"
+// amends "package://github.com/jdx/hk/releases/download/v1.58.1/hk@1.58.1#/Config.pkl"
 amends "pkl/Config.pkl"
 
 import "pkl/Builtins.pkl"

--- a/hk.usage.kdl
+++ b/hk.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name hk
 bin hk
-version "1.58.0"
+version "1.58.1"
 unknown_flags error
 subcommand_required #true
 flagset hook-options {


### PR DESCRIPTION
### 📚 Documentation

- generate page-specific social preview images by [@jdx](https://github.com/jdx) in [#1333](https://github.com/jdx/hk/pull/1333)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation URL churn only; no application or hook logic changes in this diff.
> 
> **Overview**
> **Release v1.58.1** — bumps the crate and CLI metadata from **1.58.0** to **1.58.1** (`Cargo.toml`, `Cargo.lock`, `hk.usage.kdl`, `docs/cli/*`).
> 
> Adds a **CHANGELOG** entry for **1.58.1** (2026-09-05) noting documentation work: page-specific social preview images ([#1333](https://github.com/jdx/hk/pull/1333)).
> 
> Every doc and sample **`hk.pkl`** `package://…/releases/download/v…` **`amends` / `import`** line is updated to **`v1.58.1` / `hk@1.58.1`** (README, configuration guides, public examples, `hk-example.pkl`, and the commented release URL in root `hk.pkl`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a318a13cf4c8c989cbbf296babb1aa052db12d02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->