### PR TITLE
fix(builtins): make zizmor tests pass with hash pinning

### DIFF
--- a/pkl/builtins/zizmor.pkl
+++ b/pkl/builtins/zizmor.pkl
@@ -45,7 +45,7 @@ zizmor = new Config.Step {
         build:
           runs-on: ubuntu-latest
           steps:
-            - uses: actions/checkout/////@v4
+            - uses: actions/checkout/////@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
               with:
                 persist-credentials: false
 
@@ -60,7 +60,7 @@ zizmor = new Config.Step {
         build:
           runs-on: ubuntu-latest
           steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
               with:
                 persist-credentials: false
 
@@ -77,7 +77,7 @@ zizmor = new Config.Step {
           build:
             runs-on: ubuntu-latest
             steps:
-              - uses: actions/checkout/////@v4
+              - uses: actions/checkout/////@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
                 with:
                   persist-credentials: false
 
@@ -90,7 +90,7 @@ zizmor = new Config.Step {
           build:
             runs-on: ubuntu-latest
             steps:
-              - uses: actions/checkout@v4
+              - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
                 with:
                   persist-credentials: false
 

--- a/test/builtin_tool_stubs/zizmor
+++ b/test/builtin_tool_stubs/zizmor
@@ -1,4 +1,4 @@
 #!/usr/bin/env -S mise tool-stub
 
-version = "1.19.0"
+version = "1.30.1"
 tool = "zizmor"


### PR DESCRIPTION
Users who enable `Builtins.hk_test` with `Builtins.zizmor` can see five embedded test failures with zizmor 1.20 or newer even when their project workflows are clean. The fixture reference `actions/checkout@v4` stopped being a valid clean case when zizmor changed its default policy to require hash pinning for first-party actions.

Pin the clean fixture to the immutable actions/checkout v4.4.0 commit:

```yaml
- uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
```

The bad fixture retains its extra path separators, preserving obfuscation and autofix coverage. The builtin test stub now uses zizmor 1.30.1 so CI exercises the policy that exposed this compatibility bug.

After this change, the clean fixture passes, the malformed fixture still produces the expected low-severity finding and autofix, and the missing-permissions case still exits with the expected medium-severity finding after the path is fixed.

Validation:
- all five targeted tests passed with zizmor 1.19.0
- all five targeted tests passed with zizmor 1.30.1
- all five targeted tests passed through the upgraded mise tool stub
- `mise run build`
- Pkl evaluation and formatting check
- `git diff --check`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled `zizmor` tool stub to version 1.30.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->