### PR TITLE
chore(ci): bump packslip to v1.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,7 +330,7 @@ jobs:
       # than against a key this project would have to hold. The Pkl package
       # is not an artifact anyone installs a binary from, so it stays out.
       # See https://packslip.dev.
-      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
+      - uses: jdx/packslip@a0d434ad57571c62dbd0ab5095b4eff607a71fd3 # v1.1.1
         with:
           tag: ${{ inputs.version != '' && format('v{0}', inputs.version) || github.ref_name }}
           artifacts: release-assets/hk-*.tar.gz release-assets/hk-*.tar.xz release-assets/hk-*.zip


### PR DESCRIPTION
Update the release workflow to use packslip v1.1.1 at its immutable commit SHA. This release pins the nested provenance action, so repositories enforcing full-length action SHAs can load the composite action.

Validation: `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency pin in the release workflow; no application or runtime code changes, only how release provenance is generated.
> 
> **Overview**
> Updates the **`create-release`** job in `.github/workflows/release.yml` to use **`jdx/packslip@v1.1.1`** (immutable commit `a0d434ad…`) instead of **v1.0.1**.
> 
> Release behavior is unchanged: the step still signs the same release archives and attaches the packslip inventory using the existing `tag`, `artifacts`, `bin`, and `resources` inputs. The bump mainly brings in packslip **v1.1.1**, including pinning of a nested provenance action so workflows that require full-length action SHAs can resolve the composite action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b09e8484b2d7647f6b1b837d1db2c6aeb53f994c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release packaging workflow to use a newer version of its release automation tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->