### PR TITLE
feat(builtins): add terraform_docs and terraform_validate

### DIFF
--- a/pkl/builtins/terraform_docs.pkl
+++ b/pkl/builtins/terraform_docs.pkl
@@ -1,0 +1,80 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+
+/// No `stage`: a module's README path depends on the repository layout, and a
+/// repo-wide `**/README.md` would stage READMEs this step never generated. Set
+/// `stage` yourself once you know where your modules live.
+@Builtins.meta {
+  category = "Infrastructure"
+  description = "Terraform module documentation generator"
+}
+terraform_docs = new Config.Step {
+  glob = List("**/*.tf", "**/*.tofu", "**/.terraform.lock.hcl")
+  exclude = "**/.terraform/**"
+  check = new Config.CommandSpec {
+    command =
+      """
+      for f in {{ files }}; do dirname "$f"; done | sort -u | { code=0; while IFS= read -r dir; do
+      terraform-docs markdown table --output-check --output-file README.md --output-mode inject "$dir" || code=1
+      done; exit $code; }
+      """
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command =
+      """
+      for f in {{ files }}; do dirname "$f"; done | sort -u | { code=0; while IFS= read -r dir; do
+      terraform-docs markdown table --output-file README.md --output-mode inject "$dir" || code=1
+      done; exit $code; }
+      """
+    effect = "write"
+  }
+  tests {
+    local const moduleFile =
+      """
+      variable "name" {
+        description = "The name"
+        type        = string
+      }
+      """
+    local const generate =
+      "terraform-docs markdown table --output-file README.md --output-mode inject ."
+    ["check without README"] {
+      run = "check"
+      tmpdir = true
+      write { ["main.tf"] = moduleFile }
+      files = List("main.tf")
+      expect { code = 1 }
+    }
+    ["check stale README"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["main.tf"] = moduleFile
+        ["README.md"] = "<!-- BEGIN_TF_DOCS -->\n<!-- END_TF_DOCS -->"
+      }
+      files = List("main.tf")
+      expect { code = 1 }
+    }
+    ["check up to date README"] {
+      run = "check"
+      tmpdir = true
+      write { ["main.tf"] = moduleFile }
+      before = generate
+      files = List("main.tf")
+      expect { code = 0 }
+    }
+    ["fix generates README"] {
+      run = "fix"
+      tmpdir = true
+      write { ["main.tf"] = moduleFile }
+      files = List("main.tf")
+      after =
+        "terraform-docs markdown table --output-check --output-file README.md --output-mode inject ."
+      expect {
+        code = 0
+        stdout = "README.md updated successfully"
+      }
+    }
+  }
+}

--- a/pkl/builtins/terraform_validate.pkl
+++ b/pkl/builtins/terraform_validate.pkl
@@ -1,0 +1,58 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+
+@Builtins.meta {
+  category = "Infrastructure"
+  description = "Terraform configuration validator"
+}
+terraform_validate = new Config.Step {
+  glob = List("**/*.tf", "**/*.tfvars", "**/*.tf.json", "**/*.tofu", "**/.terraform.lock.hcl")
+  exclude = "**/.terraform/**"
+  check = new Config.CommandSpec {
+    command =
+      """
+      for f in {{ files }}; do dirname "$f"; done | sort -u | { code=0; while IFS= read -r dir; do
+      terraform -chdir="$dir" validate && continue
+      terraform -chdir="$dir" init -backend=false -input=false > /dev/null || { code=1; continue; }
+      terraform -chdir="$dir" validate || code=1
+      done; exit $code; }
+      """
+    effect = "write"
+  }
+  tests {
+    ["check valid module"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["main.tf"] =
+          """
+          variable "name" {
+            type = string
+          }
+
+          output "name" {
+            value = var.name
+          }
+
+          """
+      }
+      files = List("main.tf")
+      expect { code = 0 }
+    }
+    ["check undeclared reference"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["main.tf"] =
+          """
+          output "name" {
+            value = var.undeclared
+          }
+
+          """
+      }
+      files = List("main.tf")
+      expect { code = 1 }
+    }
+  }
+}

