### PR TITLE
chore(release): publish native completions in packslip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,7 +326,10 @@ jobs:
           for shell in bash zsh fish powershell; do
             bin/hk completion "$shell" > "hk.$shell"
             test -s "hk.$shell"
+            grep -Fq '__complete_word__' "hk.$shell"
+            bin/hk __complete_word__ --shell "$shell" --line 'hk --ver' | grep -Fq -- '--verbose'
           done
+          bash -n hk.bash
           gh release upload "$TAG_NAME" hk.usage.kdl hk.bash hk.zsh hk.fish hk.powershell --clobber
       # The packslip is this release's signed inventory: every archive's
       # digest, the executable inside it, the shared objects it needs from

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,11 @@ jobs:
             --notes-file release-notes.md \
             --draft \
             release-assets/*
+      - name: Install completion syntax checkers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh fish
+          mise install github:PowerShell/PowerShell@7.5.4
       # Publish native completion scripts so installers can load them without
       # a separate usage executable. Keep the CLI spec for other consumers.
       - name: Publish completions and the CLI specification
@@ -330,6 +335,13 @@ jobs:
             bin/hk __complete_word__ --shell "$shell" --line 'hk --ver' | grep -Fq -- '--verbose'
           done
           bash -n hk.bash
+          zsh -n hk.zsh
+          fish --no-execute hk.fish
+          mise exec github:PowerShell/PowerShell@7.5.4 -- pwsh -NoProfile -Command - <<'POWERSHELL'
+            $parseErrors = $null
+            [void][System.Management.Automation.Language.Parser]::ParseFile((Join-Path $PWD "hk.powershell"), [ref]$null, [ref]$parseErrors)
+            if ($parseErrors.Count) { $parseErrors | Write-Error; exit 1 }
+          POWERSHELL
           gh release upload "$TAG_NAME" hk.usage.kdl hk.bash hk.zsh hk.fish hk.powershell --clobber
       # The packslip is this release's signed inventory: every archive's
       # digest, the executable inside it, the shared objects it needs from

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,10 +308,9 @@ jobs:
             --notes-file release-notes.md \
             --draft \
             release-assets/*
-      # A consumer that has this file can generate completions, a man page,
-      # and documentation with its own copy of usage, so nothing of hk's
-      # runs on the machine it is installed on.
-      - name: Publish the CLI specification
+      # Publish native completion scripts so installers can load them without
+      # a separate usage executable. Keep the CLI spec for other consumers.
+      - name: Publish completions and the CLI specification
         env:
           INPUTS_VERSION: ${{ inputs.version }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
@@ -324,7 +323,11 @@ jobs:
           mkdir -p bin
           tar -xzf release-assets/hk-x86_64-unknown-linux-gnu.tar.gz -C bin
           bin/hk usage > hk.usage.kdl
-          gh release upload "$TAG_NAME" hk.usage.kdl --clobber
+          for shell in bash zsh fish powershell; do
+            bin/hk completion "$shell" > "hk.$shell"
+            test -s "hk.$shell"
+          done
+          gh release upload "$TAG_NAME" hk.usage.kdl hk.bash hk.zsh hk.fish hk.powershell --clobber
       # The packslip is this release's signed inventory: every archive's
       # digest, the executable inside it, the shared objects it needs from
       # the host, and the workflow identity that signed for all of it. It
@@ -338,6 +341,10 @@ jobs:
           artifacts: release-assets/hk-*.tar.gz release-assets/hk-*.tar.xz release-assets/hk-*.zip
           bin: hk
           resources: |
+            completion/bash=asset:hk.bash
+            completion/zsh=asset:hk.zsh
+            completion/fish=asset:hk.fish
+            completion/powershell=asset:hk.powershell
             cli-spec/usage=asset:hk.usage.kdl
             skill/hk-configure=archive:skills/hk-configure
             skill/hk-debug=archive:skills/hk-debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,10 +309,17 @@ jobs:
             --draft \
             release-assets/*
       - name: Install completion syntax checkers
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y zsh fish
-          mise install github:PowerShell/PowerShell@7.5.4
+          if [[ -f /etc/apt/apt-mirrors.txt ]]; then
+            sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/apt-mirrors.txt
+          fi
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 update
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 install -y zsh fish
+          # Hosted runners include PowerShell; Namespace images have its signed apt repository.
+          if ! command -v pwsh >/dev/null 2>&1; then
+            sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15 install -y powershell
+          fi
       # Publish native completion scripts so installers can load them without
       # a separate usage executable. Keep the CLI spec for other consumers.
       - name: Publish completions and the CLI specification
@@ -337,11 +344,12 @@ jobs:
           bash -n hk.bash
           zsh -n hk.zsh
           fish --no-execute hk.fish
-          mise exec github:PowerShell/PowerShell@7.5.4 -- pwsh -NoProfile -Command - <<'POWERSHELL'
+          cat > completion-syntax-check.ps1 <<'POWERSHELL'
             $parseErrors = $null
             [void][System.Management.Automation.Language.Parser]::ParseFile((Join-Path $PWD "hk.powershell"), [ref]$null, [ref]$parseErrors)
             if ($parseErrors.Count) { $parseErrors | Write-Error; exit 1 }
           POWERSHELL
+          pwsh -NoProfile -NonInteractive -File completion-syntax-check.ps1
           gh release upload "$TAG_NAME" hk.usage.kdl hk.bash hk.zsh hk.fish hk.powershell --clobber
       # The packslip is this release's signed inventory: every archive's
       # digest, the executable inside it, the shared objects it needs from


### PR DESCRIPTION
Publish hk's native bash, zsh, fish, and PowerShell completion scripts as release assets and declare each in the signed Packslip manifest. Installers can use these scripts directly without requiring users to install `usage` or run a separate completion setup command for hk. The usage specification remains available for other consumers.

Generate the scripts from the released Linux binary alongside the CLI specification, check that each is nonempty and uses the native protocol, exercise that protocol for every shell, syntax-check the bash script, and upload all resources before Packslip signs the release inventory. This pairs with automatic completion loading in mise's activated shells in jdx/mise#12848; jdx/mise#12845 updates the user-facing guides.

Validation: generated all four scripts with hk 1.58.1 and verified they use the built-in completion protocol; bash/zsh syntax checks and scoped hk checks (including actionlint and shellcheck) passed. The release workflow itself was not dispatched.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release validation reliability with installation timeouts, package-manager retries, and network timeout handling.
  - PowerShell completion validation now runs directly through PowerShell for more consistent checks.
- **Chores**
  - Release environments now use an available Azure Ubuntu mirror when configured.
  - PowerShell is installed through the package manager only when it is not already available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release workflow packaging and Packslip resource declarations, with shell syntax and completion-protocol checks before upload.
> 
> **Overview**
> Release CI now **generates and ships native completion scripts** (bash, zsh, fish, PowerShell) alongside `hk.usage.kdl`, so installers can load completions without running `usage` or `hk completion` on end-user machines.
> 
> The **Publish completions and the CLI specification** step extracts the Linux GNU binary, runs `hk completion` for each shell, checks non-empty output and the `__complete_word__` protocol (including a smoke test for `--verbose`), **syntax-validates** each script with the target shell (plus PowerShell’s parser), then uploads all five files before Packslip runs. A preceding step installs **zsh, fish, and PowerShell** on Namespace runners when needed.
> 
> The **signed Packslip manifest** now lists `completion/{bash,zsh,fish,powershell}` assets in addition to the existing CLI spec and skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 197143d32ba359162f83374b103dedbd1e729a13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->