### PR TITLE
feat(config): support HK_SILENT environment variable

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -338,11 +338,13 @@ Useful for scripting or when you only care about the exit code.
 type = "bool"
 default = false
 sources.cli = ["--silent"]
+sources.env = ["HK_SILENT"]
 docs = """
 Suppresses all output including warnings. Only errors are shown.
 
 More extreme than `quiet` - progress indicators, info messages, and
 warnings are all hidden. Useful when only the exit code matters.
+Set `HK_SILENT=1` to apply this behavior to Git hooks without changing their commands.
 """
 
 [skip_hooks]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -198,7 +198,7 @@ pub async fn run() -> Result<Option<std::process::ExitStatus>> {
         clx::progress::set_output(ProgressOutput::Quiet);
         level = Some(log::LevelFilter::Warn);
     }
-    if args.silent {
+    if args.silent || *env::HK_SILENT {
         clx::progress::set_output(ProgressOutput::Quiet);
         level = Some(log::LevelFilter::Error);
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -49,6 +49,7 @@ pub static HK_TIMING_JSON: LazyLock<Option<PathBuf>> = LazyLock::new(|| var_path
 
 pub static HK_LIBGIT2: LazyLock<bool> = LazyLock::new(|| !var_false("HK_LIBGIT2"));
 pub static HK_HIDE_WHEN_DONE: LazyLock<bool> = LazyLock::new(|| var_true("HK_HIDE_WHEN_DONE"));
+pub static HK_SILENT: LazyLock<bool> = LazyLock::new(|| var_true("HK_SILENT"));
 pub static HK_CHECK_FIRST: LazyLock<bool> = LazyLock::new(|| !var_false("HK_CHECK_FIRST"));
 pub static HK_STASH: LazyLock<Option<StashMethod>> = LazyLock::new(|| {
     if var_false("HK_STASH") {

--- a/test/quiet_silent.bats
+++ b/test/quiet_silent.bats
@@ -116,3 +116,65 @@ EOF
     refute_output --partial "Created"
     refute_output --partial "Detected"
 }
+
+@test "HK_SILENT suppresses successful output" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks { ["check"] { steps { ["a"] { check = "echo check-success" } } } }
+EOF
+    git add hk.pkl
+    run env HK_SILENT=true hk check
+    assert_success
+    assert_output ""
+
+    run env HK_SILENT=true hk check --stats
+    assert_success
+    assert_output ""
+}
+
+@test "HK_SILENT suppresses failed step summaries and preserves output file" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks { ["check"] { steps { ["a"] { check = "echo check-diagnostic && exit 1" } } } }
+EOF
+    git add hk.pkl
+    run env HK_SILENT=1 HK_OUTPUT_FILE="$PWD/output.log" hk check
+    assert_failure
+    refute_output --partial "check-diagnostic"
+    refute_output --partial "output:"
+    assert_file_contains output.log "check-diagnostic"
+}
+
+@test "HK_SILENT works with CLI output flags" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks { ["check"] { steps { ["a"] { check = "echo check-success" } } } }
+EOF
+    git add hk.pkl
+    run env HK_SILENT=0 hk check
+    assert_success
+    assert_output --partial "check-success"
+
+    run env HK_SILENT=0 hk check --silent
+    assert_success
+    assert_output ""
+
+    run env HK_SILENT=1 hk check --verbose
+    assert_success
+    assert_output ""
+}
+
+@test "git hooks inherit HK_SILENT" {
+    cat <<EOF > hk.pkl
+amends "$PKL_PATH/Config.pkl"
+hooks { ["pre-commit"] { steps { ["a"] { check = "echo hook-success; touch hook-ran" } } } }
+EOF
+    run env HK_SILENT=1 hk install
+    assert_success
+    assert_output ""
+    git add hk.pkl
+    run env HK_SILENT=1 git commit -m "test hook"
+    assert_success
+    assert_file_exist hook-ran
+    refute_output --partial "hook-success"
+}


### PR DESCRIPTION
Add `HK_SILENT=1` to apply silent output mode to Git hooks without editing hook commands. This suppresses progress, warnings, statistics, and failed-step summaries while preserving error reporting and failure log files.

Use the existing boolean environment helper and document the new setting.

Validation:
- 32 integration tests passed across both Git backends, covering quiet/silent output, hook inheritance, and failure logs.
- Build, formatting, ShellCheck, and documentation generation passed.

*AI-assisted — Tool: codex-cli; model: openai/gpt-6-astra; version: 0.154.0.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enabling silent mode with the `HK_SILENT` environment variable (`1` or `true`).
  * Silent mode suppresses progress and successful output while retaining error diagnostics in the configured output file.
  * Silent behavior now applies to Git hooks installed through the tool.
  * Environment-based silent mode works alongside existing `--silent` and `--verbose` options.

* **Documentation**
  * Documented `HK_SILENT=1` configuration for Git hooks without changing hook commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->