### PR TITLE
feat: ship hk configuration and debugging skills with packslip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,11 +115,13 @@ jobs:
           # Match upload-rust-binary-action's default Unix archive format.
           # tar.xz is disabled by default and zip is reserved for Windows.
           tar -czf "hk-${TARGET}.tar.gz" \
-            -C "target/${TARGET}/serious-pgo" hk
+            -C "target/${TARGET}/serious-pgo" hk \
+            -C "${GITHUB_WORKSPACE}" skills
       - if: matrix.optimized != true
         uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1
         with:
           bin: hk
+          include: skills
           target: ${{ matrix.target }}
           build-tool: ${{ matrix.build-tool }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -337,8 +339,8 @@ jobs:
           bin: hk
           resources: |
             cli-spec/usage=asset:hk.usage.kdl
-            skill/hk-configure=repo:skills/hk-configure
-            skill/hk-debug=repo:skills/hk-debug
+            skill/hk-configure=archive:skills/hk-configure
+            skill/hk-debug=archive:skills/hk-debug
 
   publish-crate:
     needs: [create-release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,7 +335,10 @@ jobs:
           tag: ${{ inputs.version != '' && format('v{0}', inputs.version) || github.ref_name }}
           artifacts: release-assets/hk-*.tar.gz release-assets/hk-*.tar.xz release-assets/hk-*.zip
           bin: hk
-          resources: cli-spec/usage=asset:hk.usage.kdl
+          resources: |
+            cli-spec/usage=asset:hk.usage.kdl
+            skill/hk-configure=repo:skills/hk-configure
+            skill/hk-debug=repo:skills/hk-debug
 
   publish-crate:
     needs: [create-release]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ hk fix          # fix modified files
 hk check --all  # check the entire repository, useful in CI
 ```
 
+## Agent skills
+
+hk includes two skills for coding agents:
+
+- [hk-configure](skills/hk-configure/SKILL.md): add linters and custom checks, preserve the project's
+  Pkl schema version, and verify which files each step selects.
+- [hk-debug](skills/hk-debug/SKILL.md): diagnose hook failures, skipped steps, configuration overrides,
+  and partially staged files.
+
+The release workflow declares both skills in hk's packslip manifest, so compatible installers can
+fetch the instructions from the same commit as the release. Making them available to an agent is
+opt-in; see [mise's skills documentation](https://mise.jdx.dev/dev-tools/packslip-resources.html).
+
 ## Documentation
 
 - [Getting started](https://hk.jdx.dev/getting_started)

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ hk includes two skills for coding agents:
 - [hk-debug](skills/hk-debug/SKILL.md): diagnose hook failures, skipped steps, configuration overrides,
   and partially staged files.
 
-The release workflow declares both skills in hk's packslip manifest, so compatible installers can
-fetch the instructions from the same commit as the release. Making them available to an agent is
+Both skills ship in the `skills/` directory of each release archive. hk's packslip manifest points
+to those directories, so compatible installers can use the bundled instructions without a separate
+repository download. Making them available to an agent is
 opt-in; see [mise's skills documentation](https://mise.jdx.dev/dev-tools/packslip-resources.html).
 
 ## Documentation

--- a/skills/hk-configure/SKILL.md
+++ b/skills/hk-configure/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: hk-configure
+description: Configure hk git hooks and project checks in hk.pkl. Use when adding or changing linters, formatters, or custom steps in a project that uses hk, or when setting up hk at the user's request.
+---
+
+# Configure hk
+
+Start with the project's existing `hk.pkl` (or `.config/hk.pkl`), its tool declarations, and `hk --version`. Preserve the existing Pkl package version and hook structure unless the task includes upgrading them. `hk config sources` identifies configuration sources; a local override or `HK_FILE` may select a different file than the one you intend to edit.
+
+For a new setup, `hk init` generates a configuration with package imports matching the installed hk. Do not use `--force` to replace an existing configuration. Installing Git hooks is separate from defining checks; use `hk install` when hook installation is part of the task.
+
+## Add a check
+
+Prefer the built-in definition when it fits: `hk builtins` lists available names. Builtins configure commands and file selection; the linter executable still needs to be available through the project's existing tool setup.
+
+Extend the project's existing mapping rather than replacing its hooks. For example, with its existing `Builtins.pkl` import, add this entry to the linter mapping used by the relevant hooks:
+
+```pkl
+["prettier"] = (Builtins.prettier) {
+  glob = List("**/*.js", "**/*.ts", "**/*.json")
+}
+```
+
+Keep the `Config.pkl` and `Builtins.pkl` imports on the same package version. Do not copy a newer builtin's fields into a project pinned to an older schema without checking compatibility.
+
+For a custom step, set `glob` to the intended files, `check` to the reporting command, and `fix` only when the tool supports correction. `{{files}}` passes the selected paths. In monorepos, inspect existing `dir` and `workspace_indicator` choices before adding a repository-wide command. Use `depends` for real ordering dependencies; independent steps can run concurrently.
+
+## Verify the configuration and file selection
+
+Run `hk validate`, then preview the relevant hook before executing it:
+
+```sh
+hk check --all --why prettier
+hk check --check --step prettier --all
+```
+
+Replace `prettier` with the added step and choose explicit files instead of `--all` when the task is narrower. If the step only exists in `pre-commit`, inspect it with `hk run pre-commit --plan --why prettier` instead; do not assume the `check` hook has identical steps.
+
+`--plan` and `--why` do not execute the hook's commands. `--check` selects check commands even if the hook sets `fix = true`, but custom check commands can still write files. Read the selected commands before running them. Use `hk fix` when corrections are intended and inspect the resulting diff; pre-commit fixers may also stage changes.
+
+For less common fields, consult the [configuration reference](https://hk.jdx.dev/configuration), using the project's pinned schema and installed CLI help to resolve version differences.

--- a/skills/hk-configure/SKILL.md
+++ b/skills/hk-configure/SKILL.md
@@ -5,7 +5,9 @@ description: Configure hk git hooks and project checks in hk.pkl. Use when addin
 
 # Configure hk
 
-Start with the project's existing `hk.pkl` (or `.config/hk.pkl`), its tool declarations, and `hk --version`. Preserve the existing Pkl package version and hook structure unless the task includes upgrading them. `hk config sources` identifies configuration sources; a local override or `HK_FILE` may select a different file than the one you intend to edit.
+Start with `hk --version`, the project's tool declarations, and the configuration hk actually selects. Check `HK_FILE` first: when set, it replaces the normal candidate list (a relative path is searched from the working directory upward). Otherwise, walk upward from the working directory, checking `hk.local.pkl`, `.config/hk.local.pkl`, `hk.pkl`, then `.config/hk.pkl` at each level. Legacy `hk.toml`, `hk.yaml`, `hk.yml`, and `hk.json` are checked after those Pkl paths at each level. The first existing file wins. Inspect a local override's `amends` chain before editing the shared project file.
+
+Preserve the existing Pkl package version and hook structure unless the task includes upgrading them. `hk config sources` prints the precedence of configuration layers; it does not identify the selected project file. `hk config dump` shows merged settings.
 
 For a new setup, `hk init` generates a configuration with package imports matching the installed hk. Do not use `--force` to replace an existing configuration. Installing Git hooks is separate from defining checks; use `hk install` when hook installation is part of the task.
 
@@ -27,15 +29,20 @@ For a custom step, set `glob` to the intended files, `check` to the reporting co
 
 ## Verify the configuration and file selection
 
-Run `hk validate`, then preview the relevant hook before executing it:
+Run `hk validate`, then preview the relevant hook without executing its commands:
 
 ```sh
 hk check --all --why prettier
-hk check --check --step prettier --all
 ```
 
 Replace `prettier` with the added step and choose explicit files instead of `--all` when the task is narrower. If the step only exists in `pre-commit`, inspect it with `hk run pre-commit --plan --why prettier` instead; do not assume the `check` hook has identical steps.
 
-`--plan` and `--why` do not execute the hook's commands. `--check` selects check commands even if the hook sets `fix = true`, but custom check commands can still write files. Read the selected commands before running them. Use `hk fix` when corrections are intended and inspect the resulting diff; pre-commit fixers may also stage changes.
+After reviewing the selected commands and confirming their effects fit the task, run the targeted check:
+
+```sh
+hk check --check --step prettier --all
+```
+
+`--check` selects check commands even if the hook sets `fix = true`; it does not make arbitrary commands read-only. Custom check commands can write files. Use `hk fix` when corrections are intended and inspect the resulting diff; pre-commit fixers may also stage changes.
 
 For less common fields, consult the [configuration reference](https://hk.jdx.dev/configuration), using the project's pinned schema and installed CLI help to resolve version differences.

--- a/skills/hk-debug/SKILL.md
+++ b/skills/hk-debug/SKILL.md
@@ -9,7 +9,9 @@ Capture the failing command, `hk --version`, and `git status --short`. Distingui
 
 ## Inspect the effective configuration
 
-Use `hk config sources` and `hk config dump` to see what hk loads. `hk.local.pkl` takes precedence over `hk.pkl`, and `HK_FILE` can select another file. Inspect relevant `HK_*` overrides and use `hk config explain skip_steps` (or another relevant setting) when a setting differs from the project file.
+Check `HK_FILE` first: when set, it replaces the normal candidate list (a relative path is searched from the working directory upward). Otherwise, walk upward from the working directory, checking `hk.local.pkl`, `.config/hk.local.pkl`, `hk.pkl`, then `.config/hk.pkl` at each level. Legacy `hk.toml`, `hk.yaml`, `hk.yml`, and `hk.json` are checked after those Pkl paths at each level. The first existing file wins. Inspect a local override's `amends` chain before editing the shared project file.
+
+`hk config sources` prints the static precedence of configuration layers; `hk config dump` shows merged settings. Neither identifies the selected project file. Inspect relevant `HK_*` overrides and use `hk config explain skip_steps` (or another relevant setting) when a setting differs from the project file.
 
 Run `hk validate` for Pkl evaluation or schema errors. Compare the project's pinned package imports with its installed hk version before suggesting an upgrade.
 

--- a/skills/hk-debug/SKILL.md
+++ b/skills/hk-debug/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: hk-debug
+description: Diagnose failing or unexpectedly skipped hk checks and git hooks, including file selection, configuration overrides, and partially staged files. Use when a project using hk has a hook failure or a step runs on the wrong files.
+---
+
+# Diagnose hk checks and hooks
+
+Capture the failing command, `hk --version`, and `git status --short`. Distinguish a configuration error, an excluded step, a missing executable, and an error from the linter itself. Read the first substantive error from the failing step, not just hk's final exit status.
+
+## Inspect the effective configuration
+
+Use `hk config sources` and `hk config dump` to see what hk loads. `hk.local.pkl` takes precedence over `hk.pkl`, and `HK_FILE` can select another file. Inspect relevant `HK_*` overrides and use `hk config explain skip_steps` (or another relevant setting) when a setting differs from the project file.
+
+Run `hk validate` for Pkl evaluation or schema errors. Compare the project's pinned package imports with its installed hk version before suggesting an upgrade.
+
+## Explain skipped steps and files
+
+Preview the same hook and file-selection flags as the failing invocation:
+
+```sh
+hk run pre-commit --plan --why prettier
+hk check --all --why prettier
+```
+
+These are different scopes: the second command is useful as a comparison, not a reproduction of a staged-file failure. Replace `prettier` with the actual step. `--why` implies a plan and explains inclusion and exclusion; `--json` makes that plan machine-readable.
+
+Check the selected paths against `glob`, `exclude`, `dir`, `workspace_indicator`, profiles, conditions, and skipped-step settings. `hk check` and `hk run pre-commit` may have different step mappings and fix/stash settings. A successful all-files check does not prove the staged snapshot will pass.
+
+## Reproduce the failing step
+
+Once the plan identifies the right files and command, narrow execution to that step. For example:
+
+```sh
+hk check --check --step prettier path/to/file.ts
+```
+
+`--check` chooses check commands, but a custom check can still write files. Inspect it before executing. For command-not-found errors, check the configured `prefix`, working directory, and project tool environment rather than installing a different global tool. For linter errors, fix the reported code or configuration and rerun the same scope.
+
+For partially staged files, inspect both `git diff` and `git diff --cached`. hk may stash unstaged changes, run fixers, stage their output, then restore the unstaged work. If restoration fails, preserve hk's recovery message and the current index/worktree; do not drop stashes or reset files to make the error disappear. Resolve the specific conflict while preserving both sets of changes.
+
+Do not disable the hook or add a skip setting as a substitute for fixing the cause unless the user asks for that behavior. Report the cause, the targeted change, and which original invocation now succeeds.
+
+See the [hook lifecycle](https://hk.jdx.dev/hooks) and [CLI reference](https://hk.jdx.dev/cli/) for additional diagnostics; prefer the installed version's `--help` when flags differ.


### PR DESCRIPTION
Bundle two vendor-maintained agent skills in every hk release archive and declare their archive paths in packslip. Installing hk can provide matching instructions without a separate repository download:

- `hk-configure` covers adding checks, preserving the project's Pkl schema version, and previewing file selection before executing commands.
- `hk-debug` covers failed or skipped hooks, configuration overrides, and partially staged files.

The optimized Linux packaging command includes `skills/`; the standard build action includes that directory in Unix tarballs and Windows ZIPs. The README documents both skills and opt-in agent access. The existing CLI-spec resource remains unchanged.

Validation: skill validation, actionlint, workflow Prettier, and `git diff --check` pass. Local packaging smoke checks exercised the optimized tar command and reproduced the pinned upload action's standard tar/ZIP layout: both declared SKILL.md files were present with matching contents, and binary bytes were unchanged. hk 1.58.1 checks covered configuration discovery, file selection, and a Prettier failure/fix/pass workflow in isolated repositories. Full release publishing was not executed.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release artifact layout, packslip metadata, and documentation; the hk binary behavior is unaffected.
> 
> **Overview**
> **Adds two vendor-maintained coding-agent skills** (`hk-configure`, `hk-debug`) under `skills/` and ships them with every release binary archive.
> 
> Release packaging now includes the whole `skills/` tree alongside `hk` (optimized PGO+BOLT `tar` and `upload-rust-binary-action` via `include: skills`). The **packslip manifest** gains two `skill/…=archive:skills/…` resources so mise-compatible installers can fetch the bundled instructions without cloning the repo; the existing `cli-spec/usage` resource is unchanged.
> 
> The **README** documents both skills, that they live in release archives, and that exposing them to an agent is opt-in via packslip/mise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 949135bd90b6b5b259fc6e5f8b3b03c965cb3a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->