### PR TITLE
chore: cache perf source downloads and install only benchmark tools

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -75,6 +75,8 @@ jobs:
       # Job-local appliance volume; no remote backend is configured.
       MBX_CACHE_DIR: /var/cache/mbx
       MBX_REMOTE_URL: ""
+      # Install only the benchmark tools below, including when tasks run.
+      MISE_TASK_RUN_AUTO_INSTALL: "false"
     name: Compare instruction counts
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true'
@@ -116,6 +118,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
+          install_args: mr-boxington github:jdx/tak
         env:
           MISE_LOCKED: "1"
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -35,6 +35,8 @@ jobs:
       # Persistent appliance-local store; no remote backend is configured.
       MBX_CACHE_DIR: /var/cache/mbx
       MBX_REMOTE_URL: ""
+      # Install only the benchmark tools below, including when tasks run.
+      MISE_TASK_RUN_AUTO_INSTALL: "false"
     name: Measure
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series
@@ -42,7 +44,8 @@ jobs:
     runs-on: [self-hosted, jdx-perf-v1]
     container:
       image: ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68
-      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx
+      # Persist source downloads separately from mbx compiler artifacts.
+      options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx --mount type=bind,src=/var/cache/jdx-perf/cargo/registry,dst=/opt/cargo/registry --mount type=bind,src=/var/cache/jdx-perf/cargo/git,dst=/opt/cargo/git
     timeout-minutes: 30
     permissions:
       contents: read
@@ -56,6 +59,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           cache: false
+          install_args: mr-boxington github:jdx/tak
         env:
           MISE_LOCKED: "1"
 


### PR DESCRIPTION
Perf setup currently installs the entire development toolset, including building cargo-edit from source when no binary is available. Install only mbx and tak in both perf workflows and disable automatic task tool installation so running the benchmarks does not reinstall the remaining tools.

Persist Cargo registry and git source downloads for main builds using dedicated appliance mounts. Keep PR source downloads in the disposable container. The host directories are provisioned already and tracked in jdx/perf-runner commit 07d961e.

Validation: actionlint passed for both workflows, perf:record dry-run passed, perf-runner configuration/dispatcher checks passed, and the pinned container can access both mounts as its normal user while retaining Cargo and Rust 1.97.1. A full benchmark run has not been performed with this workflow yet.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-6; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to self-hosted perf workflow setup and caching; they do not touch application auth, data paths, or release logic.
> 
> **Overview**
> **Perf CI** no longer pulls the full mise dev stack on benchmark runs. Both `perf.yml` and `perf-pr.yml` set **`MISE_TASK_RUN_AUTO_INSTALL: "false"`** and pass **`install_args: mr-boxington github:jdx/tak`** to `mise-action`, so only the benchmark tooling is installed and task execution does not trigger a reinstall of everything else.
> 
> **Main-only persistence:** `perf.yml` adds host bind mounts for **`/opt/cargo/registry`** and **`/opt/cargo/git`** (alongside the existing mbx cache mount), so repeated main measurements reuse downloaded crate sources. **`perf-pr.yml` is unchanged** on container storage—it still uses a disposable mbx volume, keeping PR builds isolated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12bcb4e9da6d2fe12674b90bdaccf2f70bd6efc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->