### PR TITLE
feat(builtins): add terragrunt and kubeconform

### DIFF
--- a/pkl/builtins/kubeconform.pkl
+++ b/pkl/builtins/kubeconform.pkl
@@ -1,0 +1,83 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+
+/// Scoped to the conventional Kubernetes manifest directories because
+/// kubeconform fails on any YAML without a `kind`, which would reject ordinary
+/// files such as `.github/workflows/*.yml` and `docker-compose.yml`. A
+/// directory-based default therefore misses manifests in unconventional
+/// locations rather than failing on every repository that holds other YAML.
+/// Override `glob` for other layouts, and add `-schema-location` to validate
+/// custom resources.
+///
+/// Not batched: kubeconform already validates concurrently via `-n`, and one
+/// process keeps `-summary` to a single line instead of one per batch.
+@Builtins.meta {
+  category = "Infrastructure"
+  description = "Kubernetes manifest validator"
+}
+kubeconform = new Config.Step {
+  glob =
+    List(
+      "**/k8s/**/*.yaml",
+      "**/k8s/**/*.yml",
+      "**/kubernetes/**/*.yaml",
+      "**/kubernetes/**/*.yml",
+      "**/manifests/**/*.yaml",
+      "**/manifests/**/*.yml",
+      "**/deploy/**/*.yaml",
+      "**/deploy/**/*.yml",
+      "**/deployments/**/*.yaml",
+      "**/deployments/**/*.yml",
+    )
+  exclude =
+    List(
+      "**/templates/**",
+      "**/values.yaml",
+      "**/values.yml",
+      "**/kustomization.yaml",
+      "**/kustomization.yml",
+    )
+  check = new Config.CommandSpec {
+    command = new Config.Command {
+      argv = List("kubeconform", "-summary", "-strict", "-ignore-missing-schemas", "{{files}}")
+    }
+    effect = "read"
+  }
+  tests {
+    ["check manifest without kind"] {
+      run = "check"
+      tmpdir = true
+      write { ["k8s/resource.yaml"] = "key: value\n" }
+      expect { code = 1 }
+    }
+    ["check manifest without apiVersion"] {
+      run = "check"
+      tmpdir = true
+      write { ["manifests/resource.yaml"] = "kind: ConfigMap\n" }
+      expect { code = 1 }
+    }
+    ["check file with no resources"] {
+      run = "check"
+      tmpdir = true
+      write { ["kubernetes/resource.yaml"] = "# no resources here\n" }
+      expect { code = 0 }
+    }
+    ["check deploy directory manifest"] {
+      run = "check"
+      tmpdir = true
+      write { ["deploy/deployment.yaml"] = "key: value\n" }
+      expect { code = 1 }
+    }
+    ["check skips helm values and kustomization"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["k8s/resource.yaml"] = "# no resources here\n"
+        ["k8s/values.yaml"] = "replicaCount: 2\n"
+        ["k8s/kustomization.yaml"] = "resources:\n  - deployment.yaml\n"
+        ["k8s/templates/deployment.yaml"] = "{{- if .Values.enabled }}\n"
+      }
+      expect { code = 0 }
+    }
+  }
+}

--- a/pkl/builtins/terragrunt_hcl_fmt.pkl
+++ b/pkl/builtins/terragrunt_hcl_fmt.pkl
@@ -1,0 +1,109 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+
+/// `terragrunt hcl fmt` recursively rewrites every HCL file below the working
+/// directory, so it runs once per selected file via `--file` to leave unselected
+/// files untouched.
+@Builtins.meta {
+  category = "Infrastructure"
+  description = "Terragrunt HCL formatter"
+}
+terragrunt_hcl_fmt = new Config.Step {
+  glob = "**/*.hcl"
+  exclude = List("**/.terraform/**", "**/.terragrunt-cache/**")
+  check = new Config.CommandSpec {
+    command =
+      """
+      code=0; for f in {{ files }}; do
+      terragrunt hcl fmt --check --diff --file "$f" || code=1
+      done; exit $code
+      """
+    effect = "read"
+  }
+  fix = new Config.CommandSpec {
+    command =
+      """
+      code=0; for f in {{ files }}; do
+      terragrunt hcl fmt --file "$f" || code=1
+      done; exit $code
+      """
+    effect = "write"
+  }
+  tests {
+    local const formatted =
+      """
+      inputs = {
+        a = 1
+      }
+
+      """
+    local const unformatted =
+      """
+      inputs   = {
+        a=1
+      }
+
+      """
+    ["check formatted file"] {
+      run = "check"
+      tmpdir = true
+      write { ["terragrunt.hcl"] = formatted }
+      files = List("terragrunt.hcl")
+      expect { code = 0 }
+    }
+    ["check unformatted file"] {
+      run = "check"
+      tmpdir = true
+      write { ["terragrunt.hcl"] = unformatted }
+      files = List("terragrunt.hcl")
+      expect { code = 1 }
+    }
+    ["check reports every selected file"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["a/terragrunt.hcl"] = formatted
+        ["b/terragrunt.hcl"] = unformatted
+      }
+      files = List("a/terragrunt.hcl", "b/terragrunt.hcl")
+      expect {
+        code = 1
+        stderr = "b/terragrunt.hcl"
+      }
+    }
+    ["check ignores unselected files"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["a/terragrunt.hcl"] = formatted
+        ["b/terragrunt.hcl"] = unformatted
+      }
+      files = List("a/terragrunt.hcl")
+      expect { code = 0 }
+    }
+    ["fix unformatted file"] {
+      run = "fix"
+      tmpdir = true
+      write { ["terragrunt.hcl"] = unformatted }
+      files = List("terragrunt.hcl")
+      expect {
+        files { ["terragrunt.hcl"] = formatted }
+      }
+    }
+    ["fix leaves unselected files alone"] {
+      run = "fix"
+      tmpdir = true
+      write {
+        ["a/terragrunt.hcl"] = unformatted
+        ["b/terragrunt.hcl"] = unformatted
+      }
+      files = List("a/terragrunt.hcl")
+      expect {
+        files {
+          ["a/terragrunt.hcl"] = formatted
+          ["b/terragrunt.hcl"] = unformatted
+        }
+      }
+    }
+  }
+}

