### PR TITLE
ci: clarify matrix job names

### DIFF
--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -43,6 +43,7 @@ jobs:
       - run: ./scripts/check_mcp_ui_fresh
 
   build:
+    name: build (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -129,6 +130,7 @@ jobs:
           max_attempts: 3
           command: mise run test:bats:libgit2
   ci-nolibgit2:
+    name: ci-nolibgit2 (${{ matrix.os }})
     needs: build
     permissions:
       contents: read
@@ -200,6 +202,7 @@ jobs:
           max_attempts: 3
           command: mise run test:bats:nogit
   ci-other:
+    name: ci-other (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Untrusted CI runs no longer display an inactive Namespace profile in their matrix-generated job labels. The build, no-libgit2, and general CI jobs now name themselves using only the OS actually represented by the matrix entry.

Runner selection is unchanged: trusted maintainer work continues to use Namespace, while untrusted and forked pull requests use GitHub-hosted runners.

Validated with actionlint and `git diff --check`.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only display labels; no changes to steps, runner logic, or test commands.
> 
> **Overview**
> Matrix jobs **`build`**, **`ci-nolibgit2`**, and **`ci-other`** now set an explicit `name` of the form `job-id (${{ matrix.os }})`, so GitHub’s UI shows the OS for each matrix leg instead of a misleading label that referenced the Namespace **`runner`** field even when untrusted runs actually use GitHub-hosted runners.
> 
> **Runner selection is unchanged** — trusted runs still use Namespace via `matrix.runner`; untrusted/fork PRs still use `matrix.os` for `runs-on`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d911f32a4d6daab06a1f3bbe46b8c241c6246a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow visibility by displaying the operating system for build and validation jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->