### PR TITLE
chore(deps): bump mr-boxington to 1.8.3

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -601,68 +601,68 @@ url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/52
 provenance = "github-attestations"
 
 [[tools.mr-boxington]]
-version = "1.8.1"
+version = "1.8.3"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:32ee1fa381884b62cf5f99cd5261ec566403f5a74a7579591af367d2eeb7913c"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207197"
+checksum = "sha256:c8c0e6ac85afcf17f7143df127337d8ee8fdc22f879bf812081d8958ee253937"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079709"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:520c0d546f345f1f34880af2bcabd6e31106d2c8b58e85cf1993f4472e6ad007"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207199"
+checksum = "sha256:6ce3e6efedc29b52c6daa873f63c98bc757aea89d0e576e3f76a13d3280b48dd"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079710"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:d87968853cc485237e0f739c23e897e3616a569e6a17b27c40e43afec72758a6"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207219"
+checksum = "sha256:62d122a4103ca286ef86a5c8429d21404f60e795345b8c853a9da0a18ef6dbde"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079720"
 provenance = "github-attestations"
-provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-baseline"]
-checksum = "sha256:d87968853cc485237e0f739c23e897e3616a569e6a17b27c40e43afec72758a6"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207219"
+checksum = "sha256:62d122a4103ca286ef86a5c8429d21404f60e795345b8c853a9da0a18ef6dbde"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079720"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:dcddf9c35d6c28213d396a9fac9d8987b6741dcf7e003f3dd0396458869b71e2"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207220"
+checksum = "sha256:b97fb1c3525fd772610c405b16da051fa6b6e55e499f16818c648414b1b53d2b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079722"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64-musl-baseline"]
-checksum = "sha256:dcddf9c35d6c28213d396a9fac9d8987b6741dcf7e003f3dd0396458869b71e2"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207220"
+checksum = "sha256:b97fb1c3525fd772610c405b16da051fa6b6e55e499f16818c648414b1b53d2b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079722"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:541e715487e9348c389011dd2c6fc9640719e3c65ef352dd43abe84a890ba60a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207201"
+checksum = "sha256:9b01044089551944d12c4412a85dc6788d216c9020aeaf501c405e6a90435596"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079713"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools.mr-boxington."platforms.windows-arm64"]
-checksum = "sha256:5269e6dbe709da3487082e19ce4d1a12fbc23e8862f6de77e03678dbeb82f41e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207202"
+checksum = "sha256:82166b80e460255b18b3c20868409b6f25e894c8cec9b6de1db0f2f71e66155a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-aarch64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079712"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:7f8b25823f381da29147cc612fdb858fd3ef21cbcf6927063a5dcd9b1d65011b"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207206"
+checksum = "sha256:24dc00525b058f2bfb0bb17f47e9e50139e7a6a1ffd262616b550159ca53fe03"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079718"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64-baseline"]
-checksum = "sha256:7f8b25823f381da29147cc612fdb858fd3ef21cbcf6927063a5dcd9b1d65011b"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207206"
+checksum = "sha256:24dc00525b058f2bfb0bb17f47e9e50139e7a6a1ffd262616b550159ca53fe03"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.3/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/546079718"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@ communique                      = "latest"
 git-cliff                       = "latest"
 "github:crate-ci/cargo-release" = "latest"
 "github:foresterre/cargo-msrv"  = "latest"
-mr-boxington                    = "1.8.1"
+mr-boxington                    = "1.8.3"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in hk's numbers, indistinguishable from a real regression. Bump deliberately.


### PR DESCRIPTION
Update the mr-boxington tool pin and platform lockfile entries to 1.8.3.

Validation: verified `mbx --version`, checked lockfile versions and release URLs, confirmed unrelated lockfile tools are unchanged, and ran `git diff --check`. Full project CI was not run locally.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-environment and CI tooling pin only; behavior changes depend on upstream 1.8.3 release notes, but no application or security-sensitive code is modified.
> 
> **Overview**
> Bumps the pinned **mr-boxington** dev tool from **1.8.1** to **1.8.3** in `mise.toml` and refreshes the matching `mise.lock` entries (version, download URLs, checksums, and release asset IDs) for every supported platform.
> 
> The lockfile also drops `provenance_verified` on `linux-x64` and adds it on `macos-arm64` for this tool—metadata only, not application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72f28e8aa581fa92af559618d2aba187c7d8dac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `mr-boxington` tool to version 1.8.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->