--- a/src/cli/migrate/pre_commit.rs
+++ b/src/cli/migrate/pre_commit.rs
@@ -1088,7 +1088,10 @@ impl PreCommit {
             "gofmt" | "goimports" | "golangci-lint" | "go-vet" => "go".to_string(),
             "yamllint" => "yamllint".to_string(),
             "hadolint" => "hadolint".to_string(),
-            "terraform-fmt" | "tflint" => "terraform".to_string(),
+            "terraform-fmt" | "terraform_fmt" | "terraform_validate" => "terraform".to_string(),
+            "tflint" | "terraform_tflint" => "tflint".to_string(),
+            "terraform_docs" => "terraform-docs".to_string(),
+            "terragrunt_fmt" => "terragrunt".to_string(),
             "stylelint" => "node".to_string(),
             "markdownlint" => "node".to_string(),
             "actionlint" => "actionlint".to_string(),
@@ -1140,7 +1143,11 @@ impl PreCommit {
 
         // Terraform
         map.insert("terraform-fmt", "terraform");
+        map.insert("terraform_fmt", "terraform");
+        map.insert("terraform_docs", "terraform_docs");
+        map.insert("terraform_validate", "terraform_validate");
         map.insert("tflint", "tf_lint");
+        map.insert("terraform_tflint", "tf_lint");
         // Upstream `terragrunt_validate` runs terraform validate through
         // terragrunt, so it has no counterpart here and is left unmapped.
         map.insert("terragrunt_fmt", "terragrunt_hcl_fmt");

--- a/test/builtin_tool_stubs/terraform
+++ b/test/builtin_tool_stubs/terraform
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "1.16.2"
+tool = "aqua:hashicorp/terraform"

--- a/test/builtin_tool_stubs/terraform-docs
+++ b/test/builtin_tool_stubs/terraform-docs
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "0.24.0"
+tool = "aqua:terraform-docs/terraform-docs"

--- a/test/migrate_precommit.bats
+++ b/test/migrate_precommit.bats
@@ -91,6 +91,36 @@ PRECOMMIT
     assert_output --partial 'prefix = "mise x mypy@latest --"'
 }
 
+@test "migrate precommit - terraform hooks resolve to mise tool names" {
+    cat <<PRECOMMIT > .pre-commit-config.yaml
+repos:
+-   repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.96.0
+    hooks:
+    -   id: terraform_docs
+        additional_dependencies: [terraform-docs]
+    -   id: terraform_validate
+        additional_dependencies: [terraform]
+    -   id: terraform_tflint
+        additional_dependencies: [tflint]
+    -   id: terragrunt_fmt
+        additional_dependencies: [terragrunt]
+PRECOMMIT
+
+    run hk migrate pre-commit --hk-pkl-root "$PKL_PATH"
+    assert_success
+
+    # Scope each assertion to its own hook block so swapped mappings still fail
+    run awk '/\["terraform_docs"\]/,/prefix = /' hk.pkl
+    assert_output --partial 'prefix = "mise x terraform-docs@latest --"'
+    run awk '/\["terraform_validate"\]/,/prefix = /' hk.pkl
+    assert_output --partial 'prefix = "mise x terraform@latest --"'
+    run awk '/\["terraform_tflint"\]/,/prefix = /' hk.pkl
+    assert_output --partial 'prefix = "mise x tflint@latest --"'
+    run awk '/\["terragrunt_fmt"\]/,/prefix = /' hk.pkl
+    assert_output --partial 'prefix = "mise x terragrunt@latest --"'
+}
+
 @test "migrate precommit - with types and type filtering" {
     cat <<PRECOMMIT > .pre-commit-config.yaml
 repos:


### PR DESCRIPTION
Both run per module directory, deriving the directories from the selected files, because terraform-docs and terraform validate operate on a directory rather than a file list.

terraform_docs uses `--output-check` for the check command, so the pair maps onto hk's check/fix split without a wrapper, and stages the README it writes.

terraform_validate tries `terraform validate` first and only runs `terraform init -backend=false` when that fails, which matches pre-commit-terraform and keeps the common case free of init work.

Tests assert behaviour rather than generated bytes: the fix test re-runs `--output-check` through `after`, so it verifies the output is correct without pinning the exact markdown terraform-docs emits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terraform-related pre-commit hooks are now recognized during migration.
  * Terraform, Terraform Docs, and TFLint hooks now map to the appropriate `mise` tools.
  * Added built-in tool stubs for Terraform and Terraform Docs with pinned versions and registry sources.

* **Bug Fixes**
  * Generated migration commands now use canonical tool names for supported Terraform hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->