### PR TITLE
fix(builtins): run tflint in each module directory

### DIFF
--- a/pkl/builtins/tf_lint.pkl
+++ b/pkl/builtins/tf_lint.pkl
@@ -6,13 +6,95 @@ import "../Config.pkl"
   description = "Terraform linter"
 }
 tf_lint = new Config.Step {
-  glob = "**/*.tf"
+  glob = List("**/*.tf", "**/*.tfvars", "**/*.tofu")
+  exclude = "**/.terraform/**"
   check = new Config.CommandSpec {
-    command = "tflint"
+    command =
+      """
+      for f in {{ files }}; do dirname "$f"; done | sort -u | { code=0; while IFS= read -r dir; do
+      tflint --chdir="$dir" || code=1
+      done; exit $code; }
+      """
     effect = "read"
   }
   fix = new Config.CommandSpec {
-    command = "tflint --fix"
+    command =
+      """
+      for f in {{ files }}; do dirname "$f"; done | sort -u | { code=0; while IFS= read -r dir; do
+      tflint --chdir="$dir" --fix || tflint --chdir="$dir" || code=1
+      done; exit $code; }
+      """
     effect = "write"
+  }
+  tests {
+    local const cleanModule =
+      """
+      terraform {
+        required_version = ">= 1.0"
+      }
+
+      output "greeting" {
+        value = "hello"
+      }
+      """
+    local const unusedVariable =
+      """
+      terraform {
+        required_version = ">= 1.0"
+      }
+
+      output "greeting" {
+        value = "hello"
+      }
+
+      variable "unused" {
+        type = string
+      }
+      """
+    ["check clean module"] {
+      run = "check"
+      tmpdir = true
+      write { ["main.tf"] = cleanModule }
+      files = List("main.tf")
+      expect { code = 0 }
+    }
+    ["check module with unused declaration"] {
+      run = "check"
+      tmpdir = true
+      write { ["main.tf"] = unusedVariable }
+      files = List("main.tf")
+      expect { code = 1 }
+    }
+    ["check nested module directory"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["main.tf"] = cleanModule
+        ["modules/sub/main.tf"] = unusedVariable
+      }
+      files = List("modules/sub/main.tf")
+      expect { code = 1 }
+    }
+    ["check reports every module directory"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["modules/a/main.tf"] = unusedVariable
+        ["modules/b/main.tf"] = unusedVariable
+      }
+      files = List("modules/a/main.tf", "modules/b/main.tf")
+      expect {
+        code = 1
+        stdout = "modules/b"
+      }
+    }
+    ["fix removes unused declaration"] {
+      run = "fix"
+      tmpdir = true
+      write { ["main.tf"] = unusedVariable }
+      files = List("main.tf")
+      after = "tflint --chdir=."
+      expect { code = 0 }
+    }
   }
 }

--- a/test/builtin_tool_stubs/tflint
+++ b/test/builtin_tool_stubs/tflint
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "0.64.0"
+tool = "aqua:terraform-linters/tflint"


### PR DESCRIPTION
tf_lint invoked `tflint` with no arguments, which lints only the directory hk runs from. A repository whose modules live under `modules/` was therefore never linted below the root, silently.

Derive the directories from the selected files and pass `--chdir` for each, as pre-commit-terraform does. `--chdir=.` resolves the same `.tflint.hcl` as a bare invocation, so root-level files behave exactly as before and the change only adds the directories that were being skipped.

The fix command now falls back to a plain run when `--fix` reports a non-zero exit. tflint exits 2 on the run that applies a fix, so the step used to be reported as failed even when it had fixed everything.

Also widens the glob to the extensions tflint accepts and excludes `.terraform`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the TFLint tool stub.
  - Configured TFLint version 0.64.0 from its Aqua source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->