### PR TITLE
feat(config): support HK_QUIET environment variable

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -327,11 +327,12 @@ Example: `HK_PROFILE=ci,slow hk check --all` enables both profiles. A profile na
 type = "bool"
 default = false
 sources.cli = ["--quiet", "-q"]
+sources.env = ["HK_QUIET"]
 docs = """
 Suppresses non-essential output (info messages, progress indicators).
 
-When enabled, only warnings and errors will be displayed.
-Useful for scripting or when you only care about the exit code.
+Warnings, errors, and failed-step diagnostics are still shown.
+Set `HK_QUIET=1` to also suppress non-essential output from Git hooks without changing their commands.
 """
 
 [silent]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -194,7 +194,7 @@ pub async fn run() -> Result<Option<std::process::ExitStatus>> {
         clx::progress::set_output(ProgressOutput::Text);
         level = Some(log::LevelFilter::Debug);
     }
-    if args.quiet {
+    if args.quiet || *env::HK_QUIET {
         clx::progress::set_output(ProgressOutput::Quiet);
         level = Some(log::LevelFilter::Warn);
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -94,6 +94,7 @@ pub static HK_TRACE: LazyLock<TraceMode> =
     });
 
 pub static HK_JSON: LazyLock<bool> = LazyLock::new(|| var_true("HK_JSON"));
+pub static HK_QUIET: LazyLock<bool> = LazyLock::new(|| var_true("HK_QUIET"));
 
 pub static GIT_INDEX_FILE: LazyLock<Option<PathBuf>> = LazyLock::new(|| var_path("GIT_INDEX_FILE"));
 

--- a/test/quiet_silent.bats
+++ b/test/quiet_silent.bats
@@ -9,6 +9,67 @@ teardown() {
     _common_teardown
 }
 
+@test "HK_QUIET suppresses successful output" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks { ["check"] { steps { ["a"] { check = "echo check-success" } } } }
+EOF
+    git add hk.pkl
+    run env HK_QUIET=true hk check
+    assert_success
+    assert_output ""
+}
+
+@test "HK_QUIET preserves failed step diagnostics and output file" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks { ["check"] { steps { ["a"] { check = "echo check-diagnostic && exit 1" } } } }
+EOF
+    git add hk.pkl
+    run env HK_QUIET=1 HK_OUTPUT_FILE="$PWD/output.log" hk check
+    assert_failure
+    assert_output --partial "check-diagnostic"
+    assert_file_contains output.log "check-diagnostic"
+}
+
+@test "HK_QUIET works with CLI output flags" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks { ["check"] { steps { ["a"] { check = "echo check-success" } } } }
+EOF
+    git add hk.pkl
+    run env HK_QUIET=0 hk check
+    assert_success
+    assert_output --partial "check-success"
+
+    run env HK_QUIET=0 hk check --quiet
+    assert_success
+    assert_output ""
+
+    run env HK_QUIET=1 hk check --verbose
+    assert_success
+    assert_output ""
+
+    run env HK_QUIET=1 hk check --silent
+    assert_success
+    assert_output ""
+}
+
+@test "git hooks inherit HK_QUIET" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks { ["pre-commit"] { steps { ["a"] { check = "echo hook-success; touch hook-ran" } } } }
+EOF
+    run env HK_QUIET=1 hk install
+    assert_success
+    assert_output ""
+    git add hk.pkl
+    run env HK_QUIET=1 git commit -m "test hook"
+    assert_success
+    assert_file_exist hook-ran
+    refute_output --partial "hook-success"
+}
+
 @test "install --quiet suppresses output" {
     cat <<EOF > hk.pkl
 amends "$PKL_PATH/Config.pkl"


### PR DESCRIPTION
Add `HK_QUIET=1` to suppress non-essential output, including from Git hooks, without editing hook commands. Warnings, errors, failed-step diagnostics, and failure log files remain available.

Use the existing boolean environment helper and document the new setting.

Validation:
- 32 integration tests passed across both Git backends, covering quiet/silent output, hook inheritance, and failure logs.
- Build, formatting, ShellCheck, and commit hooks passed.

*AI-assisted — Tool: codex-cli; model: openai/gpt-6-astra; version: 0.154.0.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `HK_QUIET` environment variable to enable quiet output.
  * Quiet mode now preserves warnings, errors, failed-step diagnostics, and output files.
  * Quiet settings are inherited by installed Git hooks without changing their commands.
  * `HK_QUIET` works alongside existing `--quiet`, `--verbose`, and `--silent` options.

* **Documentation**
  * Updated quiet-mode documentation to reflect the retained diagnostics and Git hook behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->