### PR TITLE
docs: document escaping literal braces in step commands

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,6 +130,21 @@ Structured commands cannot be combined with the step's `shell` option or a strin
 structured command should run through a launcher. Other step behavior, including
 `dir`, `env`, and automatic batching for large file lists, continues to apply.
 
+### Literal braces in commands
+
+Commands are rendered as [Tera](https://keats.github.io/tera/) templates, so `{{` starts an expression. A tool whose own syntax uses `{{`, such as a Go template, fails to render:
+
+```pkl
+// error: "{{.ResourceKind}}" is parsed as a hk expression
+check = "kubeconform -schema-location 'https://example.com/{{.ResourceKind}}.json' {{files}}"
+```
+
+Wrap the literal part in `{% raw %}` to pass it through unchanged:
+
+```pkl
+check = "kubeconform -schema-location 'https://example.com/{% raw %}{{.ResourceKind}}{% endraw %}.json' {{files}}"
+```
+
 ### Step working directory
 
 `dir` sets the directory a step's commands run in. It is rendered as a template, so a step with `workspace_indicator` can follow each job's workspace rather than opening every command with a `cd`:


### PR DESCRIPTION
Step commands render as Tera templates, so a tool whose own syntax uses `{{` — Go templates in kubeconform, helm, or consul-template — fails to render with a template error rather than running. Document `{% raw %}` as the escape, using kubeconform's `-schema-location` as the example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for using literal braces in step commands.
  - Documented how to prevent template parsing errors when commands contain `{{` syntax.
  - Included examples showing the required raw-template wrapper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->