### PR TITLE
fix(pre-push): warn instead of crashing on malformed lines from stdin

### DIFF
--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -152,3 +152,103 @@ impl PrePush {
         self.hook.run("pre-push").await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SHA1: &str = "0123456789abcdef0123456789abcdef01234567";
+    const SHA256: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const ZERO_SHA1: &str = "0000000000000000000000000000000000000000";
+
+    #[test]
+    fn test_accepts_sha1_hash() {
+        assert!(is_valid_commit_hash(SHA1));
+    }
+
+    #[test]
+    fn test_accepts_sha256_hash() {
+        assert!(is_valid_commit_hash(SHA256));
+    }
+
+    #[test]
+    fn test_accepts_zero_sha() {
+        // Deletions and new branches arrive with an all-zeros sha. These must
+        // survive the filter so the EMPTY_REF guard in hook.rs can
+        // short-circuit them to an empty file set.
+        assert!(is_valid_commit_hash(ZERO_SHA1));
+    }
+
+    #[test]
+    fn test_rejects_abbreviated_hash() {
+        assert!(!is_valid_commit_hash("abc1234"));
+    }
+
+    #[test]
+    fn test_rejects_uppercase_hash() {
+        assert!(!is_valid_commit_hash(&SHA1.to_uppercase()));
+    }
+
+    #[test]
+    fn test_rejects_non_hex_hash() {
+        // Right length, wrong alphabet.
+        assert!(!is_valid_commit_hash(&"z".repeat(40)));
+    }
+
+    #[test]
+    fn test_accepts_well_formed_line() {
+        let line = format!("refs/heads/main {SHA1} refs/heads/main {SHA1}");
+        assert!(validate_input_line(&line));
+    }
+
+    #[test]
+    fn test_accepts_deletion_line() {
+        // git sends the all-zeros local sha when deleting a remote branch.
+        let line = format!("(delete) {ZERO_SHA1} refs/heads/gone {SHA1}");
+        assert!(validate_input_line(&line));
+    }
+
+    #[test]
+    fn test_rejects_line_with_too_few_fields() {
+        // The crash case: PrePushRefs::from indexes parts[3] unconditionally,
+        // so a short line used to panic instead of being skipped.
+        assert!(!validate_input_line("refs/heads/main"));
+        assert!(!validate_input_line(&format!("refs/heads/main {SHA1}")));
+        assert!(!validate_input_line(&format!(
+            "refs/heads/main {SHA1} refs/heads/main"
+        )));
+    }
+
+    #[test]
+    fn test_rejects_line_with_too_many_fields() {
+        let line = format!("refs/heads/main {SHA1} refs/heads/main {SHA1} extra");
+        assert!(!validate_input_line(&line));
+    }
+
+    #[test]
+    fn test_rejects_line_with_abbreviated_hashes() {
+        assert!(!validate_input_line("refs/heads/main abc refs/heads/main def"));
+    }
+
+    #[test]
+    fn test_rejects_blank_lines() {
+        assert!(!validate_input_line(""));
+        assert!(!validate_input_line("   "));
+        assert!(!validate_input_line("\t"));
+    }
+
+    #[test]
+    fn test_accepted_lines_are_safe_to_parse() {
+        // The filter/map pairing in run() means anything validate_input_line
+        // accepts is handed straight to PrePushRefs::from, which indexes
+        // parts[0..=3] without bounds checks.
+        let line = format!("refs/heads/main {SHA1} refs/heads/main {ZERO_SHA1}");
+        assert!(validate_input_line(&line));
+        let refs = PrePushRefs::from(line.as_str());
+        assert_eq!(refs.to, ("refs/heads/main".to_string(), SHA1.to_string()));
+        assert_eq!(
+            refs.from,
+            ("refs/heads/main".to_string(), ZERO_SHA1.to_string())
+        );
+    }
+}

--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -36,12 +36,16 @@ impl From<&str> for PrePushRefs {
     }
 }
 