--- a/pkl/builtins/terragrunt_hcl_validate.pkl
+++ b/pkl/builtins/terragrunt_hcl_validate.pkl
@@ -1,0 +1,87 @@
+import "../Builtins.pkl"
+import "../Config.pkl"
+
+/// `--log-level error` drops the per-dependency warning terragrunt logs for
+/// every `mock_outputs` block, which otherwise streams on successful runs.
+///
+/// `terragrunt hcl validate` has no per-file flag and validates every config
+/// below the working directory, so it runs once per selected directory to keep
+/// unrelated configs out of the result.
+@Builtins.meta {
+  category = "Infrastructure"
+  description = "Terragrunt HCL validator"
+}
+terragrunt_hcl_validate = new Config.Step {
+  glob = "**/*.hcl"
+  exclude = List("**/.terraform/**", "**/.terragrunt-cache/**")
+  check = new Config.CommandSpec {
+    command =
+      """
+      for f in {{ files }}; do dirname "$f"; done | sort -u | { code=0; while IFS= read -r dir; do
+      terragrunt hcl validate --show-config-path --log-level error --working-dir "$dir" || code=1
+      done; exit $code; }
+      """
+    effect = "read"
+  }
+  tests {
+    local const valid =
+      """
+      inputs = {
+        a = 1
+      }
+      """
+    local const undefinedReference =
+      """
+      inputs = {
+        a = local.undefined
+      }
+      """
+    ["check valid config"] {
+      run = "check"
+      tmpdir = true
+      write { ["terragrunt.hcl"] = valid }
+      files = List("terragrunt.hcl")
+      expect { code = 0 }
+    }
+    ["check unparseable config"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["terragrunt.hcl"] =
+          """
+          inputs = {
+            a = 1
+          """
+      }
+      files = List("terragrunt.hcl")
+      expect { code = 1 }
+    }
+    ["check undefined reference"] {
+      run = "check"
+      tmpdir = true
+      write { ["terragrunt.hcl"] = undefinedReference }
+      files = List("terragrunt.hcl")
+      expect { code = 1 }
+    }
+    ["check reports every selected directory"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["a/terragrunt.hcl"] = valid
+        ["b/terragrunt.hcl"] = undefinedReference
+      }
+      files = List("a/terragrunt.hcl", "b/terragrunt.hcl")
+      expect { code = 1 }
+    }
+    ["check ignores unselected directories"] {
+      run = "check"
+      tmpdir = true
+      write {
+        ["a/terragrunt.hcl"] = valid
+        ["b/terragrunt.hcl"] = undefinedReference
+      }
+      files = List("a/terragrunt.hcl")
+      expect { code = 0 }
+    }
+  }
+}

--- a/src/cli/migrate/pre_commit.rs
+++ b/src/cli/migrate/pre_commit.rs
@@ -1141,6 +1141,9 @@ impl PreCommit {
         // Terraform
         map.insert("terraform-fmt", "terraform");
         map.insert("tflint", "tf_lint");
+        // Upstream `terragrunt_validate` runs terraform validate through
+        // terragrunt, so it has no counterpart here and is left unmapped.
+        map.insert("terragrunt_fmt", "terragrunt_hcl_fmt");
 
         // CSS
         map.insert("stylelint", "stylelint");

--- a/test/builtin_tool_stubs/kubeconform
+++ b/test/builtin_tool_stubs/kubeconform
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "0.8.0"
+tool = "aqua:yannh/kubeconform"

--- a/test/builtin_tool_stubs/terragrunt
+++ b/test/builtin_tool_stubs/terragrunt
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S mise tool-stub
+
+version = "1.1.4"
+tool = "aqua:gruntwork-io/terragrunt"


### PR DESCRIPTION
terragrunt_hcl_fmt and terragrunt_hcl_validate run without a file list because `terragrunt hcl fmt --file` accepts a single path only; both commands already walk the tree from the working directory, and terragrunt skips `.terraform.lock.hcl` and cache directories itself. The glob still scopes when the steps run.

kubeconform globs all YAML. There is no naming convention for Kubernetes manifests and no flag to skip non-manifest YAML, so narrow it to your manifest paths when the repository holds other YAML.

`terragrunt_fmt` maps to terragrunt_hcl_fmt in `hk migrate pre-commit`. Upstream `terragrunt_validate` runs terraform validate through terragrunt rather than validating HCL, so it stays unmapped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the `terragrunt_fmt` pre-commit hook.
  - Added support for additional pre-commit checks, including executable shebang scripts, destroyed symlinks, and forbidden submodules.
  - Added built-in tool support for Kubeconform version 0.8.0.
  - Added built-in tool support for Terragrunt version 1.1.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->