### PR TITLE
feat(builtins): add mado linter

### DIFF
--- a/pkl/builtins/mado.pkl
+++ b/pkl/builtins/mado.pkl
@@ -1,0 +1,24 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+import "./test/helpers.pkl"
+
+@Builtins.meta {
+  category = "Markdown"
+  description = "Fast Markdown linter (CommonMark/GFM)"
+  project_indicators {
+    new { file = "mado.toml" }
+    new { file = ".mado.toml" }
+  }
+}
+mado = new Config.Step {
+  types = List("markdown")
+  check = new Config.CommandSpec {
+    command = new Config.Command { argv = List("mado", "check", "{{files}}") }
+    effect = "read"
+  }
+  tests {
+    local const testMaker = new helpers.TestMaker { filename = "test.md" }
+    ["check bad file"] = testMaker.checkFail("#Hello.", 1)
+    ["check good file"] = testMaker.checkPass("# Hello\n")
+  }
+}

--- a/test/builtin_tool_stubs/mado
+++ b/test/builtin_tool_stubs/mado
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "0.3.2"
+tool = "aqua:akiomik/mado"


### PR DESCRIPTION
## Summary

- Add a check-only hk builtin for [mado](https://github.com/akiomik/mado), a fast Rust CommonMark/GFM Markdown linter
- No `fix` support, since mado's CLI only exposes a `check` subcommand
- Add a matching `test/builtin_tool_stubs/mado` (`aqua:akiomik/mado` v0.3.2) so `hk test --step mado` can run without the real binary

## Test plan

  - [x] `hk test --step mado` — verified `mado`'s actual behavior directly against a real v0.3.2 binary matches the test expectations (`checkFail("#Hello.", 1)` and `checkPass("# Hello\n", 0)`, based on `tests/command_check.rs` in the mado  repo)
  - [x] `mise run pkl:gen` regenerated `pkl/Builtins.pkl` / `pkl/builtins_meta.json` locally to confirm the builtin registers correctly (not committed — both are gitignored build artifacts)

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: 2.1.263.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing `mado` version 0.3.2 through the mise tool registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->