-// Check that a string is a valid Git commit hash (3-64 lowercase hexits)
+// Check that a string is a valid Git commit long hash (40 or 64 lowercase hexits)
 fn is_valid_commit_hash(s: &str) -> bool {
-    if s.len() < 3 || 64 < s.len() {
+    let length_is_valid = s.len() == 40 || s.len() == 64;
+    let is_all_lowercase_hexits = s.chars().all(|c| ('0' <= c && c <= '9') || ('a' <= c && c <= 'f'));
+    let is_valid = length_is_valid && is_all_lowercase_hexits;
+    if !is_valid {
+        eprintln!("Warning: \"{}\" is not a valid full Git hash (must be exactly 40 or 64 lowercase hexits)", s);
         return false;
     }
-    return s.chars().all(|c| ('0' <= c && c <= '9') || ('a' <= c && c <= 'f'));
+    return is_valid;
 }
 
 // Check that a string is a valid four-part stdin line.

--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -1,6 +1,8 @@
 use std::io::IsTerminal;
 use std::io::Read;
 
+use similar::DiffableStr;
+
 use crate::hook_options::HookOptions;
 use crate::{
     Result,
@@ -34,6 +36,31 @@ impl From<&str> for PrePushRefs {
     }
 }
 
+// Check that a string is a valid Git commit hash (3-64 lowercase hexits)
+fn is_valid_commit_hash(s: &str) -> bool {
+    if s.len() < 3 || 64 < s.len() {
+        return false;
+    }
+    return s.chars().all(|c| ('0' <= c && c <= '9') || ('a' <= c && c <= 'f'));
+}
+
+// Check that a string is a valid four-part stdin line.
+// Silently ignores empty lines; prints warning for others.
+fn validate_input_line(line: &str) -> bool {
+    if line.is_empty() {
+        return false;
+    }
+    // Check that the line splits into four parts of which the second and fourth are commit hashes.
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    let is_valid = parts.len() == 4
+        && is_valid_commit_hash(parts[1])
+        && is_valid_commit_hash(parts[3]);
+    if !is_valid {
+        eprintln!("Ignoring malformed line from stdin: {}", line);
+    }
+    return is_valid;
+}
+
 impl PrePush {
     pub async fn run(mut self) -> Result<()> {
         if self.hook.reads_file_list_from_stdin() {
@@ -64,7 +91,7 @@ impl PrePush {
             // unrelated files.
             input
                 .lines()
-                .filter(|line| !line.is_empty())
+                .filter(|line| validate_input_line(&line))
                 .map(PrePushRefs::from)
                 .collect::<Vec<_>>()
         };

--- a/src/cli/run/pre_push.rs
+++ b/src/cli/run/pre_push.rs
@@ -1,8 +1,6 @@
 use std::io::IsTerminal;
 use std::io::Read;
 
-use similar::DiffableStr;
-
 use crate::hook_options::HookOptions;
 use crate::{
     Result,

--- a/test/pre_push.bats
+++ b/test/pre_push.bats
@@ -197,3 +197,51 @@ EOF
     assert_success
     refute_output --partial "[warn] unrelated.js"
 }
+
+@test "pre-push warns on malformed stdin lines instead of crashing" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-push"] {
+        steps {
+            ["print-files"] { check = "echo '{{files}}'" }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "test(pre-push): install hk"
+    git push origin main
+    git remote set-head origin --auto
+
+    # A line with fewer than four fields used to panic in PrePushRefs::from,
+    # which indexes parts[3] without bounds checking.
+    run bash -c "printf 'refs/heads/main\n' | hk run pre-push origin example"
+
+    assert_success
+    assert_output --partial "Ignoring malformed line from stdin"
+    refute_output --partial "panicked"
+}
+
+@test "pre-push warns on abbreviated commit hashes from stdin" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks {
+    ["pre-push"] {
+        steps {
+            ["print-files"] { check = "echo '{{files}}'" }
+        }
+    }
+}
+EOF
+    git add hk.pkl
+    git commit -m "test(pre-push): install hk"
+    git push origin main
+    git remote set-head origin --auto
+
+    run bash -c "printf 'refs/heads/main abc refs/heads/main def\n' | hk run pre-push origin example"
+
+    assert_success
+    assert_output --partial "not a valid full Git hash"
+    refute_output --partial "panicked"
+}


### PR DESCRIPTION
If hk has non-terminal stdin, then it tries to read parse lines as `[local branch] [local SHA] [remote branch] [remote SHA]`

Nonempty input lines that don't follow this format panic on an index into the string's whitespace-split parts, with an uninformative default message like `index out of bounds: the len is 1 but the index is 1`.

This can show up in shell commands that run hk in a loop, e.g.

```
some_command_that_lists_branches | while read branch ; do
   git switch $branch && hk run pre-push
 done
```

because `hk` inherits the pipe output as its own stdin. The original failure can be replicated with just `echo foo | hk run pre-push`.

Fix implemented here: warn on unparseable input; don't crash on it. Also add a validator that the local and remote SHAs are plausible Git hashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-push validation for malformed and incomplete commit references.
  * Invalid input now reports a specific rejection reason instead of being silently discarded.
  * Empty lines are explicitly reported as skipped.
  * Invalid non-empty input produces a warning without causing command failure or panic.
  * Commit hash validation continues to require full-length lowercase hexadecimal values.
  * Added coverage for malformed input and abbreviated commit hashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->